### PR TITLE
게시물 목록 조회 API 분할, 게시물 조회 API 추가 및 쿼리 최적화

### DIFF
--- a/src/main/java/cloneproject/Instagram/controller/PostController.java
+++ b/src/main/java/cloneproject/Instagram/controller/PostController.java
@@ -6,7 +6,6 @@ import cloneproject.Instagram.dto.result.ResultResponse;
 import cloneproject.Instagram.service.PostService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
-import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -74,9 +73,7 @@ public class PostController {
     }
 
     @ApiOperation(value = "게시물 페이징 조회(무한스크롤)")
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "page", value = "게시물 page", example = "1", required = true)
-    })
+    @ApiImplicitParam(name = "page", value = "게시물 page", example = "1", required = true)
     @GetMapping("/posts")
     public ResponseEntity<ResultResponse> getPostPage(
             @Validated @NotNull(message = "조회할 게시물 page는 필수입니다.") @RequestParam int page) {
@@ -94,11 +91,22 @@ public class PostController {
     }
 
     @ApiOperation(value = "게시물 삭제")
+    @ApiImplicitParam(name = "postId", value = "게시물 PK", example = "1", required = true)
     @DeleteMapping("/posts")
     public ResponseEntity<ResultResponse> deletePost(
             @Validated @NotNull(message = "삭제할 게시물 PK는 필수입니다.") @RequestParam Long postId) {
         postService.delete(postId);
 
         return ResponseEntity.ok(ResultResponse.of(DELETE_POST_SUCCESS, null));
+    }
+
+    @ApiOperation(value = "게시물 조회")
+    @ApiImplicitParam(name = "postId", value = "게시물 PK", example = "1", required = true)
+    @GetMapping("/posts/{postId}")
+    public ResponseEntity<ResultResponse> getPost(
+            @Validated @NotNull(message = "조회할 게시물 PK는 필수입니다.") @PathVariable Long postId) {
+        final PostResponse response = postService.getPost(postId);
+
+        return ResponseEntity.ok(ResultResponse.of(FIND_POST_SUCCESS, response));
     }
 }

--- a/src/main/java/cloneproject/Instagram/controller/PostController.java
+++ b/src/main/java/cloneproject/Instagram/controller/PostController.java
@@ -86,7 +86,7 @@ public class PostController {
     }
 
     @ApiOperation(value = "최근 게시물 10개 조회")
-    @GetMapping("/home/posts")
+    @GetMapping("/posts/recent")
     public ResponseEntity<ResultResponse> getRecent10Posts() {
         final List<PostDTO> postList = postService.getRecent10PostDTOs();
 

--- a/src/main/java/cloneproject/Instagram/controller/PostController.java
+++ b/src/main/java/cloneproject/Instagram/controller/PostController.java
@@ -3,7 +3,6 @@ package cloneproject.Instagram.controller;
 import cloneproject.Instagram.config.CustomValidator;
 import cloneproject.Instagram.dto.post.*;
 import cloneproject.Instagram.dto.result.ResultResponse;
-import cloneproject.Instagram.entity.post.Post;
 import cloneproject.Instagram.service.PostService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
@@ -63,7 +62,8 @@ public class PostController {
 
     @ApiOperation(value = "게시물 이미지 태그 적용")
     @PostMapping(value = "/posts/images/tags")
-    public ResponseEntity<ResultResponse> uploadImageTags(@RequestBody List<PostImageTagRequest> requests, BindingResult bindingResult) throws BindException {
+    public ResponseEntity<ResultResponse> uploadImageTags(
+            @RequestBody List<PostImageTagRequest> requests, BindingResult bindingResult) throws BindException {
         validator.validate(requests, bindingResult);
         if (bindingResult.hasErrors())
             throw new BindException(bindingResult);
@@ -73,23 +73,30 @@ public class PostController {
         return ResponseEntity.ok(ResultResponse.of(ADD_POST_IMAGE_TAGS_SUCCESS, null));
     }
 
-    @ApiOperation(value = "게시물 목록 조회")
+    @ApiOperation(value = "게시물 페이징 조회(무한스크롤)")
     @ApiImplicitParams({
-            @ApiImplicitParam(name = "size", value = "한 페이지당 가져올 게시물 size", example = "5", required = true),
             @ApiImplicitParam(name = "page", value = "게시물 page", example = "1", required = true)
     })
     @GetMapping("/posts")
-    public ResponseEntity<ResultResponse> getPosts(
-            @Validated @NotNull(message = "조회할 게시물 size는 필수입니다.") @RequestParam int size,
+    public ResponseEntity<ResultResponse> getPostPage(
             @Validated @NotNull(message = "조회할 게시물 page는 필수입니다.") @RequestParam int page) {
-        final Page<PostDTO> postPage = postService.getPostDtoPage(size, page);
+        final Page<PostDTO> postPage = postService.getPostDtoPage(1, page);
 
         return ResponseEntity.ok(ResultResponse.of(FIND_POST_PAGE_SUCCESS, postPage));
     }
 
+    @ApiOperation(value = "최근 게시물 10개 조회")
+    @GetMapping("/home/posts")
+    public ResponseEntity<ResultResponse> getRecent10Posts() {
+        final List<PostDTO> postList = postService.getRecent10PostDTOs();
+
+        return ResponseEntity.ok(ResultResponse.of(FIND_RECENT10POSTS_SUCCESS, postList));
+    }
+
     @ApiOperation(value = "게시물 삭제")
     @DeleteMapping("/posts")
-    public ResponseEntity<ResultResponse> deletePost(@Validated @NotNull(message = "삭제할 게시물 PK는 필수입니다.") @RequestParam Long postId) {
+    public ResponseEntity<ResultResponse> deletePost(
+            @Validated @NotNull(message = "삭제할 게시물 PK는 필수입니다.") @RequestParam Long postId) {
         postService.delete(postId);
 
         return ResponseEntity.ok(ResultResponse.of(DELETE_POST_SUCCESS, null));

--- a/src/main/java/cloneproject/Instagram/dto/comment/CommentDTO.java
+++ b/src/main/java/cloneproject/Instagram/dto/comment/CommentDTO.java
@@ -1,0 +1,35 @@
+package cloneproject.Instagram.dto.comment;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+public class CommentDTO {
+
+    @JsonIgnore
+    private Long postId;
+    private Long id;
+    private String username;
+    private String content;
+    private LocalDateTime uploadDate;
+    private int commentLikesCount;
+    private boolean commentLikeFlag;
+    private int repliesCount;
+
+    @QueryProjection
+    public CommentDTO(Long postId, Long id, String username, String content, LocalDateTime uploadDate, int commentLikesCount, boolean commentLikeFlag, int repliesCount) {
+        this.postId = postId;
+        this.id = id;
+        this.username = username;
+        this.content = content;
+        this.uploadDate = uploadDate;
+        this.commentLikesCount = commentLikesCount;
+        this.commentLikeFlag = commentLikeFlag;
+        this.repliesCount = repliesCount;
+    }
+}

--- a/src/main/java/cloneproject/Instagram/dto/post/PostImageDTO.java
+++ b/src/main/java/cloneproject/Instagram/dto/post/PostImageDTO.java
@@ -1,6 +1,7 @@
 package cloneproject.Instagram.dto.post;
 
-import cloneproject.Instagram.vo.Image;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.querydsl.core.annotations.QueryProjection;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -13,7 +14,16 @@ import java.util.List;
 @NoArgsConstructor
 public class PostImageDTO {
 
+    @JsonIgnore
+    private Long postId;
     private Long id;
-    private Image image;
+    private String postImageUrl;
     private List<PostTagDTO> postTagDTOs = new ArrayList<>();
+
+    @QueryProjection
+    public PostImageDTO(Long postId, Long id, String postImageUrl) {
+        this.postId = postId;
+        this.id = id;
+        this.postImageUrl = postImageUrl;
+    }
 }

--- a/src/main/java/cloneproject/Instagram/dto/post/PostResponse.java
+++ b/src/main/java/cloneproject/Instagram/dto/post/PostResponse.java
@@ -1,0 +1,46 @@
+package cloneproject.Instagram.dto.post;
+
+import cloneproject.Instagram.dto.comment.CommentDTO;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Setter
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class PostResponse {
+
+    private Long postId;
+    private String postContent;
+    private LocalDateTime postUploadDate;
+    private String memberUsername;
+    private String memberNickname;
+    private String memberImageUrl;
+    private int postLikesCount;
+    private boolean postBookmarkFlag;
+    private boolean postLikeFlag;
+    private String followingMemberUsernameLikedPost;
+    private List<PostImageDTO> postImageDTOs = new ArrayList<>();
+    private List<CommentDTO> commentDTOs = new ArrayList<>();
+
+    @QueryProjection
+    public PostResponse(Long postId, String postContent, LocalDateTime postUploadDate, String memberUsername, String memberNickname, String memberImageUrl, int postLikesCount, boolean postBookmarkFlag, boolean postLikeFlag, String followingMemberUsernameLikedPost) {
+        this.postId = postId;
+        this.postContent = postContent;
+        this.postUploadDate = postUploadDate;
+        this.memberUsername = memberUsername;
+        this.memberNickname = memberNickname;
+        this.memberImageUrl = memberImageUrl;
+        this.postLikesCount = postLikesCount;
+        this.postBookmarkFlag = postBookmarkFlag;
+        this.postLikeFlag = postLikeFlag;
+        this.followingMemberUsernameLikedPost = followingMemberUsernameLikedPost;
+    }
+}

--- a/src/main/java/cloneproject/Instagram/dto/post/PostTagDTO.java
+++ b/src/main/java/cloneproject/Instagram/dto/post/PostTagDTO.java
@@ -1,15 +1,24 @@
 package cloneproject.Instagram.dto.post;
 
 import cloneproject.Instagram.vo.Tag;
-import lombok.AllArgsConstructor;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.querydsl.core.annotations.QueryProjection;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
-@AllArgsConstructor
 @NoArgsConstructor
 public class PostTagDTO {
 
+    @JsonIgnore
+    private Long postImageId;
     private Long id;
     private Tag tag;
+
+    @QueryProjection
+    public PostTagDTO(Long postImageId, Long id, Tag tag) {
+        this.postImageId = postImageId;
+        this.id = id;
+        this.tag = tag;
+    }
 }

--- a/src/main/java/cloneproject/Instagram/dto/result/ResultCode.java
+++ b/src/main/java/cloneproject/Instagram/dto/result/ResultCode.java
@@ -32,6 +32,7 @@ public enum ResultCode {
     FIND_POST_PAGE_SUCCESS(200, "P004", "게시물 페이지 조회 성공"),
     DELETE_POST_SUCCESS(200, "P005", "게시물 삭제 성공"),
     FIND_POST_SUCCESS(200, "P006", "게시물 조회 성공"),
+    FIND_RECENT10POSTS_SUCCESS(200, "P007", "최근 게시물 10개 조회 성공"),
     ;
 
     private int status;

--- a/src/main/java/cloneproject/Instagram/entity/comment/Comment.java
+++ b/src/main/java/cloneproject/Instagram/entity/comment/Comment.java
@@ -51,6 +51,9 @@ public class Comment {
     @Column(name = "comment_upload_date")
     private LocalDateTime uploadDate;
 
+    @OneToMany(mappedBy = "comment", orphanRemoval = true)
+    private List<CommentLike> commentLikes = new ArrayList<>();
+
     @Builder
     public Comment(Comment parent, Member member, Post post, String content) {
         this.parent = (parent == null ? this : parent);

--- a/src/main/java/cloneproject/Instagram/repository/PostRepositoryCustom.java
+++ b/src/main/java/cloneproject/Instagram/repository/PostRepositoryCustom.java
@@ -1,13 +1,16 @@
 package cloneproject.Instagram.repository;
 
 import cloneproject.Instagram.dto.post.PostDTO;
+import cloneproject.Instagram.dto.post.PostResponse;
 import cloneproject.Instagram.entity.member.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface PostRepositoryCustom {
     Page<PostDTO> findPostDtoPage(Member member, Pageable pageable);
     List<PostDTO> findRecent10PostDTOs(Long memberId);
+    Optional<PostResponse> findPostResponse(Long postId, Long memberId);
 }

--- a/src/main/java/cloneproject/Instagram/repository/PostRepositoryCustom.java
+++ b/src/main/java/cloneproject/Instagram/repository/PostRepositoryCustom.java
@@ -5,6 +5,9 @@ import cloneproject.Instagram.entity.member.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface PostRepositoryCustom {
     Page<PostDTO> findPostDtoPage(Member member, Pageable pageable);
+    List<PostDTO> findRecent10PostDTOs(Long memberId);
 }

--- a/src/main/java/cloneproject/Instagram/repository/PostRepositoryCustomImpl.java
+++ b/src/main/java/cloneproject/Instagram/repository/PostRepositoryCustomImpl.java
@@ -1,12 +1,10 @@
 package cloneproject.Instagram.repository;
 
+import cloneproject.Instagram.dto.comment.CommentDTO;
+import cloneproject.Instagram.dto.comment.QCommentDTO;
 import cloneproject.Instagram.dto.post.*;
-import cloneproject.Instagram.entity.comment.QComment;
 import cloneproject.Instagram.entity.member.Member;
 import cloneproject.Instagram.entity.member.QMember;
-import cloneproject.Instagram.entity.post.Post;
-import com.querydsl.core.QueryResults;
-import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -17,16 +15,17 @@ import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static cloneproject.Instagram.entity.comment.QComment.comment;
+import static cloneproject.Instagram.entity.comment.QCommentLike.commentLike;
 import static cloneproject.Instagram.entity.member.QFollow.follow;
 import static cloneproject.Instagram.entity.post.QBookmark.bookmark;
 import static cloneproject.Instagram.entity.post.QPost.post;
 import static cloneproject.Instagram.entity.post.QPostImage.postImage;
 import static cloneproject.Instagram.entity.post.QPostLike.postLike;
 import static cloneproject.Instagram.entity.post.QPostTag.postTag;
-import static com.querydsl.core.group.GroupBy.groupBy;
-import static com.querydsl.core.group.GroupBy.list;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -201,6 +200,98 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
         postDTOs.forEach(p -> p.setPostImageDTOs(postDTOMap.get(p.getPostId())));
 
         return postDTOs;
+    }
+
+    @Override
+    public Optional<PostResponse> findPostResponse(Long postId, Long memberId) {
+        final Optional<PostResponse> response = Optional.ofNullable(queryFactory
+                .select(new QPostResponse(
+                        post.id,
+                        post.content,
+                        post.uploadDate,
+                        post.member.username,
+                        post.member.name,
+                        post.member.image.imageUrl,
+                        post.postLikes.size(),
+                        JPAExpressions
+                                .selectFrom(bookmark)
+                                .where(bookmark.post.eq(post).and(bookmark.member.id.eq(memberId)))
+                                .exists(),
+                        JPAExpressions
+                                .selectFrom(postLike)
+                                .where(postLike.post.eq(post).and(postLike.member.id.eq(memberId)))
+                                .exists(),
+                        JPAExpressions
+                                .select(postLike.member.username)
+                                .from(postLike)
+                                .where(postLike.post.eq(post)
+                                        .and(postLike.member
+                                                .in(JPAExpressions
+                                                        .select(follow.followMember)
+                                                        .from(follow)
+                                                        .where(follow.member.id.eq(memberId)))))
+                                .limit(1)
+                ))
+                .from(post)
+                .where(post.id.eq(postId))
+                .fetchOne());
+
+        if (response.isEmpty())
+            return Optional.empty();
+
+        final List<PostImageDTO> postImageDTOs = queryFactory
+                .select(new QPostImageDTO(
+                        postImage.post.id,
+                        postImage.id,
+                        postImage.image.imageUrl
+                ))
+                .from(postImage)
+                .where(postImage.post.id.eq(postId))
+                .fetch();
+
+        final List<Long> postImageIds = postImageDTOs.stream()
+                .map(PostImageDTO::getId)
+                .collect(Collectors.toList());
+
+        final List<PostTagDTO> postTagDTOs = queryFactory
+                .select(new QPostTagDTO(
+                        postTag.postImage.id,
+                        postTag.id,
+                        postTag.tag
+                ))
+                .from(postTag)
+                .where(postTag.postImage.id.in(postImageIds))
+                .fetch();
+
+        final Map<Long, List<PostTagDTO>> postImageDTOMap = postTagDTOs.stream()
+                .collect(Collectors.groupingBy(PostTagDTO::getPostImageId));
+        postImageDTOs.forEach(i -> i.setPostTagDTOs(postImageDTOMap.get(i.getId())));
+
+        response.get().setPostImageDTOs(postImageDTOs);
+
+        final List<CommentDTO> commentDTOs = queryFactory
+                .select(new QCommentDTO(
+                        comment.post.id,
+                        comment.id,
+                        comment.member.username,
+                        comment.content,
+                        comment.uploadDate,
+                        comment.commentLikes.size(),
+                        JPAExpressions
+                                .selectFrom(commentLike)
+                                .where(commentLike.comment.eq(comment).and(commentLike.member.id.eq(memberId)))
+                                .exists(),
+                        comment.children.size()
+                ))
+                .from(comment)
+                .where(comment.post.id.eq(postId))
+                .orderBy(comment.id.desc())
+                .limit(10)
+                .fetch();
+
+        response.get().setCommentDTOs(commentDTOs);
+
+        return response;
     }
 
 }

--- a/src/main/java/cloneproject/Instagram/repository/PostRepositoryCustomImpl.java
+++ b/src/main/java/cloneproject/Instagram/repository/PostRepositoryCustomImpl.java
@@ -16,6 +16,8 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import static cloneproject.Instagram.entity.member.QFollow.follow;
 import static cloneproject.Instagram.entity.post.QBookmark.bookmark;
@@ -38,7 +40,7 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
             return null;
 
         // TODO: 최신 댓글 2개 추가 -> 댓글 API 구현할 때 업데이트
-        QueryResults<PostDTO> results = queryFactory
+        final List<PostDTO> postDTOs = queryFactory
                 .select(new QPostDTO(
                         post.id,
                         post.content,
@@ -74,39 +76,131 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
                                 .select(follow.followMember.username)
                                 .from(follow)
                                 .where(follow.member.eq(member))
-                )).distinct()
+                ))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .orderBy(post.id.desc())
-                .fetchResults();
+                .fetch();
 
-        List<PostDTO> content = results.getResults();
-        for (PostDTO postDTO : content) {
-            final List<PostImageDTO> transform = queryFactory
-                    .from(postImage)
-                    .where(postImage.post.id.eq(postDTO.getPostId()))
-                    .innerJoin(postTag)
-                    .on(postImage.id.eq(postTag.postImage.id))
-                    .transform(
-                            groupBy(postImage.id).list(
-                                    Projections.fields(
-                                            PostImageDTO.class,
-                                            postImage.id,
-                                            postImage.image,
-                                            list(
-                                                    Projections.fields(
-                                                            PostTagDTO.class,
-                                                            postTag.id,
-                                                            postTag.tag
-                                                    )
-                                            ).as("postTagDTOs")
-                                    )
-                            )
-                    );
-            postDTO.setPostImageDTOs(transform);
-        }
+        final List<Long> postIds = postDTOs.stream()
+                .map(PostDTO::getPostId)
+                .collect(Collectors.toList());
 
-        return new PageImpl<>(content, pageable, content.size());
+        final List<PostImageDTO> postImageDTOs = queryFactory
+                .select(new QPostImageDTO(
+                        postImage.post.id,
+                        postImage.id,
+                        postImage.image.imageUrl
+                ))
+                .from(postImage)
+                .where(postImage.post.id.in(postIds))
+                .fetch();
+
+        final List<Long> postImageIds = postImageDTOs.stream()
+                .map(PostImageDTO::getId)
+                .collect(Collectors.toList());
+
+        final List<PostTagDTO> postTagDTOs = queryFactory
+                .select(new QPostTagDTO(
+                        postTag.postImage.id,
+                        postTag.id,
+                        postTag.tag
+                ))
+                .from(postTag)
+                .where(postTag.postImage.id.in(postImageIds))
+                .fetch();
+
+        final Map<Long, List<PostTagDTO>> postImageDTOMap = postTagDTOs.stream()
+                .collect(Collectors.groupingBy(PostTagDTO::getPostImageId));
+        postImageDTOs.forEach(i -> i.setPostTagDTOs(postImageDTOMap.get(i.getId())));
+
+        final Map<Long, List<PostImageDTO>> postDTOMap = postImageDTOs.stream()
+                .collect(Collectors.groupingBy(PostImageDTO::getPostId));
+        postDTOs.forEach(p -> p.setPostImageDTOs(postDTOMap.get(p.getPostId())));
+
+        return new PageImpl<>(postDTOs, pageable, postDTOs.size());
+    }
+
+    @Override
+    public List<PostDTO> findRecent10PostDTOs(Long memberId) {
+        final List<PostDTO> postDTOs = queryFactory
+                .select(new QPostDTO(
+                        post.id,
+                        post.content,
+                        post.uploadDate,
+                        post.member.username,
+                        post.member.name,
+                        post.member.image.imageUrl,
+                        post.comments.size(),
+                        post.postLikes.size(),
+                        JPAExpressions
+                                .selectFrom(bookmark)
+                                .where(bookmark.post.eq(post).and(bookmark.member.id.eq(memberId)))
+                                .exists(),
+                        JPAExpressions
+                                .selectFrom(postLike)
+                                .where(postLike.post.eq(post).and(postLike.member.id.eq(memberId)))
+                                .exists(),
+                        JPAExpressions
+                                .select(postLike.member.username)
+                                .from(postLike)
+                                .where(postLike.post.eq(post)
+                                        .and(postLike.member
+                                                .in(JPAExpressions
+                                                        .select(follow.followMember)
+                                                        .from(follow)
+                                                        .where(follow.member.id.eq(memberId)))))
+                                .limit(1)
+                ))
+                .from(post)
+                .join(post.member, QMember.member)
+                .on(post.member.username.in(
+                        JPAExpressions
+                                .select(follow.followMember.username)
+                                .from(follow)
+                                .where(follow.member.id.eq(memberId))
+                ))
+                .limit(10)
+                .orderBy(post.id.desc())
+                .fetch();
+
+        final List<Long> postIds = postDTOs.stream()
+                .map(PostDTO::getPostId)
+                .collect(Collectors.toList());
+
+        final List<PostImageDTO> postImageDTOs = queryFactory
+                .select(new QPostImageDTO(
+                        postImage.post.id,
+                        postImage.id,
+                        postImage.image.imageUrl
+                ))
+                .from(postImage)
+                .where(postImage.post.id.in(postIds))
+                .fetch();
+
+        final List<Long> postImageIds = postImageDTOs.stream()
+                .map(PostImageDTO::getId)
+                .collect(Collectors.toList());
+
+        final List<PostTagDTO> postTagDTOs = queryFactory
+                .select(new QPostTagDTO(
+                        postTag.postImage.id,
+                        postTag.id,
+                        postTag.tag
+                ))
+                .from(postTag)
+                .where(postTag.postImage.id.in(postImageIds))
+                .fetch();
+
+        final Map<Long, List<PostTagDTO>> postImageDTOMap = postTagDTOs.stream()
+                .collect(Collectors.groupingBy(PostTagDTO::getPostImageId));
+        postImageDTOs.forEach(i -> i.setPostTagDTOs(postImageDTOMap.get(i.getId())));
+
+        final Map<Long, List<PostImageDTO>> postDTOMap = postImageDTOs.stream()
+                .collect(Collectors.groupingBy(PostImageDTO::getPostId));
+        postDTOs.forEach(p -> p.setPostImageDTOs(postDTOMap.get(p.getPostId())));
+
+        return postDTOs;
     }
 
 }

--- a/src/main/java/cloneproject/Instagram/service/PostService.java
+++ b/src/main/java/cloneproject/Instagram/service/PostService.java
@@ -112,7 +112,7 @@ public class PostService {
     }
 
     public Page<PostDTO> getPostDtoPage(int size, int page) {
-        page = (page == 0 ? 0 : page - 1);
+        page = (page == 0 ? 0 : page - 1) + 10;
         final Pageable pageable = PageRequest.of(page, size, Sort.by(DESC, "id"));
         final Long memberId = Long.parseLong(SecurityContextHolder.getContext().getAuthentication().getName());
         final Member member = memberRepository.findById(memberId).orElseThrow(MemberDoesNotExistException::new);
@@ -124,5 +124,10 @@ public class PostService {
         final Long memberId = Long.valueOf(SecurityContextHolder.getContext().getAuthentication().getName());
         final Post post = postRepository.findByIdAndMemberId(postId, memberId).orElseThrow(PostNotFoundException::new);
         postRepository.delete(post);
+    }
+
+    public List<PostDTO> getRecent10PostDTOs() {
+        final Long memberId = Long.valueOf(SecurityContextHolder.getContext().getAuthentication().getName());
+        return postRepository.findRecent10PostDTOs(memberId);
     }
 }

--- a/src/main/java/cloneproject/Instagram/service/PostService.java
+++ b/src/main/java/cloneproject/Instagram/service/PostService.java
@@ -3,6 +3,7 @@ package cloneproject.Instagram.service;
 import cloneproject.Instagram.dto.post.PostDTO;
 import cloneproject.Instagram.dto.post.PostImageTagDTO;
 import cloneproject.Instagram.dto.post.PostImageTagRequest;
+import cloneproject.Instagram.dto.post.PostResponse;
 import cloneproject.Instagram.entity.member.Member;
 import cloneproject.Instagram.entity.post.Post;
 import cloneproject.Instagram.entity.post.PostImage;
@@ -14,12 +15,9 @@ import cloneproject.Instagram.repository.PostRepository;
 import cloneproject.Instagram.repository.PostTagRepository;
 import cloneproject.Instagram.util.S3Uploader;
 import cloneproject.Instagram.vo.Image;
-import cloneproject.Instagram.vo.ImageType;
 import cloneproject.Instagram.vo.Tag;
-import com.google.common.base.Enums;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.io.FilenameUtils;
 import org.springframework.data.domain.*;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
@@ -30,7 +28,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.UUID;
 
 import static org.springframework.data.domain.Sort.Direction.DESC;
 
@@ -129,5 +126,10 @@ public class PostService {
     public List<PostDTO> getRecent10PostDTOs() {
         final Long memberId = Long.valueOf(SecurityContextHolder.getContext().getAuthentication().getName());
         return postRepository.findRecent10PostDTOs(memberId);
+    }
+
+    public PostResponse getPost(Long postId) {
+        final Long memberId = Long.valueOf(SecurityContextHolder.getContext().getAuthentication().getName());
+        return postRepository.findPostResponse(postId, memberId).orElseThrow(PostNotFoundException::new);
     }
 }


### PR DESCRIPTION
## 변경 사항
### 게시물 목록 조회 API 두 개로 분할
- 최근 게시물 10개 조회 API
- 게시물 페이징 조회
   - 무한스크롤 전용, 11번째 게시물부터 1개씩 조회
### 쿼리 최적화
- spring.jpa.properties.hibernate.default_batch_fetch_size: 100 적용
- in 쿼리 이용. 총 3번의 쿼리 발생
    - 게시물 조회 -> 각 id를 list로 추출
    - 게시물 이미지 조회 -> 위에서 얻은 list에 속하는(in) 엔티티 조회 -> 각 이미지 id를 list로 추출
    - 게시물 이미지 태그 조회 -> 위에서 얻은 list에 속하는(in) 엔티티 조회
    - 이후, 각각 id로 그룹핑하여 Map으로 변환한 후, setter로 각각 list에 담기
### 게시물 조회 API
- 게시물 정보 + 댓글 10개 응답
- 게시물 조회 + 이미지 조회 + 태그 조회 + 댓글 조회: 쿼리 4번 수행
> 댓글, 답글 페이징 조회 API 추가 필요

## 해결한 이슈
- Resolve #38 
- Resolve #49 
- Resolve #60 