### PR TITLE
게시물 조회 쿼리 오류 해결

### DIFF
--- a/src/main/java/cloneproject/Instagram/dto/post/PostDTO.java
+++ b/src/main/java/cloneproject/Instagram/dto/post/PostDTO.java
@@ -29,7 +29,7 @@ public class PostDTO {
     private String followingMemberUsernameLikedPost;
 
     @QueryProjection
-    public PostDTO(Long postId, String postContent, LocalDateTime postUploadDate, String memberUsername, String memberNickname, String memberImageUrl, int postCommentsCount, int postLikesCount, boolean postBookmarkFlag, boolean postLikeFlag, String followingMemberUsernameLikedPost) {
+    public PostDTO(Long postId, String postContent, LocalDateTime postUploadDate, String memberUsername, String memberNickname, String memberImageUrl, int postCommentsCount, int postLikesCount, boolean postBookmarkFlag, boolean postLikeFlag) {
         this.postId = postId;
         this.postContent = postContent;
         this.postUploadDate = postUploadDate;
@@ -40,6 +40,5 @@ public class PostDTO {
         this.postLikesCount = postLikesCount;
         this.postBookmarkFlag = postBookmarkFlag;
         this.postLikeFlag = postLikeFlag;
-        this.followingMemberUsernameLikedPost = followingMemberUsernameLikedPost;
     }
 }

--- a/src/main/java/cloneproject/Instagram/dto/post/PostLikeDTO.java
+++ b/src/main/java/cloneproject/Instagram/dto/post/PostLikeDTO.java
@@ -1,0 +1,22 @@
+package cloneproject.Instagram.dto.post;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostLikeDTO {
+
+    private Long postId;
+    private String username;
+
+    @QueryProjection
+    public PostLikeDTO(Long postId, String username) {
+        this.postId = postId;
+        this.username = username;
+    }
+}

--- a/src/main/java/cloneproject/Instagram/dto/post/PostResponse.java
+++ b/src/main/java/cloneproject/Instagram/dto/post/PostResponse.java
@@ -31,7 +31,7 @@ public class PostResponse {
     private List<CommentDTO> commentDTOs = new ArrayList<>();
 
     @QueryProjection
-    public PostResponse(Long postId, String postContent, LocalDateTime postUploadDate, String memberUsername, String memberNickname, String memberImageUrl, int postLikesCount, boolean postBookmarkFlag, boolean postLikeFlag, String followingMemberUsernameLikedPost) {
+    public PostResponse(Long postId, String postContent, LocalDateTime postUploadDate, String memberUsername, String memberNickname, String memberImageUrl, int postLikesCount, boolean postBookmarkFlag, boolean postLikeFlag) {
         this.postId = postId;
         this.postContent = postContent;
         this.postUploadDate = postUploadDate;
@@ -41,6 +41,5 @@ public class PostResponse {
         this.postLikesCount = postLikesCount;
         this.postBookmarkFlag = postBookmarkFlag;
         this.postLikeFlag = postLikeFlag;
-        this.followingMemberUsernameLikedPost = followingMemberUsernameLikedPost;
     }
 }

--- a/src/main/java/cloneproject/Instagram/repository/post/PostRepositoryQuerydslImpl.java
+++ b/src/main/java/cloneproject/Instagram/repository/post/PostRepositoryQuerydslImpl.java
@@ -56,17 +56,7 @@ public class PostRepositoryQuerydslImpl implements PostRepositoryQuerydsl {
                         JPAExpressions
                                 .selectFrom(postLike)
                                 .where(postLike.post.eq(post).and(postLike.member.eq(member)))
-                                .exists(),
-                        JPAExpressions
-                                .select(postLike.member.username)
-                                .from(postLike)
-                                .where(postLike.post.eq(post)
-                                        .and(postLike.member
-                                                .in(JPAExpressions
-                                                        .select(follow.followMember)
-                                                        .from(follow)
-                                                        .where(follow.member.eq(member)))))
-                                .limit(1)
+                                .exists()
                 ))
                 .from(post)
                 .join(QMember.member)
@@ -85,6 +75,23 @@ public class PostRepositoryQuerydslImpl implements PostRepositoryQuerydsl {
         final List<Long> postIds = postDTOs.stream()
                 .map(PostDTO::getPostId)
                 .collect(Collectors.toList());
+
+        final List<PostLikeDTO> postLikeDTOs = queryFactory
+                .select(new QPostLikeDTO(
+                        postLike.post.id,
+                        postLike.member.username
+                ))
+                .from(postLike)
+                .where(postLike.post.id.in(postIds)
+                        .and(postLike.member.in(
+                                JPAExpressions
+                                        .select(follow.followMember)
+                                        .from(follow)
+                                        .where(follow.member.eq(member))
+                        ))).fetch();
+        final Map<Long, List<PostLikeDTO>> postLikeDTOMap = postLikeDTOs.stream()
+                .collect(Collectors.groupingBy(PostLikeDTO::getPostId));
+        postDTOs.forEach(p -> p.setFollowingMemberUsernameLikedPost(postLikeDTOMap.containsKey(p.getPostId()) ? postLikeDTOMap.get(p.getPostId()).get(0).getUsername() : ""));
 
         final List<PostImageDTO> postImageDTOs = queryFactory
                 .select(new QPostImageDTO(
@@ -140,17 +147,7 @@ public class PostRepositoryQuerydslImpl implements PostRepositoryQuerydsl {
                         JPAExpressions
                                 .selectFrom(postLike)
                                 .where(postLike.post.eq(post).and(postLike.member.id.eq(memberId)))
-                                .exists(),
-                        JPAExpressions
-                                .select(postLike.member.username)
-                                .from(postLike)
-                                .where(postLike.post.eq(post)
-                                        .and(postLike.member
-                                                .in(JPAExpressions
-                                                        .select(follow.followMember)
-                                                        .from(follow)
-                                                        .where(follow.member.id.eq(memberId)))))
-                                .limit(1)
+                                .exists()
                 ))
                 .from(post)
                 .join(post.member, QMember.member)
@@ -167,6 +164,23 @@ public class PostRepositoryQuerydslImpl implements PostRepositoryQuerydsl {
         final List<Long> postIds = postDTOs.stream()
                 .map(PostDTO::getPostId)
                 .collect(Collectors.toList());
+
+        final List<PostLikeDTO> postLikeDTOs = queryFactory
+                .select(new QPostLikeDTO(
+                        postLike.post.id,
+                        postLike.member.username
+                ))
+                .from(postLike)
+                .where(postLike.post.id.in(postIds)
+                        .and(postLike.member.in(
+                                JPAExpressions
+                                        .select(follow.followMember)
+                                        .from(follow)
+                                        .where(follow.member.id.eq(memberId))
+                        ))).fetch();
+        final Map<Long, List<PostLikeDTO>> postLikeDTOMap = postLikeDTOs.stream()
+                .collect(Collectors.groupingBy(PostLikeDTO::getPostId));
+        postDTOs.forEach(p -> p.setFollowingMemberUsernameLikedPost(postLikeDTOMap.containsKey(p.getPostId()) ? postLikeDTOMap.get(p.getPostId()).get(0).getUsername() : ""));
 
         final List<PostImageDTO> postImageDTOs = queryFactory
                 .select(new QPostImageDTO(
@@ -221,17 +235,7 @@ public class PostRepositoryQuerydslImpl implements PostRepositoryQuerydsl {
                         JPAExpressions
                                 .selectFrom(postLike)
                                 .where(postLike.post.eq(post).and(postLike.member.id.eq(memberId)))
-                                .exists(),
-                        JPAExpressions
-                                .select(postLike.member.username)
-                                .from(postLike)
-                                .where(postLike.post.eq(post)
-                                        .and(postLike.member
-                                                .in(JPAExpressions
-                                                        .select(follow.followMember)
-                                                        .from(follow)
-                                                        .where(follow.member.id.eq(memberId)))))
-                                .limit(1)
+                                .exists()
                 ))
                 .from(post)
                 .where(post.id.eq(postId))
@@ -239,6 +243,21 @@ public class PostRepositoryQuerydslImpl implements PostRepositoryQuerydsl {
 
         if (response.isEmpty())
             return Optional.empty();
+
+        final List<PostLikeDTO> postLikeDTOs = queryFactory
+                .select(new QPostLikeDTO(
+                        postLike.post.id,
+                        postLike.member.username
+                ))
+                .from(postLike)
+                .where(postLike.post.id.eq(postId)
+                        .and(postLike.member.in(
+                                JPAExpressions
+                                        .select(follow.followMember)
+                                        .from(follow)
+                                        .where(follow.member.id.eq(memberId))
+                        ))).fetch();
+        response.get().setFollowingMemberUsernameLikedPost(postLikeDTOs.isEmpty() ? "" : postLikeDTOs.get(0).getUsername());
 
         final List<PostImageDTO> postImageDTOs = queryFactory
                 .select(new QPostImageDTO(

--- a/src/main/java/cloneproject/Instagram/repository/post/PostRepositoryQuerydslImpl.java
+++ b/src/main/java/cloneproject/Instagram/repository/post/PostRepositoryQuerydslImpl.java
@@ -82,13 +82,16 @@ public class PostRepositoryQuerydslImpl implements PostRepositoryQuerydsl {
                         postLike.member.username
                 ))
                 .from(postLike)
+                .innerJoin(postLike.member, QMember.member)
                 .where(postLike.post.id.in(postIds)
                         .and(postLike.member.in(
                                 JPAExpressions
                                         .select(follow.followMember)
                                         .from(follow)
-                                        .where(follow.member.eq(member))
-                        ))).fetch();
+                                        .innerJoin(follow.member, QMember.member)
+                                        .innerJoin(follow.followMember, QMember.member)
+                                        .where(follow.member.eq(member)))))
+                .fetch();
         final Map<Long, List<PostLikeDTO>> postLikeDTOMap = postLikeDTOs.stream()
                 .collect(Collectors.groupingBy(PostLikeDTO::getPostId));
         postDTOs.forEach(p -> p.setFollowingMemberUsernameLikedPost(postLikeDTOMap.containsKey(p.getPostId()) ? postLikeDTOMap.get(p.getPostId()).get(0).getUsername() : ""));
@@ -171,13 +174,16 @@ public class PostRepositoryQuerydslImpl implements PostRepositoryQuerydsl {
                         postLike.member.username
                 ))
                 .from(postLike)
+                .innerJoin(postLike.member, QMember.member)
                 .where(postLike.post.id.in(postIds)
                         .and(postLike.member.in(
                                 JPAExpressions
                                         .select(follow.followMember)
                                         .from(follow)
-                                        .where(follow.member.id.eq(memberId))
-                        ))).fetch();
+                                        .innerJoin(follow.member, QMember.member)
+                                        .innerJoin(follow.followMember, QMember.member)
+                                        .on(follow.member.id.eq(memberId)))))
+                .fetch();
         final Map<Long, List<PostLikeDTO>> postLikeDTOMap = postLikeDTOs.stream()
                 .collect(Collectors.groupingBy(PostLikeDTO::getPostId));
         postDTOs.forEach(p -> p.setFollowingMemberUsernameLikedPost(postLikeDTOMap.containsKey(p.getPostId()) ? postLikeDTOMap.get(p.getPostId()).get(0).getUsername() : ""));
@@ -250,13 +256,17 @@ public class PostRepositoryQuerydslImpl implements PostRepositoryQuerydsl {
                         postLike.member.username
                 ))
                 .from(postLike)
+                .innerJoin(postLike.member, QMember.member)
                 .where(postLike.post.id.eq(postId)
                         .and(postLike.member.in(
                                 JPAExpressions
                                         .select(follow.followMember)
                                         .from(follow)
+                                        .innerJoin(follow.member, QMember.member)
+                                        .innerJoin(follow.followMember, QMember.member)
                                         .where(follow.member.id.eq(memberId))
-                        ))).fetch();
+                        )))
+                .fetch();
         response.get().setFollowingMemberUsernameLikedPost(postLikeDTOs.isEmpty() ? "" : postLikeDTOs.get(0).getUsername());
 
         final List<PostImageDTO> postImageDTOs = queryFactory


### PR DESCRIPTION
### 변경 사항
- select절 서브 쿼리에 limit 적용 안되는 문제 발생
- 내가 팔로우한 사람 중 해당 게시물을 좋아요한 유저 한 명을 찾는 쿼리를 따로 분리함
    ![image](https://user-images.githubusercontent.com/68049320/150698609-3bde495f-3393-4262-b17e-8fab1bd01bf4.png)
- 결과적으로 아래 쿼리 1번 추가된 셈
    ![image](https://user-images.githubusercontent.com/68049320/150698578-7a42b841-9565-4b75-8c1b-dfaa848426cf.png)

### 해결한 이슈
- Resolve: #70 