### PR TITLE
알림 API 구현

### DIFF
--- a/src/main/java/cloneproject/Instagram/controller/AlarmController.java
+++ b/src/main/java/cloneproject/Instagram/controller/AlarmController.java
@@ -1,0 +1,35 @@
+package cloneproject.Instagram.controller;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import cloneproject.Instagram.dto.alarm.AlarmDTO;
+import cloneproject.Instagram.dto.result.ResultCode;
+import cloneproject.Instagram.dto.result.ResultResponse;
+import cloneproject.Instagram.service.AlarmService;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+
+@Api(tags = "알림 API")
+@RestController
+@RequiredArgsConstructor
+public class AlarmController {
+
+    private final AlarmService alarmService;
+
+    @ApiOperation(value = "알림 목록 조회")
+    @GetMapping(value = "/alarms")
+    public ResponseEntity<ResultResponse> getAlarms(){
+        List<AlarmDTO> alarms = alarmService.getAlarms();
+
+        ResultResponse result = ResultResponse.of(ResultCode.GET_ALARMS_SUCCESS, alarms);
+        return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
+    }
+
+    
+}

--- a/src/main/java/cloneproject/Instagram/dto/alarm/AlarmDTO.java
+++ b/src/main/java/cloneproject/Instagram/dto/alarm/AlarmDTO.java
@@ -1,0 +1,45 @@
+package cloneproject.Instagram.dto.alarm;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.querydsl.core.annotations.QueryProjection;
+
+import cloneproject.Instagram.util.DateUtil;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class AlarmDTO implements Comparable<AlarmDTO>{
+
+    @JsonIgnore
+    private Long id;
+    private String type;
+    private String alarmMessage;
+    private String agentUsername;
+    private String targetUsername;
+    private Map<String, Long> itemIds;
+    private String createdAt;
+
+    @Override
+    public int compareTo(AlarmDTO alarmDTO) {
+         return this.id.compareTo(alarmDTO.id); 
+    }
+
+    @QueryProjection
+    public AlarmDTO(Long id, AlarmType type, String agentUsername, String targetUsername, Long itemId, Date createdAt){
+        this.itemIds = new HashMap<>();
+
+        this.id = id;
+        this.type = type.toString();
+        this.alarmMessage = type.getAlarmMesasge();
+        this.agentUsername = agentUsername;
+        this.targetUsername = targetUsername;
+        this.itemIds.put(type.getFirstItemType(), itemId);
+        this.createdAt = DateUtil.convertDateToString(createdAt);
+    }
+
+}

--- a/src/main/java/cloneproject/Instagram/dto/alarm/AlarmType.java
+++ b/src/main/java/cloneproject/Instagram/dto/alarm/AlarmType.java
@@ -1,0 +1,19 @@
+package cloneproject.Instagram.dto.alarm;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum AlarmType {
+    
+    POST_LIKES_ALARM("agentUsername이 targetUsername의 postId인 포스트를 좋아합니다", "postId"),
+    POST_COMMENT_ALARM("agentUsername이 targetUsername의 postId인 포스트에 댓글을 남겼습니다.", "commentId"),
+    COMMENT_LIKES_ALARM("agentUsername이 targetUsername의 postId인 포스트에 댓글을 남겼습니다.", "commentId"),
+    MEMBER_FOLLOW_ALARM("agentUsername이 targetUsername(나)를 팔로우 합니다", "followId"),
+    MEMBER_TAGGED_ALARM("agentUsername이 postId인 포스트에서 targetUsername(나)를 태그했습니다", "postId");
+
+    private String alarmMesasge;
+    private String firstItemType;
+
+}

--- a/src/main/java/cloneproject/Instagram/dto/alarm/AlarmType.java
+++ b/src/main/java/cloneproject/Instagram/dto/alarm/AlarmType.java
@@ -8,8 +8,8 @@ import lombok.Getter;
 public enum AlarmType {
     
     POST_LIKES_ALARM("agentUsername이 targetUsername(나)의 postId인 포스트를 좋아합니다", "postId"),
-    POST_COMMENT_ALARM("agentUsername이 targetUsername(나)의 postId인 포스트에 댓글을 남겼습니다.", "commentId"),
-    COMMENT_LIKES_ALARM("agentUsername이 targetUsername(나)의 postId인 포스트에 댓글을 남겼습니다.", "commentId"),
+    POST_COMMENT_ALARM("agentUsername이 targetUsername(나)의 postId인 포스트에 댓글을 남겼습니다.", "postId"),
+    COMMENT_LIKES_ALARM("agentUsername이 targetUsername(나)의 postId인 포스트에 댓글을 남겼습니다.", "postId"),
     MEMBER_FOLLOW_ALARM("agentUsername이 targetUsername(나)를 팔로우 합니다", "followId"),
     MEMBER_TAGGED_ALARM("agentUsername이 postId인 포스트에서 targetUsername(나)를 태그했습니다", "postId");
 

--- a/src/main/java/cloneproject/Instagram/dto/alarm/AlarmType.java
+++ b/src/main/java/cloneproject/Instagram/dto/alarm/AlarmType.java
@@ -7,9 +7,9 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum AlarmType {
     
-    POST_LIKES_ALARM("agentUsername이 targetUsername의 postId인 포스트를 좋아합니다", "postId"),
-    POST_COMMENT_ALARM("agentUsername이 targetUsername의 postId인 포스트에 댓글을 남겼습니다.", "commentId"),
-    COMMENT_LIKES_ALARM("agentUsername이 targetUsername의 postId인 포스트에 댓글을 남겼습니다.", "commentId"),
+    POST_LIKES_ALARM("agentUsername이 targetUsername(나)의 postId인 포스트를 좋아합니다", "postId"),
+    POST_COMMENT_ALARM("agentUsername이 targetUsername(나)의 postId인 포스트에 댓글을 남겼습니다.", "commentId"),
+    COMMENT_LIKES_ALARM("agentUsername이 targetUsername(나)의 postId인 포스트에 댓글을 남겼습니다.", "commentId"),
     MEMBER_FOLLOW_ALARM("agentUsername이 targetUsername(나)를 팔로우 합니다", "followId"),
     MEMBER_TAGGED_ALARM("agentUsername이 postId인 포스트에서 targetUsername(나)를 태그했습니다", "postId");
 

--- a/src/main/java/cloneproject/Instagram/dto/result/ResultCode.java
+++ b/src/main/java/cloneproject/Instagram/dto/result/ResultCode.java
@@ -24,6 +24,9 @@ public enum ResultCode {
     SEND_CONFIRM_EMAIL_SUCCESS(200, "M014", "인증코드 이메일 전송 완료"),
     SEARCH_MEMBER_SUCCESS(200, "M015", "회원 검색 완료"),
     GET_MENU_MEMBER_SUCCESS(200, "M016", "상단 메뉴 프로필 조회 완료"),
+    
+    // Alarm
+    GET_ALARMS_SUCCESS(200, "A016", "알림 조회 완료"),
 
     //Follow
     FOLLOW_SUCCESS(200, "F001", "회원 팔로우 완료"),

--- a/src/main/java/cloneproject/Instagram/dto/result/ResultCode.java
+++ b/src/main/java/cloneproject/Instagram/dto/result/ResultCode.java
@@ -26,7 +26,7 @@ public enum ResultCode {
     GET_MENU_MEMBER_SUCCESS(200, "M016", "상단 메뉴 프로필 조회 완료"),
     
     // Alarm
-    GET_ALARMS_SUCCESS(200, "A016", "알림 조회 완료"),
+    GET_ALARMS_SUCCESS(200, "A001", "알림 조회 완료"),
 
     //Follow
     FOLLOW_SUCCESS(200, "F001", "회원 팔로우 완료"),

--- a/src/main/java/cloneproject/Instagram/entity/alarms/Alarm.java
+++ b/src/main/java/cloneproject/Instagram/entity/alarms/Alarm.java
@@ -1,0 +1,67 @@
+package cloneproject.Instagram.entity.alarms;
+
+import java.util.Date;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import cloneproject.Instagram.dto.alarm.AlarmType;
+import cloneproject.Instagram.entity.member.Member;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "alarms")
+public class Alarm {
+    
+    @Id
+    @Column(name = "alarm_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @Column(name = "alarm_type")
+    @Enumerated(EnumType.STRING)
+    private AlarmType type;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "alarm_agent_id")
+    private Member agent;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "alarm_target_id")
+    private Member target;
+
+    @Column(name = "alarm_item_id")
+    private Long itemId;
+
+    @CreatedDate
+    @Column(name = "alarm_created_at")
+    private Date createdAt;
+    
+    @Builder
+    public Alarm(AlarmType type, Member agent, Member target, Long itemId){
+        this.type = type;
+        this.agent = agent;
+        this.target = target;
+        this.itemId = itemId;
+    }
+
+}

--- a/src/main/java/cloneproject/Instagram/repository/AlarmRepository.java
+++ b/src/main/java/cloneproject/Instagram/repository/AlarmRepository.java
@@ -1,0 +1,11 @@
+package cloneproject.Instagram.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import cloneproject.Instagram.entity.alarms.Alarm;
+
+public interface AlarmRepository extends JpaRepository<Alarm, Long>, AlarmRepositoryQuerydsl{
+    
+    void deleteAllByTargetId(Long targetId);
+
+}

--- a/src/main/java/cloneproject/Instagram/repository/AlarmRepositoryQuerydsl.java
+++ b/src/main/java/cloneproject/Instagram/repository/AlarmRepositoryQuerydsl.java
@@ -1,0 +1,11 @@
+package cloneproject.Instagram.repository;
+
+import java.util.List;
+
+import cloneproject.Instagram.dto.alarm.AlarmDTO;
+
+public interface AlarmRepositoryQuerydsl {
+    
+    public List<AlarmDTO> getAlarms(Long loginedMemberId);
+
+}

--- a/src/main/java/cloneproject/Instagram/repository/AlarmRepositoryQuerydslImpl.java
+++ b/src/main/java/cloneproject/Instagram/repository/AlarmRepositoryQuerydslImpl.java
@@ -1,18 +1,11 @@
 package cloneproject.Instagram.repository;
 
 import java.util.List;
-import java.util.Map;
-
-import com.querydsl.core.group.GroupBy;
-import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import cloneproject.Instagram.dto.alarm.AlarmDTO;
-import cloneproject.Instagram.dto.alarm.AlarmType;
 import cloneproject.Instagram.dto.alarm.QAlarmDTO;
 import lombok.RequiredArgsConstructor;
-
-import static cloneproject.Instagram.entity.comment.QComment.comment;
 import static cloneproject.Instagram.entity.alarms.QAlarm.alarm;
 
 @RequiredArgsConstructor
@@ -23,28 +16,30 @@ public class AlarmRepositoryQuerydslImpl implements AlarmRepositoryQuerydsl{
     @Override
     public List<AlarmDTO> getAlarms(Long loginedMemberId){
 
-        Map<Long, AlarmDTO> resultAboutComment = queryFactory
-                                    .from(alarm)
-                                    .where(alarm.target.id.eq(loginedMemberId).and(alarm.type.eq(AlarmType.POST_COMMENT_ALARM)))
-                                    .transform(GroupBy.groupBy(alarm.id).as(new QAlarmDTO(
-                                        alarm.id,
-                                        alarm.type, 
-                                        alarm.agent.username, 
-                                        alarm.target.username, 
-                                        alarm.itemId, 
-                                        alarm.createdAt)));
 
-        Map<Long, Long> postIds = queryFactory
-                                    .from(alarm)
-                                    .where(alarm.target.id.eq(loginedMemberId).and(alarm.type.eq(AlarmType.POST_COMMENT_ALARM)))
-                                    .transform(GroupBy.groupBy(alarm.id).as(
-                                        JPAExpressions
-                                            .select(comment.post.id)
-                                            .from(comment)
-                                            .where(comment.id.eq(alarm.itemId))        
-                                    ));
+        // * 주석 처리한 부분은 로직이 복잡해 보류됨 참고 : Issue #76
+        // Map<Long, AlarmDTO> resultAboutComment = queryFactory
+        //                             .from(alarm)
+        //                             .where(alarm.target.id.eq(loginedMemberId).and(alarm.type.eq(AlarmType.POST_COMMENT_ALARM)))
+        //                             .transform(GroupBy.groupBy(alarm.id).as(new QAlarmDTO(
+        //                                 alarm.id,
+        //                                 alarm.type, 
+        //                                 alarm.agent.username, 
+        //                                 alarm.target.username, 
+        //                                 alarm.itemId, 
+        //                                 alarm.createdAt)));
+
+        // Map<Long, Long> postIds = queryFactory
+        //                             .from(alarm)
+        //                             .where(alarm.target.id.eq(loginedMemberId).and(alarm.type.eq(AlarmType.POST_COMMENT_ALARM)))
+        //                             .transform(GroupBy.groupBy(alarm.id).as(
+        //                                 JPAExpressions
+        //                                     .select(comment.post.id)
+        //                                     .from(comment)
+        //                                     .where(comment.id.eq(alarm.itemId))        
+        //                             ));
         
-        resultAboutComment.forEach((key, alarm)->alarm.getItemIds().put("postId", postIds.get(key)));
+        // resultAboutComment.forEach((key, alarm)->alarm.getItemIds().put("postId", postIds.get(key)));
 
         List<AlarmDTO> result = queryFactory
                                     .select(new QAlarmDTO(
@@ -56,10 +51,11 @@ public class AlarmRepositoryQuerydslImpl implements AlarmRepositoryQuerydsl{
                                         alarm.createdAt))
 
                                     .from(alarm)
-                                    .where(alarm.target.id.eq(loginedMemberId).and(alarm.type.ne(AlarmType.POST_COMMENT_ALARM)))
+                                    .where(alarm.target.id.eq(loginedMemberId))
+                                    // .where(alarm.target.id.eq(loginedMemberId).and(alarm.type.ne(AlarmType.POST_COMMENT_ALARM)))
                                     .fetch();
 
-        result.addAll(resultAboutComment.values()); // ? 최적화 방법 떠오르지않음
+        // result.addAll(resultAboutComment.values());
         return result;
     }
 

--- a/src/main/java/cloneproject/Instagram/repository/AlarmRepositoryQuerydslImpl.java
+++ b/src/main/java/cloneproject/Instagram/repository/AlarmRepositoryQuerydslImpl.java
@@ -1,0 +1,66 @@
+package cloneproject.Instagram.repository;
+
+import java.util.List;
+import java.util.Map;
+
+import com.querydsl.core.group.GroupBy;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import cloneproject.Instagram.dto.alarm.AlarmDTO;
+import cloneproject.Instagram.dto.alarm.AlarmType;
+import cloneproject.Instagram.dto.alarm.QAlarmDTO;
+import lombok.RequiredArgsConstructor;
+
+import static cloneproject.Instagram.entity.comment.QComment.comment;
+import static cloneproject.Instagram.entity.alarms.QAlarm.alarm;
+
+@RequiredArgsConstructor
+public class AlarmRepositoryQuerydslImpl implements AlarmRepositoryQuerydsl{
+    
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<AlarmDTO> getAlarms(Long loginedMemberId){
+
+        Map<Long, AlarmDTO> resultAboutComment = queryFactory
+                                    .from(alarm)
+                                    .where(alarm.target.id.eq(loginedMemberId).and(alarm.type.eq(AlarmType.POST_COMMENT_ALARM)))
+                                    .transform(GroupBy.groupBy(alarm.id).as(new QAlarmDTO(
+                                        alarm.id,
+                                        alarm.type, 
+                                        alarm.agent.username, 
+                                        alarm.target.username, 
+                                        alarm.itemId, 
+                                        alarm.createdAt)));
+
+        Map<Long, Long> postIds = queryFactory
+                                    .from(alarm)
+                                    .where(alarm.target.id.eq(loginedMemberId).and(alarm.type.eq(AlarmType.POST_COMMENT_ALARM)))
+                                    .transform(GroupBy.groupBy(alarm.id).as(
+                                        JPAExpressions
+                                            .select(comment.post.id)
+                                            .from(comment)
+                                            .where(comment.id.eq(alarm.itemId))        
+                                    ));
+        
+        resultAboutComment.forEach((key, alarm)->alarm.getItemIds().put("postId", postIds.get(key)));
+
+        List<AlarmDTO> result = queryFactory
+                                    .select(new QAlarmDTO(
+                                        alarm.id,
+                                        alarm.type, 
+                                        alarm.agent.username, 
+                                        alarm.target.username, 
+                                        alarm.itemId, 
+                                        alarm.createdAt))
+
+                                    .from(alarm)
+                                    .where(alarm.target.id.eq(loginedMemberId).and(alarm.type.ne(AlarmType.POST_COMMENT_ALARM)))
+                                    .fetch();
+
+        result.addAll(resultAboutComment.values()); // ? 최적화 방법 떠오르지않음
+        return result;
+    }
+
+}

--- a/src/main/java/cloneproject/Instagram/repository/MemberRepositoryQuerydsl.java
+++ b/src/main/java/cloneproject/Instagram/repository/MemberRepositoryQuerydsl.java
@@ -10,12 +10,14 @@ import cloneproject.Instagram.dto.member.MiniProfileResponse;
 import cloneproject.Instagram.dto.member.SearchedMemberDTO;
 import cloneproject.Instagram.dto.member.UserProfileResponse;
 import cloneproject.Instagram.dto.post.MemberPostDTO;
+import cloneproject.Instagram.entity.member.Member;
 
 public interface MemberRepositoryQuerydsl {
     
     UserProfileResponse getUserProfile(Long loginedUserId, String username);
     MiniProfileResponse getMiniProfile(Long loginedUserId, String username);
     List<SearchedMemberDTO> searchMember(Long loginedUserId, String text);
+    List<Member> findAllByUsernames(List<String> usernames);
     List<MemberPostDTO> getRecent15PostDTOs(Long loginedUserId, String username);
     Page<MemberPostDTO> getMemberPostDto(Long loginedUserId, String username, Pageable pageable);
 

--- a/src/main/java/cloneproject/Instagram/repository/MemberRepositoryQuerydslImpl.java
+++ b/src/main/java/cloneproject/Instagram/repository/MemberRepositoryQuerydslImpl.java
@@ -19,6 +19,7 @@ import cloneproject.Instagram.dto.post.MemberPostDTO;
 import cloneproject.Instagram.dto.post.PostImageDTO;
 import cloneproject.Instagram.dto.post.QMemberPostDTO;
 import cloneproject.Instagram.dto.post.QPostImageDTO;
+import cloneproject.Instagram.entity.member.Member;
 import lombok.RequiredArgsConstructor;
 
 import static cloneproject.Instagram.entity.member.QFollow.follow;
@@ -212,6 +213,15 @@ public class MemberRepositoryQuerydslImpl implements MemberRepositoryQuerydsl{
                                             .collect(Collectors.groupingBy(FollowDTO::getFollowMemberUsername));
         result.forEach(r -> r.setFollowingMemberFollow(followsMap.get(r.getUsername())));
 
+        return result;
+    }
+
+    @Override
+    public List<Member> findAllByUsernames(List<String> usernames){
+        List<Member> result = queryFactory
+                                .selectFrom(member)
+                                .where(member.username.in(usernames))
+                                .fetch();
         return result;
     }
 

--- a/src/main/java/cloneproject/Instagram/service/AlarmService.java
+++ b/src/main/java/cloneproject/Instagram/service/AlarmService.java
@@ -1,0 +1,49 @@
+package cloneproject.Instagram.service;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import cloneproject.Instagram.dto.alarm.AlarmDTO;
+import cloneproject.Instagram.dto.alarm.AlarmType;
+import cloneproject.Instagram.entity.alarms.Alarm;
+import cloneproject.Instagram.entity.member.Member;
+import cloneproject.Instagram.exception.MemberDoesNotExistException;
+import cloneproject.Instagram.repository.AlarmRepository;
+import cloneproject.Instagram.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AlarmService {
+    
+    private final AlarmRepository alarmRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public List<AlarmDTO> getAlarms(){
+        final String memberId = SecurityContextHolder.getContext().getAuthentication().getName();
+        List<AlarmDTO> result = alarmRepository.getAlarms(Long.valueOf(memberId));
+        // alarmRepository.deleteAllByTargetId(Long.valueOf(memberId));
+        Collections.sort(result);
+        return result;
+    }
+
+    @Transactional
+    public void alert(AlarmType type, Member target, Long itemId){
+        final String memberId = SecurityContextHolder.getContext().getAuthentication().getName();
+        Member agent = memberRepository.findById(Long.valueOf(memberId))
+                        .orElseThrow(MemberDoesNotExistException::new);
+        Alarm alarm = Alarm.builder()
+                            .type(type)
+                            .agent(agent)
+                            .target(target)
+                            .itemId(itemId)
+                            .build();
+        alarmRepository.save(alarm);
+    }
+
+}

--- a/src/main/java/cloneproject/Instagram/service/AlarmService.java
+++ b/src/main/java/cloneproject/Instagram/service/AlarmService.java
@@ -29,6 +29,7 @@ public class AlarmService {
         List<AlarmDTO> result = alarmRepository.getAlarms(Long.valueOf(memberId));
         // alarmRepository.deleteAllByTargetId(Long.valueOf(memberId));
         Collections.sort(result);
+        Collections.reverse(result);
         return result;
     }
 

--- a/src/main/java/cloneproject/Instagram/service/FollowService.java
+++ b/src/main/java/cloneproject/Instagram/service/FollowService.java
@@ -7,6 +7,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import cloneproject.Instagram.dto.alarm.AlarmType;
 import cloneproject.Instagram.dto.member.FollowerDTO;
 import cloneproject.Instagram.entity.member.Block;
 import cloneproject.Instagram.entity.member.Follow;
@@ -31,6 +32,7 @@ public class FollowService {
     private final FollowRepository followRepository;
     private final MemberRepository memberRepository;
     private final BlockRepository blockRepository;
+    private final AlarmService alarmService;
 
     @Transactional
     public boolean follow(String followMemberUsername){
@@ -60,6 +62,9 @@ public class FollowService {
 
         Follow follow = new Follow(member, followMember);
         followRepository.save(follow);
+
+        alarmService.alert(AlarmType.MEMBER_FOLLOW_ALARM, followMember, follow.getId());
+
         return true;
         
     }

--- a/src/main/java/cloneproject/Instagram/service/PostService.java
+++ b/src/main/java/cloneproject/Instagram/service/PostService.java
@@ -105,12 +105,13 @@ public class PostService {
             if (idx != postImageTag.getId())
                 idx = postImageTag.getId().intValue();
             postImageTag.setId(postImageIds.get(idx - 1));
-        
-            Member taggedMember = memberRepository.findByUsername(postImageTag.getUsername())
-                                        .orElseThrow(MemberDoesNotExistException::new);
-            alarmService.alert(AlarmType.MEMBER_TAGGED_ALARM, taggedMember, post.getId());
         }
 
+        List<String> taggedMemberUsernames = postImageTags.stream().map(PostImageTagRequest::getUsername).collect(Collectors.toList());
+        List<Member> taggedMembers = memberRepository.findAllByUsernames(taggedMemberUsernames);
+        for(Member taggedMember: taggedMembers){
+            alarmService.alert(AlarmType.MEMBER_TAGGED_ALARM, taggedMember, post.getId());
+        }
         postRepository.savePostTags(postImageTags);
 
         return post.getId();

--- a/src/main/java/cloneproject/Instagram/service/PostService.java
+++ b/src/main/java/cloneproject/Instagram/service/PostService.java
@@ -1,5 +1,6 @@
 package cloneproject.Instagram.service;
 
+import cloneproject.Instagram.dto.alarm.AlarmType;
 import cloneproject.Instagram.dto.error.ErrorResponse.FieldError;
 import cloneproject.Instagram.dto.post.PostDTO;
 import cloneproject.Instagram.dto.post.PostImageTagRequest;
@@ -43,6 +44,7 @@ public class PostService {
     private final BookmarkRepository bookmarkRepository;
     private final MemberRepository memberRepository;
     private final S3Uploader uploader;
+    private final AlarmService alarmService;
 
     public Page<PostDTO> getPostDtoPage(int size, int page) {
         page = (page == 0 ? 0 : page - 1) + 10;
@@ -103,6 +105,10 @@ public class PostService {
             if (idx != postImageTag.getId())
                 idx = postImageTag.getId().intValue();
             postImageTag.setId(postImageIds.get(idx - 1));
+        
+            Member taggedMember = memberRepository.findByUsername(postImageTag.getUsername())
+                                        .orElseThrow(MemberDoesNotExistException::new);
+            alarmService.alert(AlarmType.MEMBER_TAGGED_ALARM, taggedMember, post.getId());
         }
 
         postRepository.savePostTags(postImageTags);
@@ -142,6 +148,7 @@ public class PostService {
         if (postLikeRepository.findByMemberIdAndPostId(memberId, postId).isPresent())
             throw new PostLikeAlreadyExistException();
         postLikeRepository.save(new PostLike(member, post));
+        alarmService.alert(AlarmType.POST_LIKES_ALARM, post.getMember(), post.getId());
         return true;
     }
 

--- a/src/main/java/cloneproject/Instagram/util/S3Uploader.java
+++ b/src/main/java/cloneproject/Instagram/util/S3Uploader.java
@@ -61,7 +61,6 @@ public class S3Uploader {
     private String upload(File uploadFile, String dirName, String UUID, String name, String type) {
         String fileName = dirName + "/" + UUID + "_" + name + "." + type;
         String uploadImageUrl = putS3(uploadFile, fileName);
-        log.info(uploadImageUrl);
         removeNewFile(uploadFile);
         return uploadImageUrl;
     }
@@ -77,7 +76,6 @@ public class S3Uploader {
 
     private void removeNewFile(File targetFile) {
         if (targetFile.delete()) {
-            log.info("File delete success");
             return;
         }
         log.info("File delete fail");
@@ -86,7 +84,6 @@ public class S3Uploader {
     // 로컬에 파일 업로드 하기
     private Optional<File> convert(MultipartFile file) throws IOException {
         File convertFile = new File(System.getProperty("user.dir") + "\\upload\\" + file.getOriginalFilename());
-        log.info(convertFile.getAbsolutePath());
         if (convertFile.createNewFile()) { // 바로 위에서 지정한 경로에 File이 생성됨 (경로가 잘못되었다면 생성 불가능)
             try (FileOutputStream fos = new FileOutputStream(convertFile)) { // FileOutputStream 데이터를 파일에 바이트 스트림으로 저장하기 위함
                 fos.write(file.getBytes());


### PR DESCRIPTION
## 알림 API 구현

### 알림 불러오기 API
- 아래와 같은 형식으로 반환됨.
```
{
  "status": 200,
  "code": "A001",
  "message": "알림 조회 완료",
  "data": [
    {
      "type": "MEMBER_TAGGED_ALARM",
      "alarmMessage": "agentUsername이 postId인 포스트에서 targetUsername(나)를 태그했습니다",
      "agentUsername": "dlwlrma2",
      "targetUsername": "dlwlrma",
      "itemIds": {
        "postId": 18
      },
      "createdAt": "2022-01-27 02:07"
    },
    {
      "type": "MEMBER_FOLLOW_ALARM",
      "alarmMessage": "agentUsername이 targetUsername(나)를 팔로우 합니다",
      "agentUsername": "dlwlrma2",
      "targetUsername": "dlwlrma",
      "itemIds": {
        "followId": 20
      },
      "createdAt": "2022-01-27 01:38"
    },
    {
      "type": "POST_LIKES_ALARM",
      "alarmMessage": "agentUsername이 targetUsername(나)의 postId인 포스트를 좋아합니다",
      "agentUsername": "dlwlrma2",
      "targetUsername": "dlwlrma",
      "itemIds": {
        "postId": 5
      },
      "createdAt": "2022-01-27 01:38"
    },
    {
      "type": "MEMBER_TAGGED_ALARM",
      "alarmMessage": "agentUsername이 postId인 포스트에서 targetUsername(나)를 태그했습니다",
      "agentUsername": "dlwlrma2",
      "targetUsername": "dlwlrma",
      "itemIds": {
        "postId": 14
      },
      "createdAt": "2022-01-27 01:37"
    }
  ]
}
```
- 최신 순으로 정렬되어 반환
- `alarmMessage`를 통해 프론트에서 작업할 때 이해하기 쉽도록 함
- `itemIds`는 알림과 관련된 Entity의 PK의 목록을 반환함
- 여러 엔티티와 연관된(ex 댓글 알림인 경우 댓글 PK와 게시물 PK를 모두 반환해야함) 알림을 처리하기 위해 배열로 구현
=> 현재 댓글 API가 없어서 테스트는 못해봄
- 불러오기 쿼리의 최적화가 필요해보이나 마땅한 방법을 찾지못함
### 알림 발생 추가
- 팔로우, 게시물 좋아요, 게시물 태그됨 알림 추가
- 댓글도 알림발생은 구현해놓았으나 댓글 API가 없어 테스트해보지 못함
  => 추후에 테스트 필요
### S3Uploader 내 불필요한 로그 삭제
- S3Uploader 구현 시 테스트를 위해 사용했던 로그가 남아있어 삭제
- 파일삭제 오류 발생 시의 로그는 그대로 남겨둠