### PR TITLE
Feature/member swagger

### DIFF
--- a/src/main/java/cloneproject/Instagram/config/WebSecurityConfig.java
+++ b/src/main/java/cloneproject/Instagram/config/WebSecurityConfig.java
@@ -78,7 +78,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter{
                 .csrf().disable()
                 .authorizeRequests()
                 .antMatchers("/login", "/accounts", "/swagger-resources/**", "/swagger-ui/**").permitAll()
-                .antMatchers("/info", "/posts/**", "/accounts/**").hasAuthority("ROLE_USER")
+                .antMatchers("/info", "/posts/**", "/accounts/image").hasAuthority("ROLE_USER")
                 .antMatchers("/**/follow", "/**/unfollow",  "/**/followers", "/**/following").hasAuthority("ROLE_USER")
                 .antMatchers("/admin").hasAuthority("ROLE_ADMIN");
     }

--- a/src/main/java/cloneproject/Instagram/controller/FollowController.java
+++ b/src/main/java/cloneproject/Instagram/controller/FollowController.java
@@ -16,15 +16,21 @@ import cloneproject.Instagram.dto.result.ResultCode;
 import cloneproject.Instagram.dto.result.ResultResponse;
 import cloneproject.Instagram.service.FollowService;
 import cloneproject.Instagram.vo.FollowerInfo;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 
+@Api(tags = "팔로우 API")
 @RestController
 @RequiredArgsConstructor
 public class FollowController {
     
     private final FollowService followService;
 
+    @ApiOperation(value = "팔로우")
     @PostMapping("/{followMemberUsername}/follow")
+    @ApiImplicitParam(name = "followMemberUsername", value = "팔로우할 계정의 username", required = true, example = "dlwlrma")
     public ResponseEntity<ResultResponse> follow(@PathVariable("followMemberUsername") @Validated
                                                  @NotBlank(message = "username이 필요합니다") String followMemberUsername){
         boolean success = followService.follow(followMemberUsername);
@@ -33,7 +39,9 @@ public class FollowController {
         return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
     }
 
+    @ApiOperation(value = "언팔로우")
     @PostMapping("/{followMemberUsername}/unfollow")
+    @ApiImplicitParam(name = "followMemberUsername", value = "언팔로우할 계정의 username", required = true, example = "dlwlrma")
     public ResponseEntity<ResultResponse> unfollow(@PathVariable("followMemberUsername") @Validated
                                                 @NotBlank(message = "username이 필요합니다") String followMemberUsername){
         boolean success = followService.unfollow(followMemberUsername);
@@ -42,7 +50,9 @@ public class FollowController {
         return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
     }
 
+    @ApiOperation(value = "팔로잉 목록 조회")
     @GetMapping("/{memberUsername}/following")
+    @ApiImplicitParam(name = "memberUsername", value = "조회 할 계정의 username", required = true, example = "dlwlrma")
     public ResponseEntity<ResultResponse> getFollowings(@PathVariable("memberUsername") @Validated
                                                 @NotBlank(message = "username이 필요합니다") String memberUsername){
         List<FollowerInfo> followings = followService.getFollowings(memberUsername);
@@ -51,7 +61,9 @@ public class FollowController {
         return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
     }
 
+    @ApiOperation(value = "팔로워 목록 조회")
     @GetMapping("/{memberUsername}/followers")
+    @ApiImplicitParam(name = "memberUsername", value = "조회 할 계정의 username", required = true, example = "dlwlrma")
     public ResponseEntity<ResultResponse> getFollowers(@PathVariable("memberUsername") @Validated
                                                 @NotBlank(message = "username이 필요합니다") String memberUsername){
         List<FollowerInfo> followings = followService.getFollowers(memberUsername);

--- a/src/main/java/cloneproject/Instagram/controller/MemberController.java
+++ b/src/main/java/cloneproject/Instagram/controller/MemberController.java
@@ -2,7 +2,11 @@ package cloneproject.Instagram.controller;
 
 
 
+import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+import io.swagger.annotations.ApiOperation;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -32,12 +36,14 @@ import org.springframework.web.bind.annotation.RequestParam;
 //  프로필 조회 o
 //  이미지 등록 o
 //  이미지 삭제
+@Api(tags = "멤버 API")
 @RestController
 @RequiredArgsConstructor
 public class MemberController {
     
     private final MemberService memberService;
 
+    @ApiOperation(value = "회원가입")
     @ApiImplicitParam(name = "Authorization", value = "불필요", required = false, example = " ")
     @PostMapping(value = "/accounts")
     public ResponseEntity<ResultResponse> register(@Validated @RequestBody RegisterRequest registerRequest) {
@@ -46,6 +52,7 @@ public class MemberController {
         return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
     }
 
+    @ApiOperation(value = "로그인")
     @ApiImplicitParam(name = "Authorization", value = "불필요", required = false, example = " ")
     @PostMapping(value = "/login")
     public ResponseEntity<ResultResponse> login(@Validated @RequestBody LoginRequest loginRequest) {
@@ -55,6 +62,7 @@ public class MemberController {
         return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
     }
 
+    @ApiOperation(value = "토큰 재발급")
     @ApiImplicitParam(name = "Authorization", value = "불필요", required = false, example = " ")
     @PostMapping(value = "/reissue")
     public ResponseEntity<ResultResponse> reissue(@Validated @RequestBody ReissueRequest reissueRequest) {
@@ -64,6 +72,11 @@ public class MemberController {
         return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
     }
 
+    @ApiOperation(value = "유저 프로필 조회")
+    @ApiImplicitParams({
+        @ApiImplicitParam(name = "Authorization", value = "불필요", required = false, example = " "),
+        @ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma")
+    })
     @GetMapping(value = "/accounts/{username}")
     public ResponseEntity<ResultResponse> getUserProfile(@PathVariable("username") String username){
         UserProfileResponse userProfileResponse = memberService.getUserProfile(username);
@@ -72,7 +85,7 @@ public class MemberController {
         return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
     }
 
-    // TODO UPLOAD IMAGE SUCCESS 수정.(POST와 MEMBER 구분)
+    @ApiOperation(value = "회원 프로필 사진 업로드")
     @PostMapping(value = "/accounts/image")
     public ResponseEntity<ResultResponse> uploadImage(@RequestParam MultipartFile uploadedImage) {
         Long memberId = Long.valueOf(SecurityContextHolder.getContext().getAuthentication().getName());
@@ -82,7 +95,7 @@ public class MemberController {
         return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
     }
 
-    // ! login 권한 테스트를 위해 임시로 만든 메서드입니다. 추후에 변경
+    // TODO 임시
     @GetMapping(value = "/accounts/edit")
     public String getEdit() {
         String memberId = SecurityContextHolder.getContext().getAuthentication().getName();

--- a/src/main/java/cloneproject/Instagram/dto/member/JwtDto.java
+++ b/src/main/java/cloneproject/Instagram/dto/member/JwtDto.java
@@ -2,18 +2,25 @@ package cloneproject.Instagram.dto.member;
 
 import java.util.Date;
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@ApiModel("JWT 토큰 응답 데이터 모델")
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class JwtDto {
+    @ApiModelProperty(value = "토큰 타입", example = "Bearer")
     private String type;
+    @ApiModelProperty(value = "Access 토큰", example = "AAA.BBB.CCC")
     private String accessToken;
+    @ApiModelProperty(value = "Refresh 토큰", example = "AAA.BBB.CCC")
     private String refreshToken;
+    @ApiModelProperty(value = "Access 토큰 만료시간", example = "2021-12-26T05:51:30.099+00:00")
     private Date accessTokenExpires;
 }

--- a/src/main/java/cloneproject/Instagram/dto/member/LoginRequest.java
+++ b/src/main/java/cloneproject/Instagram/dto/member/LoginRequest.java
@@ -4,6 +4,7 @@ import javax.validation.constraints.NotBlank;
 
 import org.hibernate.validator.constraints.Length;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,10 +16,12 @@ import lombok.Setter;
 @AllArgsConstructor
 public class LoginRequest {
     
+    @ApiModelProperty(value = "유저네임", example = "dlwlrma", required = true)
     @NotBlank(message = "ID를 입력해주세요")
     @Length(min = 4, max = 12, message = "ID는 4문자 이상 12문자 이하여야 합니다")
     private String username;
 
+    @ApiModelProperty(value = "비밀번호", example = "a12341234", required = true)
     @NotBlank(message = "비밀번호를 입력해주세요")
     @Length(max = 20, message = "비밀번호는 20문자 이하여야 합니다")
     private String password;

--- a/src/main/java/cloneproject/Instagram/dto/member/RegisterRequest.java
+++ b/src/main/java/cloneproject/Instagram/dto/member/RegisterRequest.java
@@ -6,6 +6,7 @@ import javax.validation.constraints.Pattern;
 import org.hibernate.validator.constraints.Length;
 
 import cloneproject.Instagram.entity.member.Member;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,20 +18,24 @@ import lombok.Setter;
 @AllArgsConstructor
 public class RegisterRequest {
     
-    @NotBlank(message = "ID를 입력해주세요")
+    @ApiModelProperty(value = "유저네임", example = "dlwlrma", required = true)
+    @NotBlank(message = "username을 입력해주세요")
     @Length(min = 4, max = 12, message = "ID는 4문자 이상 12문자 이하여야 합니다")
     private String username;
     
+    @ApiModelProperty(value = "이름", example = "이지금", required = true)
     @NotBlank(message = "이름을 입력해주세요")
     @Length(min = 2, max = 12, message = "이름은 2문자 이상 12문자 이하여야 합니다")
     private String name;
 
+    @ApiModelProperty(value = "비밀번호", example = "a12341234", required = true)
     @NotBlank(message = "비밀번호를 입력해주세요")
     @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,}$", 
                 message = "비밀번호는 8자 이상, 최소 하나의 문자와 숫자가 필요합니다")
     @Length(max = 20, message = "비밀번호는 20문자 이하여야 합니다")
     private String password;
 
+    @ApiModelProperty(value = "휴대폰 번호", example = "010-0000-0000", required = true)
     @NotBlank(message = "휴대폰 번호를 입력해주세요")
     @Pattern(regexp = "^\\d{3}-\\d{3,4}-\\d{4}$", message = "휴대폰 번호 양식이 맞지 않습니다")
     private String phone;

--- a/src/main/java/cloneproject/Instagram/dto/member/ReissueRequest.java
+++ b/src/main/java/cloneproject/Instagram/dto/member/ReissueRequest.java
@@ -2,7 +2,7 @@ package cloneproject.Instagram.dto.member;
 
 import javax.validation.constraints.NotBlank;
 
-
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,9 +14,11 @@ import lombok.NoArgsConstructor;
 @Builder
 public class ReissueRequest {
 
+    @ApiModelProperty(value = "Access 토큰", example = "AAA.BBB.CCC", required = true)
     @NotBlank(message = "유효한 Access Token이 없습니다")
     private String accessToken;
 
+    @ApiModelProperty(value = "Refresh 토큰", example = "AAA.BBB.CCC", required = true)
     @NotBlank(message = "유효한 Refresh Token이 없습니다")
     private String refreshToken;
 

--- a/src/main/java/cloneproject/Instagram/dto/member/UserProfileResponse.java
+++ b/src/main/java/cloneproject/Instagram/dto/member/UserProfileResponse.java
@@ -1,16 +1,24 @@
 package cloneproject.Instagram.dto.member;
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+@ApiModel("유저 프로필 조회 응답 모델")
 @Getter
 @Builder
 @AllArgsConstructor
 public class UserProfileResponse {
+    @ApiModelProperty(value = "유저네임", example = "dlwlrma")
     String memberUsername;
+    @ApiModelProperty(value = "이름", example = "이지금")
     String memberName;
+    @ApiModelProperty(value = "프로필사진 URL", example = "https://drive.google.com/file/d/1Gu0DcGCJNs4Vo0bz2U9U6v01d_VwKijs/view?usp=sharing")
     String memberImageUrl;
-    Long memberFollowers;
-    Long memberFollowings;
+    @ApiModelProperty(value = "팔로워 수", example = "100")
+    Integer memberFollowers;
+    @ApiModelProperty(value = "팔로잉 수", example = "100")
+    Integer memberFollowings;
 }

--- a/src/main/java/cloneproject/Instagram/service/FollowService.java
+++ b/src/main/java/cloneproject/Instagram/service/FollowService.java
@@ -29,10 +29,10 @@ public class FollowService {
 
     @Transactional
     public boolean follow(String followMemberUsername){
-        String memberId = SecurityContextHolder.getContext().getAuthentication().getName();
-        Member member = memberRepository.findById(Long.valueOf(memberId))
+        final String memberId = SecurityContextHolder.getContext().getAuthentication().getName();
+        final Member member = memberRepository.findById(Long.valueOf(memberId))
                                         .orElseThrow(MemberDoesNotExistException::new);
-        Member followMember = memberRepository.findByUsername(followMemberUsername)
+        final Member followMember = memberRepository.findByUsername(followMemberUsername)
                                                 .orElseThrow(MemberDoesNotExistException::new);
         if(member.getId().equals(followMember.getId())){
             throw new CantFollowMyselfException();
@@ -47,8 +47,8 @@ public class FollowService {
 
     @Transactional
     public boolean unfollow(String followMemberUsername){
-        String memberId = SecurityContextHolder.getContext().getAuthentication().getName();
-        Member followMember = memberRepository.findByUsername(followMemberUsername)
+        final String memberId = SecurityContextHolder.getContext().getAuthentication().getName();
+        final Member followMember = memberRepository.findByUsername(followMemberUsername)
                                                 .orElseThrow(MemberDoesNotExistException::new);
         if(Long.valueOf(memberId).equals(followMember.getId())){
             throw new CantUnfollowMyselfException();
@@ -61,30 +61,47 @@ public class FollowService {
 
     @Transactional(readOnly = true)
     public List<FollowerInfo> getFollowings(String memberUsername){ 
-        Member member = memberRepository.findByUsername(memberUsername)
+        final Member member = memberRepository.findByUsername(memberUsername)
                                                 .orElseThrow(MemberDoesNotExistException::new);
-        List<Follow> follows = followRepository.findAllByMemberId(member.getId());
-        List<Member> followingMembers = follows.stream()
+        final List<Follow> follows = followRepository.findAllByMemberId(member.getId());
+        final List<Member> followingMembers = follows.stream()
                                                 .map(follow->follow.getFollowMember())
                                                 .collect(Collectors.toList());
-        List<FollowerInfo> result = followingMembers.stream()
-                                                .map(this::convertMemberToUsernameWithImages)
+        final List<FollowerInfo> result = followingMembers.stream()
+                                                .map(this::convertMemberToFollowerInfo)
                                                 .collect(Collectors.toList());
         return result;
     }
 
     @Transactional(readOnly = true)
     public List<FollowerInfo> getFollowers(String memberUsername){ 
-        Member member = memberRepository.findByUsername(memberUsername)
+        final Member member = memberRepository.findByUsername(memberUsername)
                                                 .orElseThrow(MemberDoesNotExistException::new);
-        List<Follow> follows = followRepository.findAllByFollowMemberId(member.getId());
-        List<Member> followingMembers = follows.stream()
+        final List<Follow> follows = followRepository.findAllByFollowMemberId(member.getId());
+        final List<Member> followingMembers = follows.stream()
                                                 .map(follow->follow.getMember())
                                                 .collect(Collectors.toList());
-        List<FollowerInfo> result = followingMembers.stream()
-                                                .map(this::convertMemberToUsernameWithImages)
+        final List<FollowerInfo> result = followingMembers.stream()
+                                                .map(this::convertMemberToFollowerInfo)
                                                 .collect(Collectors.toList());
         return result;
+    }
+
+
+    @Transactional(readOnly = true)
+    public Integer getFollowingsCount(String memberUsername){ 
+        final Member member = memberRepository.findByUsername(memberUsername)
+                                                .orElseThrow(MemberDoesNotExistException::new);
+        final List<Follow> follows = followRepository.findAllByMemberId(member.getId());
+        return follows.size();
+    }
+
+    @Transactional(readOnly = true)
+    public Integer getFollowersCount(String memberUsername){ 
+        final Member member = memberRepository.findByUsername(memberUsername)
+                                                .orElseThrow(MemberDoesNotExistException::new);
+        final List<Follow> follows = followRepository.findAllByFollowMemberId(member.getId());
+        return follows.size();
     }
 
     /**
@@ -94,9 +111,9 @@ public class FollowService {
      */
     @Transactional(readOnly = true)
     public List<Long> getOnlyFollowingsMemberId(){
-        String memberId = SecurityContextHolder.getContext().getAuthentication().getName();
-        List<Follow> follows = followRepository.findAllByMemberId(Long.valueOf(memberId));
-        List<Long> result = follows.stream()
+        final String memberId = SecurityContextHolder.getContext().getAuthentication().getName();
+        final List<Follow> follows = followRepository.findAllByMemberId(Long.valueOf(memberId));
+        final List<Long> result = follows.stream()
                                         .map(follow->follow.getFollowMember().getId())
                                         .collect(Collectors.toList());
         return result;
@@ -111,14 +128,14 @@ public class FollowService {
      */
     @Transactional(readOnly = true)
     public boolean isFollowing(String followMemberUsername){
-        String memberId = SecurityContextHolder.getContext().getAuthentication().getName();
-        Member followMember = memberRepository.findByUsername(followMemberUsername)
+        final String memberId = SecurityContextHolder.getContext().getAuthentication().getName();
+        final Member followMember = memberRepository.findByUsername(followMemberUsername)
                                                 .orElseThrow(MemberDoesNotExistException::new);
         return followRepository.existsByMemberIdAndFollowMemberId(Long.valueOf(memberId), followMember.getId());
     }
 
-    private FollowerInfo convertMemberToUsernameWithImages(Member member){
-        FollowerInfo result = FollowerInfo.builder()
+    private FollowerInfo convertMemberToFollowerInfo(Member member){
+        final FollowerInfo result = FollowerInfo.builder()
                                     .username(member.getUsername())
                                     .name(member.getName())
                                     .image(member.getImage())

--- a/src/main/java/cloneproject/Instagram/service/JwtUserDetailsService.java
+++ b/src/main/java/cloneproject/Instagram/service/JwtUserDetailsService.java
@@ -8,14 +8,16 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import cloneproject.Instagram.entity.member.Member;
-import cloneproject.Instagram.exception.MemberDoesNotExistException;
 import cloneproject.Instagram.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class JwtUserDetailsService implements UserDetailsService{
@@ -27,12 +29,11 @@ public class JwtUserDetailsService implements UserDetailsService{
     public UserDetails loadUserByUsername(String username) {
         return memberRepository.findByUsername(username)
                 .map(this::createUserDetails)
-                .orElseThrow(() -> new MemberDoesNotExistException());
+                .orElseThrow(() -> new UsernameNotFoundException("일치하는 계정이 없습니다"));
     }
 
     private UserDetails createUserDetails(Member member){
         GrantedAuthority grantedAuthority = new SimpleGrantedAuthority(member.getRole().toString());
-
         // TOKEN, AUTHENTICATION 에 넣을 값 (ex. username, id)
         return new User(
             String.valueOf(member.getId()),

--- a/src/main/java/cloneproject/Instagram/service/MemberService.java
+++ b/src/main/java/cloneproject/Instagram/service/MemberService.java
@@ -11,11 +11,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import cloneproject.Instagram.dto.member.JwtDto;
-import cloneproject.Instagram.dto.member.LoginRequest;
-import cloneproject.Instagram.dto.member.RegisterRequest;
-import cloneproject.Instagram.dto.member.ReissueRequest;
-import cloneproject.Instagram.dto.member.UserProfileResponse;
+import cloneproject.Instagram.dto.member.*;
 import cloneproject.Instagram.entity.member.Member;
 import cloneproject.Instagram.exception.AccountDoesNotMatch;
 import cloneproject.Instagram.exception.InvalidJwtException;
@@ -28,7 +24,9 @@ import cloneproject.Instagram.vo.Image;
 import cloneproject.Instagram.vo.RefreshToken;
 import io.jsonwebtoken.JwtException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class MemberService {
@@ -37,6 +35,7 @@ public class MemberService {
     private final JwtUtil jwtUtil;
 
     private final MemberRepository memberRepository;
+    private final FollowService followService;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
     @Transactional
@@ -107,8 +106,8 @@ public class MemberService {
                                 .memberUsername(member.getUsername())
                                 .memberName(member.getName())
                                 .memberImageUrl(member.getImage().getImageUrl())
-                                // .memberFollowers() // TODO: 팔로워 구현 후 추가할것
-                                // .memberFollowings()
+                                .memberFollowers(followService.getFollowersCount(username))
+                                .memberFollowings(followService.getFollowingsCount(username))
                                 .build();
     }
 


### PR DESCRIPTION
### 시큐리티 설정 변경
- 로그인 시 username에 해당하는 계정이 없을때 500 오류 발생을 처리하는 로직 추가(계정정보가 일치하지 않습니다 에러가 발생하도록 변경)
- 프로필 조회는 로그인없이도 가능하도록 수정
---
### Follow, Member 서비스 수정
- 팔로워, 팔로잉 수를 구하는 메서드 구현
- 위의 메서드를 바탕으로 유저프로필조회에 사용하도록 수정
- 서비스 내에서 final 키워드를 사용할 수 있는 객체에 키워드 추가
---
### Follow, Member Swagger 설정
- 팔로우 관련 Swagger 정보 설정
- 멤버 관련 Swagger 정보 설정


resolves: #46 