### PR TITLE
Feat: Swagger, JWT 만료시간 관련 설정 추가, Member 관련 업데이트

### DIFF
--- a/src/main/java/cloneproject/Instagram/config/SwaggerConfig.java
+++ b/src/main/java/cloneproject/Instagram/config/SwaggerConfig.java
@@ -3,12 +3,17 @@ package cloneproject.Instagram.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.builders.ParameterBuilder;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.schema.ModelRef;
 import springfox.documentation.service.ApiInfo;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @EnableSwagger2
 @Configuration
@@ -16,7 +21,19 @@ public class SwaggerConfig {
 
     @Bean
     public Docket api() {
+        // Authorization header 글로벌 처리
+        List global = new ArrayList();
+        global.add(new ParameterBuilder()
+                .name("Authorization")
+                .description("Access Token")
+                .parameterType("header")
+                .required(true)
+                .modelRef(new ModelRef("string"))
+                .scalarExample("Bearer AAA.BBB.CCC")
+                .build());
+
         return new Docket(DocumentationType.SWAGGER_2)
+                .globalOperationParameters(global)
                 .useDefaultResponseMessages(false)
                 .apiInfo(apiInfo())
                 .select()

--- a/src/main/java/cloneproject/Instagram/config/WebSecurityConfig.java
+++ b/src/main/java/cloneproject/Instagram/config/WebSecurityConfig.java
@@ -1,5 +1,6 @@
 package cloneproject.Instagram.config;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
@@ -17,6 +18,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import cloneproject.Instagram.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
 
+@Slf4j
 @Configuration
 @EnableWebSecurity
 @EnableGlobalMethodSecurity(prePostEnabled = true)
@@ -51,7 +53,12 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter{
 
     @Override
     public void configure(WebSecurity web) throws Exception{
-        web.ignoring().antMatchers("/css/**", "/js/**"); // 나중에 수정
+        web.ignoring().antMatchers("/static/css/**", "/static/js/**", "*.ico"); // 나중에 수정
+
+        // swagger
+        web.ignoring().antMatchers(
+                "/v2/api-docs", "/configuration/ui", "/swagger-resources",
+                "/configuration/security", "/swagger-ui.html", "/webjars/**","/swagger/**");
     }
 
     @Override
@@ -70,7 +77,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter{
                 .and()
                 .csrf().disable()
                 .authorizeRequests()
-                .antMatchers("/login", "/accounts").permitAll()
+                .antMatchers("/login", "/accounts", "/swagger-resources/**", "/swagger-ui/**").permitAll()
                 .antMatchers("/info", "/posts/**", "/accounts/**").hasAuthority("ROLE_USER")
                 .antMatchers("/**/follow", "/**/unfollow",  "/**/followers", "/**/following").hasAuthority("ROLE_USER")
                 .antMatchers("/admin").hasAuthority("ROLE_ADMIN");

--- a/src/main/java/cloneproject/Instagram/controller/MemberController.java
+++ b/src/main/java/cloneproject/Instagram/controller/MemberController.java
@@ -2,6 +2,7 @@ package cloneproject.Instagram.controller;
 
 
 
+import io.swagger.annotations.ApiImplicitParam;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -37,6 +38,7 @@ public class MemberController {
     
     private final MemberService memberService;
 
+    @ApiImplicitParam(name = "Authorization", value = "불필요", required = false, example = " ")
     @PostMapping(value = "/accounts")
     public ResponseEntity<ResultResponse> register(@Validated @RequestBody RegisterRequest registerRequest) {
         memberService.register(registerRequest);
@@ -44,6 +46,7 @@ public class MemberController {
         return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
     }
 
+    @ApiImplicitParam(name = "Authorization", value = "불필요", required = false, example = " ")
     @PostMapping(value = "/login")
     public ResponseEntity<ResultResponse> login(@Validated @RequestBody LoginRequest loginRequest) {
         JwtDto jwt = memberService.login(loginRequest);
@@ -52,6 +55,7 @@ public class MemberController {
         return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
     }
 
+    @ApiImplicitParam(name = "Authorization", value = "불필요", required = false, example = " ")
     @PostMapping(value = "/reissue")
     public ResponseEntity<ResultResponse> reissue(@Validated @RequestBody ReissueRequest reissueRequest) {
         JwtDto jwt = memberService.reisuue(reissueRequest);
@@ -60,7 +64,7 @@ public class MemberController {
         return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
     }
 
-    @GetMapping(value = "/{username}")
+    @GetMapping(value = "/accounts/{username}")
     public ResponseEntity<ResultResponse> getUserProfile(@PathVariable("username") String username){
         UserProfileResponse userProfileResponse = memberService.getUserProfile(username);
 

--- a/src/main/java/cloneproject/Instagram/entity/member/Member.java
+++ b/src/main/java/cloneproject/Instagram/entity/member/Member.java
@@ -12,6 +12,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 
 @Getter
 @Entity
@@ -55,6 +58,8 @@ public class Member {
     @Enumerated(EnumType.STRING)
     private Gender gender;
 
+    @OneToMany(mappedBy = "member")
+    private List<Follow> followings = new ArrayList<>();
     
     @Embedded
     @AttributeOverrides({

--- a/src/main/java/cloneproject/Instagram/util/JwtUtil.java
+++ b/src/main/java/cloneproject/Instagram/util/JwtUtil.java
@@ -30,9 +30,11 @@ import io.jsonwebtoken.security.Keys;
 
 @Component
 public class JwtUtil {
-    
-    private final static long ACCESS_TOKEN_EXPIRES = 1000 * 60 * 10; // 10분
-    private final static long REFRESH_TOKEN_EXPIRES = 1000 * 60 * 60 * 24 * 7; // 7일
+
+    @Value("access-token-expires")
+    private long ACCESS_TOKEN_EXPIRES;
+    @Value("refresh-token-expires")
+    private long REFRESH_TOKEN_EXPIRES;
     
     private final static String BEARER_TYPE = "Bearer";
     private final static String AUTHENTITIES_KEY = "auth";

--- a/src/main/java/cloneproject/Instagram/util/JwtUtil.java
+++ b/src/main/java/cloneproject/Instagram/util/JwtUtil.java
@@ -31,9 +31,9 @@ import io.jsonwebtoken.security.Keys;
 @Component
 public class JwtUtil {
 
-    @Value("access-token-expires")
+    @Value("${access-token-expires}")
     private long ACCESS_TOKEN_EXPIRES;
-    @Value("refresh-token-expires")
+    @Value("${refresh-token-expires}")
     private long REFRESH_TOKEN_EXPIRES;
     
     private final static String BEARER_TYPE = "Bearer";


### PR DESCRIPTION
## 변경 사항
### Swagger 설정 추가
- api 문서에 각 api마다 Authorization 헤더 자동 추가 -> `SwaggerConfig` 참고
- 시큐리티 설정에 Swagger 관련 url 모두 허용 -> `WebSecurityConfig` 참고
### 설정 파일에서 JWT 만료시간 변경
- `application-xxx.yml` 에서 따로 설정하도록 이동
    ```
    access-token-expires: 600000 # 10분
    refresh-token-expires: 604800000 # 7일
    ```
- 운영 환경, 테스트 환경 분리 위함
### MemberController 업데이트
- JWT 토큰이 필요하지 않은 api에는 글로벌 설정 무력화
    - Authorization header -> `required = false`로 명시
- getUserProfile 메소드 endpoint 수정 -> `/accounts/{username}`
### Member 엔티티 연관관계 추가
- 일대다 : followings 추가