### PR TITLE
게시물 목록 조회 API 추가

### DIFF
--- a/src/main/java/cloneproject/Instagram/controller/PostController.java
+++ b/src/main/java/cloneproject/Instagram/controller/PostController.java
@@ -1,16 +1,20 @@
 package cloneproject.Instagram.controller;
 
 import cloneproject.Instagram.config.CustomValidator;
+import cloneproject.Instagram.dto.post.PostDTO;
 import cloneproject.Instagram.dto.post.PostCreateResponse;
 import cloneproject.Instagram.dto.post.PostImageTagRequest;
 import cloneproject.Instagram.dto.post.PostImageUploadResponse;
 import cloneproject.Instagram.dto.result.ResultResponse;
+import cloneproject.Instagram.entity.post.Post;
 import cloneproject.Instagram.service.PostService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.validator.constraints.Length;
+import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
@@ -33,6 +37,7 @@ public class PostController {
     private final PostService postService;
     private final CustomValidator validator;
 
+    @ApiOperation(value = "게시물 생성")
     @ApiImplicitParam(name = "content", value = "게시물 내용", example = "안녕하세요.", required = true)
     @PostMapping("/posts")
     public ResponseEntity<ResultResponse> createPost(
@@ -44,6 +49,7 @@ public class PostController {
         return ResponseEntity.ok(ResultResponse.of(CREATE_POST_SUCCESS, response));
     }
 
+    @ApiOperation(value = "게시물 이미지 업로드")
     @ApiImplicitParam(name = "id", value = "게시물 PK", example = "1", required = true)
     @PostMapping("/posts/images")
     public ResponseEntity<ResultResponse> uploadImages(
@@ -53,9 +59,10 @@ public class PostController {
         final List<Long> imageIdList = postService.uploadImages(id, uploadImages);
         PostImageUploadResponse response = new PostImageUploadResponse(imageIdList);
 
-        return ResponseEntity.ok(ResultResponse.of(UPLOAD_IMAGES_SUCCESS, response));
+        return ResponseEntity.ok(ResultResponse.of(UPLOAD_POST_IMAGES_SUCCESS, response));
     }
 
+    @ApiOperation(value = "게시물 이미지 태그 적용")
     @PostMapping("/posts/images/tags")
     public ResponseEntity<ResultResponse> uploadImageTags(@RequestBody List<PostImageTagRequest> requests, BindingResult bindingResult) throws BindException {
         validator.validate(requests, bindingResult);
@@ -64,6 +71,14 @@ public class PostController {
 
         postService.addTags(requests);
 
-        return ResponseEntity.ok(ResultResponse.of(ADD_TAGS_SUCCESS, null));
+        return ResponseEntity.ok(ResultResponse.of(ADD_POST_IMAGE_TAGS_SUCCESS, null));
+    }
+
+    @ApiOperation(value = "게시물 목록 조회")
+    @GetMapping("/posts")
+    public ResponseEntity<ResultResponse> postDtoList(int size) {
+        final Slice<PostDTO> postPage = postService.getPostDtoPage(size);
+
+        return ResponseEntity.ok(ResultResponse.of(FIND_POST_PAGE_SUCCESS, postPage));
     }
 }

--- a/src/main/java/cloneproject/Instagram/controller/PostController.java
+++ b/src/main/java/cloneproject/Instagram/controller/PostController.java
@@ -6,6 +6,7 @@ import cloneproject.Instagram.dto.result.ResultResponse;
 import cloneproject.Instagram.service.PostService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -72,6 +73,10 @@ public class PostController {
     }
 
     @ApiOperation(value = "게시물 목록 조회")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "size", value = "한 페이지당 가져올 게시물 size", example = "5", required = true),
+            @ApiImplicitParam(name = "page", value = "게시물 page", example = "1", required = true)
+    })
     @GetMapping("/posts")
     public ResponseEntity<ResultResponse> getPosts(
             @Validated @NotNull(message = "조회할 게시물 size는 필수입니다.") @RequestParam int size,

--- a/src/main/java/cloneproject/Instagram/controller/PostController.java
+++ b/src/main/java/cloneproject/Instagram/controller/PostController.java
@@ -76,9 +76,17 @@ public class PostController {
 
     @ApiOperation(value = "게시물 목록 조회")
     @GetMapping("/posts")
-    public ResponseEntity<ResultResponse> postDtoList(int size) {
+    public ResponseEntity<ResultResponse> postDtoList(@Validated @NotNull(message = "조회할 게시물 size는 필수입니다.") @RequestParam int size) {
         final Slice<PostDTO> postPage = postService.getPostDtoPage(size);
 
         return ResponseEntity.ok(ResultResponse.of(FIND_POST_PAGE_SUCCESS, postPage));
+    }
+
+    @ApiOperation(value = "게시물 삭제")
+    @DeleteMapping("/posts")
+    public ResponseEntity<ResultResponse> deletePost(@Validated @NotNull(message = "삭제할 게시물 PK는 필수입니다.") @RequestParam Long postId) {
+        postService.delete(postId);
+
+        return ResponseEntity.ok(ResultResponse.of(DELETE_POST_SUCCESS, null));
     }
 }

--- a/src/main/java/cloneproject/Instagram/controller/PostController.java
+++ b/src/main/java/cloneproject/Instagram/controller/PostController.java
@@ -3,6 +3,7 @@ package cloneproject.Instagram.controller;
 import cloneproject.Instagram.config.CustomValidator;
 import cloneproject.Instagram.dto.post.*;
 import cloneproject.Instagram.dto.result.ResultResponse;
+import cloneproject.Instagram.entity.post.Post;
 import cloneproject.Instagram.service.PostService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
@@ -93,13 +94,4 @@ public class PostController {
 
         return ResponseEntity.ok(ResultResponse.of(DELETE_POST_SUCCESS, null));
     }
-
-    /*// TODO: 게시물 목록 조회 쿼리 개선하면서 같이 구현하기
-    @ApiOperation(value = "게시물 조회")
-    @GetMapping("/posts/{postId}")
-    public ResponseEntity<ResultResponse> getPost(@Validated @NotNull(message = "삭제할 게시물 PK는 필수입니다.") @PathVariable Long postId) {
-        final PostResponse response = postService.getPost(postId);
-
-        return ResponseEntity.ok(ResultResponse.of(FIND_POST_SUCCESS, response));
-    }*/
 }

--- a/src/main/java/cloneproject/Instagram/dto/error/ErrorCode.java
+++ b/src/main/java/cloneproject/Instagram/dto/error/ErrorCode.java
@@ -38,6 +38,7 @@ public enum ErrorCode {
     NOT_SUPPORTED_IMAGE_TYPE(400, "P003", "지원하지 않는 이미지 타입입니다."),
     POST_IMAGE_NOT_FOUND(400, "P004", "존재하지 않는 게시물 이미지입니다."),
     NO_POST_IMAGE_TAG(400, "P005", "게시물 이미지 태그는 필수입니다."),
+    INVALID_TAG_LOCATION(400, "P006", "게시물 이미지 태그 위치가 유효하지 않습니다."),
 
     // FILE
     CANT_CONVERT_FILE(401, "FI001", "파일을 변환할수 없습니다");

--- a/src/main/java/cloneproject/Instagram/dto/error/ErrorCode.java
+++ b/src/main/java/cloneproject/Instagram/dto/error/ErrorCode.java
@@ -37,6 +37,7 @@ public enum ErrorCode {
     NOT_SUPPORTED_IMAGE_TYPE(400, "P003", "지원하지 않는 이미지 타입입니다."),
     POST_IMAGE_NOT_FOUND(400, "P004", "존재하지 않는 게시물 이미지입니다."),
     NO_POST_IMAGE_TAG(400, "P005", "게시물 이미지 태그는 필수입니다."),
+    INVALID_TAG_LOCATION(400, "P006", "게시물 이미지 태그 위치가 유효하지 않습니다."),
     ;
 
     private int status;

--- a/src/main/java/cloneproject/Instagram/dto/post/PostDTO.java
+++ b/src/main/java/cloneproject/Instagram/dto/post/PostDTO.java
@@ -1,0 +1,45 @@
+package cloneproject.Instagram.dto.post;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostDTO {
+
+    private Long postId;
+    private String postContent;
+    private List<PostImageDTO> postImageDTOs = new ArrayList<>();
+    private LocalDateTime postUploadDate;
+    private String memberUsername;
+    private String memberNickname;
+    private String memberImageUrl;
+    private int postCommentsCount;
+    private int postLikesCount;
+    private boolean postBookmarkFlag;
+    private boolean postLikeFlag;
+    private String followingMemberUsernameLikedPost;
+
+    @QueryProjection
+    public PostDTO(Long postId, String postContent, LocalDateTime postUploadDate, String memberUsername, String memberNickname, String memberImageUrl, int postCommentsCount, int postLikesCount, boolean postBookmarkFlag, boolean postLikeFlag, String followingMemberUsernameLikedPost) {
+        this.postId = postId;
+        this.postContent = postContent;
+        this.postUploadDate = postUploadDate;
+        this.memberUsername = memberUsername;
+        this.memberNickname = memberNickname;
+        this.memberImageUrl = memberImageUrl;
+        this.postCommentsCount = postCommentsCount;
+        this.postLikesCount = postLikesCount;
+        this.postBookmarkFlag = postBookmarkFlag;
+        this.postLikeFlag = postLikeFlag;
+        this.followingMemberUsernameLikedPost = followingMemberUsernameLikedPost;
+    }
+}

--- a/src/main/java/cloneproject/Instagram/dto/post/PostImageDTO.java
+++ b/src/main/java/cloneproject/Instagram/dto/post/PostImageDTO.java
@@ -1,0 +1,19 @@
+package cloneproject.Instagram.dto.post;
+
+import cloneproject.Instagram.vo.Image;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class PostImageDTO {
+
+    private Long id;
+    private Image image;
+    private List<PostTagDTO> postTagDTOs = new ArrayList<>();
+}

--- a/src/main/java/cloneproject/Instagram/dto/post/PostTagDTO.java
+++ b/src/main/java/cloneproject/Instagram/dto/post/PostTagDTO.java
@@ -1,0 +1,15 @@
+package cloneproject.Instagram.dto.post;
+
+import cloneproject.Instagram.vo.Tag;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class PostTagDTO {
+
+    private Long id;
+    private Tag tag;
+}

--- a/src/main/java/cloneproject/Instagram/dto/result/ResultCode.java
+++ b/src/main/java/cloneproject/Instagram/dto/result/ResultCode.java
@@ -22,8 +22,9 @@ public enum ResultCode {
 
     // POST
     CREATE_POST_SUCCESS(200, "P001", "게시물 생성 성공"),
-    UPLOAD_IMAGES_SUCCESS(200, "P002", "이미지 업로드 성공"),
-    ADD_TAGS_SUCCESS(200, "P003", "태그 추가 성공"),
+    UPLOAD_POST_IMAGES_SUCCESS(200, "P002", "게시물 이미지 업로드 성공"),
+    ADD_POST_IMAGE_TAGS_SUCCESS(200, "P003", "게시물 이미지 태그 추가 성공"),
+    FIND_POST_PAGE_SUCCESS(200, "P004", "게시물 페이지 조회 성공"),
     ;
 
     private int status;

--- a/src/main/java/cloneproject/Instagram/dto/result/ResultCode.java
+++ b/src/main/java/cloneproject/Instagram/dto/result/ResultCode.java
@@ -25,6 +25,7 @@ public enum ResultCode {
     UPLOAD_POST_IMAGES_SUCCESS(200, "P002", "게시물 이미지 업로드 성공"),
     ADD_POST_IMAGE_TAGS_SUCCESS(200, "P003", "게시물 이미지 태그 추가 성공"),
     FIND_POST_PAGE_SUCCESS(200, "P004", "게시물 페이지 조회 성공"),
+    DELETE_POST_SUCCESS(200, "P005", "게시물 삭제 성공"),
     ;
 
     private int status;

--- a/src/main/java/cloneproject/Instagram/dto/result/ResultCode.java
+++ b/src/main/java/cloneproject/Instagram/dto/result/ResultCode.java
@@ -31,6 +31,7 @@ public enum ResultCode {
     ADD_POST_IMAGE_TAGS_SUCCESS(200, "P003", "게시물 이미지 태그 추가 성공"),
     FIND_POST_PAGE_SUCCESS(200, "P004", "게시물 페이지 조회 성공"),
     DELETE_POST_SUCCESS(200, "P005", "게시물 삭제 성공"),
+    FIND_POST_SUCCESS(200, "P006", "게시물 조회 성공"),
     ;
 
     private int status;

--- a/src/main/java/cloneproject/Instagram/entity/post/Post.java
+++ b/src/main/java/cloneproject/Instagram/entity/post/Post.java
@@ -1,5 +1,6 @@
 package cloneproject.Instagram.entity.post;
 
+import cloneproject.Instagram.entity.comment.Comment;
 import cloneproject.Instagram.entity.member.Member;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -10,6 +11,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Entity
@@ -33,6 +36,18 @@ public class Post {
 
     @CreatedDate
     private LocalDateTime uploadDate;
+
+    @OneToMany(mappedBy = "post")
+    private List<Comment> comments = new ArrayList<>();
+
+    @OneToMany(mappedBy = "post")
+    private List<PostLike> postLikes = new ArrayList<>();
+
+    @OneToMany(mappedBy = "post")
+    private List<Bookmark> bookmarks = new ArrayList<>();
+
+    @OneToMany(mappedBy = "post")
+    private List<PostImage> postImages = new ArrayList<>();
 
     @Builder
     public Post(Member member, String content) {

--- a/src/main/java/cloneproject/Instagram/entity/post/Post.java
+++ b/src/main/java/cloneproject/Instagram/entity/post/Post.java
@@ -37,16 +37,16 @@ public class Post {
     @CreatedDate
     private LocalDateTime uploadDate;
 
-    @OneToMany(mappedBy = "post")
+    @OneToMany(mappedBy = "post", orphanRemoval = true)
     private List<Comment> comments = new ArrayList<>();
 
-    @OneToMany(mappedBy = "post")
+    @OneToMany(mappedBy = "post", orphanRemoval = true)
     private List<PostLike> postLikes = new ArrayList<>();
 
-    @OneToMany(mappedBy = "post")
+    @OneToMany(mappedBy = "post", orphanRemoval = true)
     private List<Bookmark> bookmarks = new ArrayList<>();
 
-    @OneToMany(mappedBy = "post")
+    @OneToMany(mappedBy = "post", orphanRemoval = true)
     private List<PostImage> postImages = new ArrayList<>();
 
     @Builder

--- a/src/main/java/cloneproject/Instagram/entity/post/PostImage.java
+++ b/src/main/java/cloneproject/Instagram/entity/post/PostImage.java
@@ -41,7 +41,7 @@ public class PostImage {
     @CreatedDate
     private LocalDateTime uploadDate;
 
-    @OneToMany(mappedBy = "postImage")
+    @OneToMany(mappedBy = "postImage", orphanRemoval = true)
     private List<PostTag> postTags = new ArrayList<>();
 
     @Builder

--- a/src/main/java/cloneproject/Instagram/entity/post/PostImage.java
+++ b/src/main/java/cloneproject/Instagram/entity/post/PostImage.java
@@ -10,6 +10,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Entity
@@ -38,6 +40,9 @@ public class PostImage {
 
     @CreatedDate
     private LocalDateTime uploadDate;
+
+    @OneToMany(mappedBy = "postImage")
+    private List<PostTag> postTags = new ArrayList<>();
 
     @Builder
     public PostImage(Post post, Image image) {

--- a/src/main/java/cloneproject/Instagram/entity/post/PostImage.java
+++ b/src/main/java/cloneproject/Instagram/entity/post/PostImage.java
@@ -5,11 +5,9 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -37,9 +35,6 @@ public class PostImage {
             @AttributeOverride(name = "imageUUID", column = @Column(name = "post_image_uuid"))
     })
     private Image image;
-
-    @CreatedDate
-    private LocalDateTime uploadDate;
 
     @OneToMany(mappedBy = "postImage", orphanRemoval = true)
     private List<PostTag> postTags = new ArrayList<>();

--- a/src/main/java/cloneproject/Instagram/entity/post/PostTag.java
+++ b/src/main/java/cloneproject/Instagram/entity/post/PostTag.java
@@ -1,6 +1,5 @@
 package cloneproject.Instagram.entity.post;
 
-import cloneproject.Instagram.entity.member.Member;
 import cloneproject.Instagram.vo.Tag;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -21,23 +20,19 @@ public class PostTag {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
-    private Member member;
-
-    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_image_id")
     private PostImage postImage;
 
     @Embedded
     @AttributeOverrides({
             @AttributeOverride(name = "y", column = @Column(name = "post_tag_y")),
-            @AttributeOverride(name = "x", column = @Column(name = "post_tag_x"))
+            @AttributeOverride(name = "x", column = @Column(name = "post_tag_x")),
+            @AttributeOverride(name = "username", column = @Column(name = "post_tag_username"))
     })
     private Tag tag;
 
     @Builder
-    public PostTag(Member member, PostImage postImage, Tag tag) {
-        this.member = member;
+    public PostTag(PostImage postImage, Tag tag) {
         this.postImage = postImage;
         this.tag = tag;
     }

--- a/src/main/java/cloneproject/Instagram/exception/InvalidTagLocationException.java
+++ b/src/main/java/cloneproject/Instagram/exception/InvalidTagLocationException.java
@@ -1,0 +1,10 @@
+package cloneproject.Instagram.exception;
+
+import cloneproject.Instagram.dto.error.ErrorCode;
+
+public class InvalidTagLocationException extends BusinessException {
+
+    public InvalidTagLocationException(){
+        super(ErrorCode.INVALID_TAG_LOCATION);
+    }
+}

--- a/src/main/java/cloneproject/Instagram/repository/PostRepository.java
+++ b/src/main/java/cloneproject/Instagram/repository/PostRepository.java
@@ -3,5 +3,6 @@ package cloneproject.Instagram.repository;
 import cloneproject.Instagram.entity.post.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PostRepository extends JpaRepository<Post, Long> {
+public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryCustom {
+
 }

--- a/src/main/java/cloneproject/Instagram/repository/PostRepository.java
+++ b/src/main/java/cloneproject/Instagram/repository/PostRepository.java
@@ -3,6 +3,9 @@ package cloneproject.Instagram.repository;
 import cloneproject.Instagram.entity.post.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryCustom {
 
+    Optional<Post> findByIdAndMemberId(Long postId, Long memberId);
 }

--- a/src/main/java/cloneproject/Instagram/repository/PostRepositoryCustom.java
+++ b/src/main/java/cloneproject/Instagram/repository/PostRepositoryCustom.java
@@ -2,9 +2,9 @@ package cloneproject.Instagram.repository;
 
 import cloneproject.Instagram.dto.post.PostDTO;
 import cloneproject.Instagram.entity.member.Member;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 
 public interface PostRepositoryCustom {
-    Slice<PostDTO> findPostDtoPage(Member member, Pageable pageable);
+    Page<PostDTO> findPostDtoPage(Member member, Pageable pageable);
 }

--- a/src/main/java/cloneproject/Instagram/repository/PostRepositoryCustom.java
+++ b/src/main/java/cloneproject/Instagram/repository/PostRepositoryCustom.java
@@ -1,0 +1,10 @@
+package cloneproject.Instagram.repository;
+
+import cloneproject.Instagram.dto.post.PostDTO;
+import cloneproject.Instagram.entity.member.Member;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+public interface PostRepositoryCustom {
+    Slice<PostDTO> findPostDtoPage(Member member, Pageable pageable);
+}

--- a/src/main/java/cloneproject/Instagram/repository/PostRepositoryCustomImpl.java
+++ b/src/main/java/cloneproject/Instagram/repository/PostRepositoryCustomImpl.java
@@ -12,8 +12,9 @@ import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 
 import java.util.List;
@@ -34,7 +35,7 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Slice<PostDTO> findPostDtoPage(Member member, Pageable pageable) {
+    public Page<PostDTO> findPostDtoPage(Member member, Pageable pageable) {
         if (member.getFollowings().isEmpty())
             return null;
 
@@ -107,8 +108,6 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
             postDTO.setPostImageDTOs(transform);
         }
 
-        boolean hasNext = pageable.isPaged() && content.size() > pageable.getPageSize();
-
-        return new SliceImpl<>(content, pageable, hasNext);
+        return new PageImpl<>(content, pageable, content.size());
     }
 }

--- a/src/main/java/cloneproject/Instagram/repository/PostRepositoryCustomImpl.java
+++ b/src/main/java/cloneproject/Instagram/repository/PostRepositoryCustomImpl.java
@@ -1,11 +1,10 @@
 package cloneproject.Instagram.repository;
 
-import cloneproject.Instagram.dto.post.PostDTO;
-import cloneproject.Instagram.dto.post.PostImageDTO;
-import cloneproject.Instagram.dto.post.PostTagDTO;
-import cloneproject.Instagram.dto.post.QPostDTO;
+import cloneproject.Instagram.dto.post.*;
+import cloneproject.Instagram.entity.comment.QComment;
 import cloneproject.Instagram.entity.member.Member;
 import cloneproject.Instagram.entity.member.QMember;
+import cloneproject.Instagram.entity.post.Post;
 import com.querydsl.core.QueryResults;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.JPAExpressions;
@@ -15,7 +14,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.SliceImpl;
 
 import java.util.List;
 
@@ -110,4 +108,5 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
 
         return new PageImpl<>(content, pageable, content.size());
     }
+
 }

--- a/src/main/java/cloneproject/Instagram/repository/PostRepositoryCustomImpl.java
+++ b/src/main/java/cloneproject/Instagram/repository/PostRepositoryCustomImpl.java
@@ -1,0 +1,114 @@
+package cloneproject.Instagram.repository;
+
+import cloneproject.Instagram.dto.post.PostDTO;
+import cloneproject.Instagram.dto.post.PostImageDTO;
+import cloneproject.Instagram.dto.post.PostTagDTO;
+import cloneproject.Instagram.dto.post.QPostDTO;
+import cloneproject.Instagram.entity.member.Member;
+import cloneproject.Instagram.entity.member.QMember;
+import com.querydsl.core.QueryResults;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+
+import java.util.List;
+
+import static cloneproject.Instagram.entity.member.QFollow.follow;
+import static cloneproject.Instagram.entity.post.QBookmark.bookmark;
+import static cloneproject.Instagram.entity.post.QPost.post;
+import static cloneproject.Instagram.entity.post.QPostImage.postImage;
+import static cloneproject.Instagram.entity.post.QPostLike.postLike;
+import static cloneproject.Instagram.entity.post.QPostTag.postTag;
+import static com.querydsl.core.group.GroupBy.groupBy;
+import static com.querydsl.core.group.GroupBy.list;
+
+@Slf4j
+@RequiredArgsConstructor
+public class PostRepositoryCustomImpl implements PostRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Slice<PostDTO> findPostDtoPage(Member member, Pageable pageable) {
+        if (member.getFollowings().isEmpty())
+            return null;
+
+        // TODO: 최신 댓글 2개 추가 -> 댓글 API 구현할 때 업데이트
+        QueryResults<PostDTO> results = queryFactory
+                .select(new QPostDTO(
+                        post.id,
+                        post.content,
+                        post.uploadDate,
+                        post.member.username,
+                        post.member.name,
+                        post.member.image.imageUrl,
+                        post.comments.size(),
+                        post.postLikes.size(),
+                        JPAExpressions
+                                .selectFrom(bookmark)
+                                .where(bookmark.post.eq(post).and(bookmark.member.eq(member)))
+                                .exists(),
+                        JPAExpressions
+                                .selectFrom(postLike)
+                                .where(postLike.post.eq(post).and(postLike.member.eq(member)))
+                                .exists(),
+                        JPAExpressions
+                                .select(postLike.member.username)
+                                .from(postLike)
+                                .where(postLike.post.eq(post)
+                                        .and(postLike.member
+                                                .in(JPAExpressions
+                                                        .select(follow.followMember)
+                                                        .from(follow)
+                                                        .where(follow.member.eq(member)))))
+                                .limit(1)
+                ))
+                .from(post)
+                .join(QMember.member)
+                .on(post.member.username.in(
+                        JPAExpressions
+                                .select(follow.followMember.username)
+                                .from(follow)
+                                .where(follow.member.eq(member))
+                )).distinct()
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(post.id.desc())
+                .fetchResults();
+
+        List<PostDTO> content = results.getResults();
+        for (PostDTO postDTO : content) {
+            final List<PostImageDTO> transform = queryFactory
+                    .from(postImage)
+                    .where(postImage.post.id.eq(postDTO.getPostId()))
+                    .innerJoin(postTag)
+                    .on(postImage.id.eq(postTag.postImage.id))
+                    .transform(
+                            groupBy(postImage.id).list(
+                                    Projections.fields(
+                                            PostImageDTO.class,
+                                            postImage.id,
+                                            postImage.image,
+                                            list(
+                                                    Projections.fields(
+                                                            PostTagDTO.class,
+                                                            postTag.id,
+                                                            postTag.tag
+                                                    )
+                                            ).as("postTagDTOs")
+                                    )
+                            )
+                    );
+            postDTO.setPostImageDTOs(transform);
+        }
+
+        boolean hasNext = pageable.isPaged() && content.size() > pageable.getPageSize();
+
+        return new SliceImpl<>(content, pageable, hasNext);
+    }
+}

--- a/src/main/java/cloneproject/Instagram/service/PostService.java
+++ b/src/main/java/cloneproject/Instagram/service/PostService.java
@@ -3,6 +3,7 @@ package cloneproject.Instagram.service;
 import cloneproject.Instagram.dto.post.PostDTO;
 import cloneproject.Instagram.dto.post.PostImageTagDTO;
 import cloneproject.Instagram.dto.post.PostImageTagRequest;
+import cloneproject.Instagram.dto.post.PostResponse;
 import cloneproject.Instagram.entity.member.Member;
 import cloneproject.Instagram.entity.post.Post;
 import cloneproject.Instagram.entity.post.PostImage;
@@ -116,11 +117,13 @@ public class PostService {
 
                 postTagRepository.save(postTag);
             }
+
         }
     }
 
-    public Slice<PostDTO> getPostDtoPage(int size) {
-        final Pageable pageable = PageRequest.of(0, size, Sort.by(DESC, "id"));
+    public Page<PostDTO> getPostDtoPage(int size, int page) {
+        page = (page == 0 ? 0 : page - 1);
+        final Pageable pageable = PageRequest.of(page, size, Sort.by(DESC, "id"));
         final Long memberId = Long.parseLong(SecurityContextHolder.getContext().getAuthentication().getName());
         final Member member = memberRepository.findById(memberId).orElseThrow(MemberDoesNotExistException::new);
         return postRepository.findPostDtoPage(member, pageable);
@@ -131,5 +134,10 @@ public class PostService {
         final Long memberId = Long.valueOf(SecurityContextHolder.getContext().getAuthentication().getName());
         final Post post = postRepository.findByIdAndMemberId(postId, memberId).orElseThrow(PostNotFoundException::new);
         postRepository.delete(post);
+    }
+
+    public PostResponse getPost(Long postId) {
+
+        return null;
     }
 }

--- a/src/main/java/cloneproject/Instagram/service/PostService.java
+++ b/src/main/java/cloneproject/Instagram/service/PostService.java
@@ -44,7 +44,7 @@ public class PostService {
 
     @Transactional
     public Long create(String content) {
-        String memberId = SecurityContextHolder.getContext().getAuthentication().getName();
+        final String memberId = SecurityContextHolder.getContext().getAuthentication().getName();
         final Member member = memberRepository.findById(Long.valueOf(memberId)).orElseThrow(MemberDoesNotExistException::new);
         Post post = Post.builder()
                 .member(member)
@@ -124,5 +124,12 @@ public class PostService {
         final Long memberId = Long.parseLong(SecurityContextHolder.getContext().getAuthentication().getName());
         final Member member = memberRepository.findById(memberId).orElseThrow(MemberDoesNotExistException::new);
         return postRepository.findPostDtoPage(member, pageable);
+    }
+
+    @Transactional
+    public void delete(Long postId) {
+        final Long memberId = Long.valueOf(SecurityContextHolder.getContext().getAuthentication().getName());
+        final Post post = postRepository.findByIdAndMemberId(postId, memberId).orElseThrow(PostNotFoundException::new);
+        postRepository.delete(post);
     }
 }

--- a/src/main/java/cloneproject/Instagram/vo/Tag.java
+++ b/src/main/java/cloneproject/Instagram/vo/Tag.java
@@ -14,10 +14,11 @@ public class Tag {
 
     private Long x;
     private Long y;
+    private String username;
 
     @Override
     public int hashCode() {
-        return Objects.hash(x, y);
+        return Objects.hash(x, y, username);
     }
 
     @Override
@@ -28,6 +29,6 @@ public class Tag {
             return false;
 
         Tag tag = (Tag) obj;
-        return Objects.equals(x, tag.x) && Objects.equals(y, tag.y);
+        return Objects.equals(x, tag.x) && Objects.equals(y, tag.y) && Objects.equals(username, tag.username);
     }
 }


### PR DESCRIPTION
## 변경 사항
### 게시물 목록 조회 API 추가
- 현재 게시물마다 이미지 조회 쿼리 추가 발생(N + 1)
- 일단 에러는 해결되었으므로, 빠른 진행을 위해 이후에 해결방법 찾을 예정
### 게시물 관련 엔티티 연관관계 업데이트
- Post: 일대다 연관관계 추가(댓글, 좋아요, 저장, 이미지)
- PostImage: 일대다 연관관계 추가(사용자 태그)
- PostTag: 다대일 연관관계 제거(회원) -> Tag VO에 username 필드 추가
- 일대다 연관관계 orphanRemoval = true 속성 추가
### 게시물 삭제 API 추가
### 이미지 S#에 저장 로직 추가

Resolves: #37 #39 #48 