### PR TITLE
게시물 좋아요/취소, 저장/취소 API 추가

### DIFF
--- a/src/main/java/cloneproject/Instagram/controller/PostController.java
+++ b/src/main/java/cloneproject/Instagram/controller/PostController.java
@@ -1,5 +1,6 @@
 package cloneproject.Instagram.controller;
 
+import cloneproject.Instagram.dto.StatusResponse;
 import cloneproject.Instagram.dto.post.*;
 import cloneproject.Instagram.dto.result.ResultResponse;
 import cloneproject.Instagram.service.PostService;
@@ -73,5 +74,49 @@ public class PostController {
         final PostResponse response = postService.getPost(postId);
 
         return ResponseEntity.ok(ResultResponse.of(FIND_POST_SUCCESS, response));
+    }
+
+    @ApiOperation(value = "게시물 좋아요")
+    @ApiImplicitParam(name = "postId", value = "게시물 PK", example = "1", required = true)
+    @PostMapping("/posts/like")
+    public ResponseEntity<ResultResponse> likePost(
+            @Validated @NotNull(message = "좋아요할 게시물 PK는 필수입니다.") @RequestParam Long postId) {
+        final boolean status = postService.likePost(postId);
+        final StatusResponse response = new StatusResponse(status);
+
+        return ResponseEntity.ok(ResultResponse.of(LIKE_POST_SUCCESS, response));
+    }
+
+    @ApiOperation(value = "게시물 좋아요 취소")
+    @ApiImplicitParam(name = "postId", value = "게시물 PK", example = "1", required = true)
+    @DeleteMapping("/posts/like")
+    public ResponseEntity<ResultResponse> unlikePost(
+            @Validated @NotNull(message = "좋아요 취소할 게시물 PK는 필수입니다.") @RequestParam Long postId){
+        final boolean status = postService.unlikePost(postId);
+        final StatusResponse response = new StatusResponse(status);
+
+        return ResponseEntity.ok(ResultResponse.of(UNLIKE_POST_SUCCESS, response));
+    }
+
+    @ApiOperation(value = "게시물 저장")
+    @ApiImplicitParam(name = "postId", value = "게시물 PK", example = "1", required = true)
+    @PostMapping("/posts/save")
+    public ResponseEntity<ResultResponse> savePost(
+            @Validated @NotNull(message = "저장할 게시물 PK는 필수입니다.") @RequestParam Long postId) {
+        final boolean status = postService.savePost(postId);
+        final StatusResponse response = new StatusResponse(status);
+
+        return ResponseEntity.ok(ResultResponse.of(SAVE_POST_SUCCESS, response));
+    }
+
+    @ApiOperation(value = "게시물 저장 취소")
+    @ApiImplicitParam(name = "postId", value = "게시물 PK", example = "1", required = true)
+    @DeleteMapping("/posts/save")
+    public ResponseEntity<ResultResponse> unsavePost(
+            @Validated @NotNull(message = "저장 취소할 게시물 PK는 필수입니다.") @RequestParam Long postId) {
+        final boolean status = postService.unsavePost(postId);
+        final StatusResponse response = new StatusResponse(status);
+
+        return ResponseEntity.ok(ResultResponse.of(UNSAVE_POST_SUCCESS, response));
     }
 }

--- a/src/main/java/cloneproject/Instagram/dto/StatusResponse.java
+++ b/src/main/java/cloneproject/Instagram/dto/StatusResponse.java
@@ -1,0 +1,13 @@
+package cloneproject.Instagram.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class StatusResponse {
+
+    private boolean status;
+}

--- a/src/main/java/cloneproject/Instagram/dto/error/ErrorCode.java
+++ b/src/main/java/cloneproject/Instagram/dto/error/ErrorCode.java
@@ -42,6 +42,10 @@ public enum ErrorCode {
     INVALID_TAG_POSITION(400, "P007", "태그 좌표는 0 ~ 100 사이로 입력해주세요."),
     INVALID_IMAGE_SEQUENCE(400, "P008", "이미지 순번이 유효하지 않습니다."),
     INVALID_POST_IMAGE(400, "P009", "게시물 이미지는 필수입니다."),
+    POST_LIKE_NOT_FOUND(400, "P010", "해당 게시물에 좋아요를 누르지 않은 회원입니다."),
+    POST_LIKE_ALREADY_EXIST(400, "P011", "해당 게시물에 이미 좋아요를 누른 회원입니다."),
+    BOOKMARK_ALREADY_EXIST(400, "P012", "이미 해당 게시물을 저장하였습니다."),
+    BOOKMARK_NOT_FOUND(400, "P013", "아직 해당 게시물을 저장하지 않았습니다."),
 
     // FILE
     CANT_CONVERT_FILE(401, "FI001", "파일을 변환할수 없습니다");

--- a/src/main/java/cloneproject/Instagram/dto/result/ResultCode.java
+++ b/src/main/java/cloneproject/Instagram/dto/result/ResultCode.java
@@ -38,6 +38,10 @@ public enum ResultCode {
     DELETE_POST_SUCCESS(200, "P005", "게시물 삭제 성공"),
     FIND_POST_SUCCESS(200, "P006", "게시물 조회 성공"),
     FIND_RECENT10POSTS_SUCCESS(200, "P007", "최근 게시물 10개 조회 성공"),
+    LIKE_POST_SUCCESS(200, "P008", "게시물 좋아요 성공"),
+    UNLIKE_POST_SUCCESS(200, "P009", "게시물 좋아요 취소 성공"),
+    SAVE_POST_SUCCESS(200, "P010", "게시물 저장 성공"),
+    UNSAVE_POST_SUCCESS(200, "P011", "게시물 저장 취소 성공"),
     ;
 
     private int status;

--- a/src/main/java/cloneproject/Instagram/exception/BookmarkAlreadyExistException.java
+++ b/src/main/java/cloneproject/Instagram/exception/BookmarkAlreadyExistException.java
@@ -1,0 +1,10 @@
+package cloneproject.Instagram.exception;
+
+import cloneproject.Instagram.dto.error.ErrorCode;
+
+public class BookmarkAlreadyExistException extends BusinessException {
+
+    public BookmarkAlreadyExistException() {
+        super(ErrorCode.BOOKMARK_ALREADY_EXIST);
+    }
+}

--- a/src/main/java/cloneproject/Instagram/exception/BookmarkNotFoundException.java
+++ b/src/main/java/cloneproject/Instagram/exception/BookmarkNotFoundException.java
@@ -1,0 +1,10 @@
+package cloneproject.Instagram.exception;
+
+import cloneproject.Instagram.dto.error.ErrorCode;
+
+public class BookmarkNotFoundException extends BusinessException {
+
+    public BookmarkNotFoundException() {
+        super(ErrorCode.BOOKMARK_NOT_FOUND);
+    }
+}

--- a/src/main/java/cloneproject/Instagram/exception/PostLikeAlreadyExistException.java
+++ b/src/main/java/cloneproject/Instagram/exception/PostLikeAlreadyExistException.java
@@ -1,0 +1,10 @@
+package cloneproject.Instagram.exception;
+
+import cloneproject.Instagram.dto.error.ErrorCode;
+
+public class PostLikeAlreadyExistException extends BusinessException {
+
+    public PostLikeAlreadyExistException() {
+        super(ErrorCode.POST_LIKE_ALREADY_EXIST);
+    }
+}

--- a/src/main/java/cloneproject/Instagram/exception/PostLikeNotFoundException.java
+++ b/src/main/java/cloneproject/Instagram/exception/PostLikeNotFoundException.java
@@ -1,0 +1,10 @@
+package cloneproject.Instagram.exception;
+
+import cloneproject.Instagram.dto.error.ErrorCode;
+
+public class PostLikeNotFoundException extends BusinessException {
+
+    public PostLikeNotFoundException() {
+        super(ErrorCode.POST_LIKE_NOT_FOUND);
+    }
+}

--- a/src/main/java/cloneproject/Instagram/repository/BookmarkRepository.java
+++ b/src/main/java/cloneproject/Instagram/repository/BookmarkRepository.java
@@ -1,0 +1,10 @@
+package cloneproject.Instagram.repository;
+
+import cloneproject.Instagram.entity.post.Bookmark;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
+    Optional<Bookmark> findByMemberIdAndPostId(Long memberId, Long postId);
+}

--- a/src/main/java/cloneproject/Instagram/repository/PostLikeRepository.java
+++ b/src/main/java/cloneproject/Instagram/repository/PostLikeRepository.java
@@ -1,0 +1,10 @@
+package cloneproject.Instagram.repository;
+
+import cloneproject.Instagram.entity.post.PostLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
+    Optional<PostLike> findByMemberIdAndPostId(Long memberId, Long postId);
+}

--- a/src/main/java/cloneproject/Instagram/repository/post/PostRepository.java
+++ b/src/main/java/cloneproject/Instagram/repository/post/PostRepository.java
@@ -1,4 +1,4 @@
-package cloneproject.Instagram.repository;
+package cloneproject.Instagram.repository.post;
 
 import cloneproject.Instagram.entity.post.Post;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/cloneproject/Instagram/repository/post/PostRepositoryJdbc.java
+++ b/src/main/java/cloneproject/Instagram/repository/post/PostRepositoryJdbc.java
@@ -1,4 +1,4 @@
-package cloneproject.Instagram.repository;
+package cloneproject.Instagram.repository.post;
 
 import cloneproject.Instagram.dto.post.PostImageTagRequest;
 import cloneproject.Instagram.vo.Image;

--- a/src/main/java/cloneproject/Instagram/repository/post/PostRepositoryJdbcImpl.java
+++ b/src/main/java/cloneproject/Instagram/repository/post/PostRepositoryJdbcImpl.java
@@ -1,4 +1,4 @@
-package cloneproject.Instagram.repository;
+package cloneproject.Instagram.repository.post;
 
 import cloneproject.Instagram.dto.post.PostImageTagRequest;
 import cloneproject.Instagram.vo.Image;

--- a/src/main/java/cloneproject/Instagram/repository/post/PostRepositoryQuerydsl.java
+++ b/src/main/java/cloneproject/Instagram/repository/post/PostRepositoryQuerydsl.java
@@ -1,4 +1,4 @@
-package cloneproject.Instagram.repository;
+package cloneproject.Instagram.repository.post;
 
 import cloneproject.Instagram.dto.post.PostDTO;
 import cloneproject.Instagram.dto.post.PostResponse;

--- a/src/main/java/cloneproject/Instagram/repository/post/PostRepositoryQuerydslImpl.java
+++ b/src/main/java/cloneproject/Instagram/repository/post/PostRepositoryQuerydslImpl.java
@@ -1,4 +1,4 @@
-package cloneproject.Instagram.repository;
+package cloneproject.Instagram.repository.post;
 
 import cloneproject.Instagram.dto.comment.CommentDTO;
 import cloneproject.Instagram.dto.comment.QCommentDTO;


### PR DESCRIPTION
## 변경 사항
- 게시물 좋아요, 좋아요 취소 API 추가
- 게시물 저장, 저장 취소 API 추가

### 테스트
- Swagger로 좋아요, 저장 API 호출 이후, 게시물 목록 조회 시 적용되는 결과를 확인함
- 마찬가지로 취소 API 호출 이후에도 적용되는 결과를 확인함

## 해결한 이슈
- Resolve #65 