### PR TITLE
Feat: 예외/정상 Response, Advice 추가

### DIFF
--- a/src/main/java/cloneproject/Instagram/advice/GlobalExceptionHandler.java
+++ b/src/main/java/cloneproject/Instagram/advice/GlobalExceptionHandler.java
@@ -1,0 +1,64 @@
+package cloneproject.Instagram.advice;
+
+import cloneproject.Instagram.dto.error.ErrorCode;
+import cloneproject.Instagram.dto.error.ErrorResponse;
+import cloneproject.Instagram.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import static cloneproject.Instagram.dto.error.ErrorCode.*;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        final ErrorResponse response = ErrorResponse.of(INVALID_INPUT_VALUE, e.getBindingResult());
+        return new ResponseEntity<>(response, BAD_REQUEST);
+    }
+
+    @ExceptionHandler
+    protected ResponseEntity<ErrorResponse> handleBindException(BindException e) {
+        final ErrorResponse response = ErrorResponse.of(INVALID_INPUT_VALUE, e.getBindingResult());
+        return new ResponseEntity<>(response, BAD_REQUEST);
+    }
+
+    @ExceptionHandler
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
+        final ErrorResponse response = ErrorResponse.of(e);
+        return new ResponseEntity<>(response, BAD_REQUEST);
+    }
+
+    @ExceptionHandler
+    protected ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
+        final ErrorResponse response = ErrorResponse.of(INVALID_INPUT_VALUE);
+        return new ResponseEntity<>(response, BAD_REQUEST);
+    }
+
+    @ExceptionHandler
+    protected ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
+        final ErrorResponse response = ErrorResponse.of(METHOD_NOT_ALLOWED);
+        return new ResponseEntity<>(response, HttpStatus.METHOD_NOT_ALLOWED);
+    }
+
+    @ExceptionHandler
+    protected ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
+        final ErrorCode errorCode = e.getErrorCode();
+        final ErrorResponse response = ErrorResponse.of(errorCode);
+        return new ResponseEntity<>(response, HttpStatus.valueOf(errorCode.getStatus()));
+    }
+
+    @ExceptionHandler
+    protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+        final ErrorResponse response = ErrorResponse.of(INTERNAL_SERVER_ERROR);
+        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/cloneproject/Instagram/dto/error/ErrorCode.java
+++ b/src/main/java/cloneproject/Instagram/dto/error/ErrorCode.java
@@ -1,0 +1,20 @@
+package cloneproject.Instagram.dto.error;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+    // Common
+    INTERNAL_SERVER_ERROR(500, "U001", "내부 서버 오류입니다."),
+    INVALID_INPUT_VALUE(400, "U002", "유효하지 않은 입력입니다."),
+    METHOD_NOT_ALLOWED(405, "U003", "허용되지 않은 HTTP method입니다."),
+    INVALID_TYPE_VALUE(400, "U004", "입력 타입이 유효하지 않습니다."),
+    ;
+
+    private int status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/cloneproject/Instagram/dto/error/ErrorResponse.java
+++ b/src/main/java/cloneproject/Instagram/dto/error/ErrorResponse.java
@@ -1,0 +1,79 @@
+package cloneproject.Instagram.dto.error;
+
+import lombok.Getter;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class ErrorResponse {
+
+    private int status;
+    private String code;
+    private String message;
+    private List<FieldError> errors;
+
+    private ErrorResponse(final ErrorCode code, final List<FieldError> errors) {
+        this.message = code.getMessage();
+        this.status = code.getStatus();
+        this.errors = errors;
+        this.code = code.getCode();
+    }
+
+    private ErrorResponse(final ErrorCode code) {
+        this.message = code.getMessage();
+        this.status = code.getStatus();
+        this.code = code.getCode();
+        this.errors = new ArrayList<>();
+    }
+
+    public static ErrorResponse of(final ErrorCode code, final BindingResult bindingResult) {
+        return new ErrorResponse(code, FieldError.of(bindingResult));
+    }
+
+    public static ErrorResponse of(final ErrorCode code) {
+        return new ErrorResponse(code);
+    }
+
+    public static ErrorResponse of(final ErrorCode code, final List<FieldError> errors) {
+        return new ErrorResponse(code, errors);
+    }
+
+    public static ErrorResponse of(MethodArgumentTypeMismatchException e) {
+        final String value = e.getValue() == null ? "" : e.getValue().toString();
+        final List<FieldError> errors = FieldError.of(e.getName(), value, e.getErrorCode());
+        return new ErrorResponse(ErrorCode.INVALID_TYPE_VALUE, errors);
+    }
+
+    @Getter
+    public static class FieldError {
+        private String field;
+        private String value;
+        private String reason;
+
+        private FieldError(final String field, final String value, final String reason) {
+            this.field = field;
+            this.value = value;
+            this.reason = reason;
+        }
+
+        public static List<FieldError> of(final String field, final String value, final String reason) {
+            List<FieldError> fieldErrors = new ArrayList<>();
+            fieldErrors.add(new FieldError(field, value, reason));
+            return fieldErrors;
+        }
+
+        private static List<FieldError> of(final BindingResult bindingResult) {
+            final List<org.springframework.validation.FieldError> fieldErrors = bindingResult.getFieldErrors();
+            return fieldErrors.stream()
+                    .map(error -> new FieldError(
+                            error.getField(),
+                            error.getRejectedValue() == null ? "" : error.getRejectedValue().toString(),
+                            error.getDefaultMessage()))
+                    .collect(Collectors.toList());
+        }
+    }
+}

--- a/src/main/java/cloneproject/Instagram/dto/result/ResultCode.java
+++ b/src/main/java/cloneproject/Instagram/dto/result/ResultCode.java
@@ -1,0 +1,17 @@
+package cloneproject.Instagram.dto.result;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ResultCode {
+
+    // Member
+    REGISTER_SUCCESS(200, "M001", "회원가입 되었습니다."),
+    ;
+
+    private int status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/cloneproject/Instagram/dto/result/ResultResponse.java
+++ b/src/main/java/cloneproject/Instagram/dto/result/ResultResponse.java
@@ -1,0 +1,30 @@
+package cloneproject.Instagram.dto.result;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Getter;
+
+@ApiModel(description = "결과 응답 데이터 모델")
+@Getter
+public class ResultResponse {
+
+    @ApiModelProperty(value = "Http 상태 코드")
+    private int status;
+    @ApiModelProperty(value = "Business 상태 코드")
+    private String code;
+    @ApiModelProperty(value = "응답 메세지")
+    private String message;
+    @ApiModelProperty(value = "응답 데이터")
+    private Object data;
+
+    public static ResultResponse of(ResultCode resultCode, Object data) {
+        return new ResultResponse(resultCode, data);
+    }
+
+    public ResultResponse(ResultCode resultCode, Object data) {
+        this.status = resultCode.getStatus();
+        this.code = resultCode.getCode();
+        this.message = resultCode.getMessage();
+        this.data = data;
+    }
+}

--- a/src/main/java/cloneproject/Instagram/exception/BusinessException.java
+++ b/src/main/java/cloneproject/Instagram/exception/BusinessException.java
@@ -1,0 +1,21 @@
+package cloneproject.Instagram.exception;
+
+import cloneproject.Instagram.dto.error.ErrorCode;
+
+public class BusinessException extends RuntimeException {
+    private ErrorCode errorCode;
+
+    public BusinessException(String message, ErrorCode errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}


### PR DESCRIPTION
## BusinessException 도입 목적
1. 각 비즈니스(커스텀) 예외들이 `BusinessException`을 상속 받고, Advice에서 `BusinessException`에 대한 하나의 Exception Handler로 모든 비즈니스 예외를 핸들링 -> `다형성` 활용
2. 비즈니스 예외를 추가할 때마다, Exception Handler를 추가로 만들어야 하는 번거로움 제거
> 아래는 예시 이미지입니다.
![image](https://user-images.githubusercontent.com/68049320/140140220-f8730563-1c97-4b75-9fcb-966d79f08b5e.png)
___
## ErrorResponse, ResultResponse 도입 목적
1. 예외와 정상 응답 형식을 항상 동일하게 일치시킴으로써, Front 분들이 로직 짜기가 수월해지는 효과
2. 핵심적으로 필요한 정보만 응답 가능
3. 개발자마다 응답 형식이 다름으로써 발생할 수 있는 혼동 방지
> ResultCode, ErrorCode 필드 소개
> 1. `status`: HTTP code
> 2. `code`: Business code
> 3. `message`: 응답 메세지
### 사용 방법
- `ErrorCode`, `ResultCode`는 각 예외, 정상 응답마다 추가해서 사용하시면 됩니다.
- `ErrorResponse.of()`, `ResultResponse.of()` 전역 메소드로 사용하시면 됩니다.
- 커스텀 예외 추가 시, BusinessException 상속하고, 생성자 만들어서 super() 호출하시면 됩니다.
    - 비즈니스 예외 핸들링은 구현해 놓았으므로, 이 외에는 따로 추가하실 필요 없습니다!
    > 예시 이미지
    > ![image](https://user-images.githubusercontent.com/68049320/140635678-d63ab6ee-fb1d-40e7-a864-44686374e228.png)

___
## Exception Handler에서 처리하는 Exception 소개
1. **MethodArgumentNotValidException** (`자바 표준 예외`)
    - `@Validated`에서 binding error 발생
    - HttpMessageConverter에서 등록한 컨버터가 binding 하지 못할 경우 발생
    - 주로 `@RequestBody`에서 발생
2. **BindException** (`자바 표준 예외`)
    - `@Validated`에서 binding error 발생
    - HttpMessageConverter에서 등록한 컨버터가 binding 하지 못할 경우 발생
    - 주로 `@ModelAttribute`에서 발생
3. **MethodArgumentTypeMismatchException** (`자바 표준 예외`)
    - `@Validated`에서 binding error 발생
    - HttpMessageConverter에서 등록한 컨버터가 binding 하지 못할 경우 발생
    - 주로 `@RequestParam`에서 발생
4. **HttpMessageNotReadableException** (`스프링 표준 예외`)
    - JSON을 parsing한 데이터를 원하는 값으로 읽을 수 없는 경우 발생
         > ex) enum 타입인 `ROLE_USER`을 입력받아야 하는 상황에서, `USER`를 입력받는 경우 발생
    - 주로 `@RequestBody`에서 발생
5. **HttpRequestMethodNotSupportedException** (`스프링 표준 예외`)
    - 지원하지 않는 HTTP method를 호출하는 경우 발생
6.  **BusinessException** (`커스텀 예외`)
    - 비즈니스 예외(커스텀 예외) 발생

Resolve: #22