### PR TITLE
DM 관련 엔티티, 채팅방 생성, 조회, 삭제 API 추가

### DIFF
--- a/src/main/java/cloneproject/Instagram/controller/ChatController.java
+++ b/src/main/java/cloneproject/Instagram/controller/ChatController.java
@@ -1,0 +1,65 @@
+package cloneproject.Instagram.controller;
+
+import cloneproject.Instagram.dto.chat.ChatRoomCreateResponse;
+import cloneproject.Instagram.dto.chat.JoinRoomDTO;
+import cloneproject.Instagram.dto.chat.ChatRoomInquireResponse;
+import cloneproject.Instagram.dto.chat.JoinRoomDeleteResponse;
+import cloneproject.Instagram.dto.result.ResultResponse;
+import cloneproject.Instagram.service.ChatService;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+import static cloneproject.Instagram.dto.result.ResultCode.*;
+
+@Api(tags = "채팅 API")
+@RestController
+@RequiredArgsConstructor
+public class ChatController {
+
+    private final ChatService chatService;
+
+    @ApiOperation(value = "채팅방 생성")
+    @ApiImplicitParam(name = "username", value = "상대방 username", example = "dlwlrma1", required = true)
+    @PostMapping("/chat/rooms")
+    public ResponseEntity<ResultResponse> createChatRoom(
+            @Validated @NotBlank(message = "상대방 username은 필수입니다.") @RequestParam String username) {
+        final ChatRoomCreateResponse response = chatService.createRoom(username);
+
+        return ResponseEntity.ok(ResultResponse.of(CREATE_CHAT_ROOM_SUCCESS, response));
+    }
+
+    @ApiOperation(value = "채팅방 조회")
+    @DeleteMapping("/chat/rooms/{roomId}")
+    public ResponseEntity<ResultResponse> inquireChatRoom(@PathVariable Long roomId) {
+        final ChatRoomInquireResponse response = chatService.inquireRoom(roomId);
+
+        return ResponseEntity.ok(ResultResponse.of(INQUIRE_CHAT_ROOM_SUCCESS, response));
+    }
+
+    @ApiOperation(value = "채팅방 삭제")
+    @DeleteMapping("/chat/rooms/hide")
+    public ResponseEntity<ResultResponse> hideChatRoom(
+            @Validated @NotNull(message = "채팅방 PK는 필수입니다.") @RequestParam Long roomId) {
+        final JoinRoomDeleteResponse response = chatService.deleteJoinRoom(roomId);
+
+        return ResponseEntity.ok(ResultResponse.of(DELETE_JOIN_ROOM_SUCCESS, response));
+    }
+
+    /*@ApiOperation(value = "채팅방 목록 페이징 조회", notes = "1페이지당 10개씩 조회할 수 있습니다.")
+    @GetMapping("/chat/rooms")
+    public ResponseEntity<ResultResponse> getJoinRooms(
+            @Validated @NotNull(message = "페이지는 필수입니다.") @RequestParam Integer page) {
+        final Page<JoinRoomDTO> response = chatService.getJoinRooms(page);
+
+        return ResponseEntity.ok(ResultResponse.of(GET_JOIN_ROOMS_SUCCESS, response));
+    }*/
+}

--- a/src/main/java/cloneproject/Instagram/dto/chat/ChatRoomCreateResponse.java
+++ b/src/main/java/cloneproject/Instagram/dto/chat/ChatRoomCreateResponse.java
@@ -1,0 +1,19 @@
+package cloneproject.Instagram.dto.chat;
+
+import cloneproject.Instagram.entity.member.Member;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ChatRoomCreateResponse {
+
+    private boolean status;
+    private Long chatRoomId;
+    private List<Opponent> opponents = new ArrayList<>();
+}

--- a/src/main/java/cloneproject/Instagram/dto/chat/ChatRoomInquireResponse.java
+++ b/src/main/java/cloneproject/Instagram/dto/chat/ChatRoomInquireResponse.java
@@ -1,0 +1,14 @@
+package cloneproject.Instagram.dto.chat;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ChatRoomInquireResponse {
+
+    private boolean status;
+    private Long unseenCount;
+}

--- a/src/main/java/cloneproject/Instagram/dto/chat/JoinRoomDTO.java
+++ b/src/main/java/cloneproject/Instagram/dto/chat/JoinRoomDTO.java
@@ -1,0 +1,19 @@
+package cloneproject.Instagram.dto.chat;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class JoinRoomDTO {
+
+    private Long chatRoomId;
+    private MessageDTO lastMessage;
+    private Long unseenCount;
+    private List<Opponent> opponents = new ArrayList<>();
+}

--- a/src/main/java/cloneproject/Instagram/dto/chat/JoinRoomDeleteResponse.java
+++ b/src/main/java/cloneproject/Instagram/dto/chat/JoinRoomDeleteResponse.java
@@ -1,0 +1,13 @@
+package cloneproject.Instagram.dto.chat;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class JoinRoomDeleteResponse {
+
+    private boolean status;
+}

--- a/src/main/java/cloneproject/Instagram/dto/chat/MessageDTO.java
+++ b/src/main/java/cloneproject/Instagram/dto/chat/MessageDTO.java
@@ -1,0 +1,23 @@
+package cloneproject.Instagram.dto.chat;
+
+import cloneproject.Instagram.entity.chat.Message;
+import cloneproject.Instagram.entity.chat.MessageType;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MessageDTO {
+
+    private Long messageId;
+    private MessageType messageType;
+    private String content;
+    private Long userId;
+
+    public MessageDTO(Message message) {
+        this.messageId = message.getId();
+        this.messageType = message.getType();
+        this.content = message.getContent();
+        this.userId = message.getMember().getId();
+    }
+}

--- a/src/main/java/cloneproject/Instagram/dto/chat/Opponent.java
+++ b/src/main/java/cloneproject/Instagram/dto/chat/Opponent.java
@@ -1,0 +1,20 @@
+package cloneproject.Instagram.dto.chat;
+
+import cloneproject.Instagram.entity.member.Member;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class Opponent {
+
+    private String username;
+    private String name;
+    private String imageUrl;
+
+    public Opponent(Member member) {
+        this.username = member.getUsername();
+        this.name = member.getName();
+        this.imageUrl = member.getImage().getImageUrl();
+    }
+}

--- a/src/main/java/cloneproject/Instagram/dto/error/ErrorCode.java
+++ b/src/main/java/cloneproject/Instagram/dto/error/ErrorCode.java
@@ -53,6 +53,10 @@ public enum ErrorCode {
     BOOKMARK_ALREADY_EXIST(400, "P012", "이미 해당 게시물을 저장하였습니다."),
     BOOKMARK_NOT_FOUND(400, "P013", "아직 해당 게시물을 저장하지 않았습니다."),
 
+    // Chat
+    CHAT_ROOM_NOT_FOUND(400, "C001", "존재하지 않는 채팅방입니다."),
+    JOIN_ROOM_NOT_FOUND(400, "C002", "해당 채팅방에 참여하지 않은 회원입니다."),
+
     // FILE
     CANT_CONVERT_FILE(401, "FI001", "파일을 변환할수 없습니다");
     ;

--- a/src/main/java/cloneproject/Instagram/dto/result/ResultCode.java
+++ b/src/main/java/cloneproject/Instagram/dto/result/ResultCode.java
@@ -52,6 +52,12 @@ public enum ResultCode {
     UNLIKE_POST_SUCCESS(200, "P009", "게시물 좋아요 취소 성공"),
     SAVE_POST_SUCCESS(200, "P010", "게시물 저장 성공"),
     UNSAVE_POST_SUCCESS(200, "P011", "게시물 저장 취소 성공"),
+
+    // CHAT
+    CREATE_CHAT_ROOM_SUCCESS(200, "C001", "채팅방 생성 성공"),
+    INQUIRE_CHAT_ROOM_SUCCESS(200, "C002", "채팅방 조회 성공"),
+    DELETE_JOIN_ROOM_SUCCESS(200, "C003", "참여 중인 채팅방 삭제 성공"),
+    GET_JOIN_ROOMS_SUCCESS(200, "C004", "채팅방 목록 조회 성공"),
     ;
 
     private int status;

--- a/src/main/java/cloneproject/Instagram/entity/chat/JoinRoom.java
+++ b/src/main/java/cloneproject/Instagram/entity/chat/JoinRoom.java
@@ -1,0 +1,43 @@
+package cloneproject.Instagram.entity.chat;
+
+import cloneproject.Instagram.entity.member.Member;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "join_rooms")
+public class JoinRoom {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "join_room_id")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id")
+    private Room room;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Column(name = "join_flag")
+    private boolean isJoin;
+
+    @Column(name = "read_flag")
+    private boolean isRead;
+
+    @Builder
+    public JoinRoom(Room room, Member member) {
+        this.room = room;
+        this.member = member;
+        this.isJoin = true;
+        this.isRead = true;
+    }
+}

--- a/src/main/java/cloneproject/Instagram/entity/chat/Message.java
+++ b/src/main/java/cloneproject/Instagram/entity/chat/Message.java
@@ -1,0 +1,52 @@
+package cloneproject.Instagram.entity.chat;
+
+import cloneproject.Instagram.entity.member.Member;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "messages")
+public class Message {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "message_id")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "join_room_id")
+    private JoinRoom joinRoom;
+
+    @Lob
+    @Column(name = "message_content")
+    private String content;
+
+    @CreatedDate
+    @Column(name = "message_created_date")
+    private LocalDateTime createdDate;
+
+    @Column(name = "message_type")
+    private MessageType type;
+
+    @Builder
+    public Message(Member member, JoinRoom joinRoom, String content, MessageType type) {
+        this.member = member;
+        this.joinRoom = joinRoom;
+        this.content = content;
+        this.type = type;
+    }
+}

--- a/src/main/java/cloneproject/Instagram/entity/chat/Message.java
+++ b/src/main/java/cloneproject/Instagram/entity/chat/Message.java
@@ -23,13 +23,13 @@ public class Message {
     @Column(name = "message_id")
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "join_room_id")
-    private JoinRoom joinRoom;
+    private Room room;
 
     @Lob
     @Column(name = "message_content")
@@ -43,9 +43,9 @@ public class Message {
     private MessageType type;
 
     @Builder
-    public Message(Member member, JoinRoom joinRoom, String content, MessageType type) {
+    public Message(Member member, Room room, String content, MessageType type) {
         this.member = member;
-        this.joinRoom = joinRoom;
+        this.room = room;
         this.content = content;
         this.type = type;
     }

--- a/src/main/java/cloneproject/Instagram/entity/chat/MessageImage.java
+++ b/src/main/java/cloneproject/Instagram/entity/chat/MessageImage.java
@@ -1,0 +1,40 @@
+package cloneproject.Instagram.entity.chat;
+
+import cloneproject.Instagram.vo.Image;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "message_images")
+public class MessageImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "message_image_id")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "message_id")
+    private Message message;
+
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "imageUrl", column = @Column(name = "post_image_url")),
+            @AttributeOverride(name = "imageType", column = @Column(name = "post_image_type")),
+            @AttributeOverride(name = "imageName", column = @Column(name = "post_image_name")),
+            @AttributeOverride(name = "imageUUID", column = @Column(name = "post_image_uuid"))
+    })
+    private Image image;
+
+    @Builder
+    public MessageImage(Message message, Image image) {
+        this.message = message;
+        this.image = image;
+    }
+}

--- a/src/main/java/cloneproject/Instagram/entity/chat/MessageLike.java
+++ b/src/main/java/cloneproject/Instagram/entity/chat/MessageLike.java
@@ -1,0 +1,35 @@
+package cloneproject.Instagram.entity.chat;
+
+import cloneproject.Instagram.entity.member.Member;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "message_likes")
+public class MessageLike {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "message_like_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "message_id")
+    private Message message;
+
+    @Builder
+    public MessageLike(Member member, Message message) {
+        this.member = member;
+        this.message = message;
+    }
+}

--- a/src/main/java/cloneproject/Instagram/entity/chat/MessageType.java
+++ b/src/main/java/cloneproject/Instagram/entity/chat/MessageType.java
@@ -1,0 +1,5 @@
+package cloneproject.Instagram.entity.chat;
+
+public enum MessageType {
+    TEXT, IMAGE
+}

--- a/src/main/java/cloneproject/Instagram/entity/chat/Room.java
+++ b/src/main/java/cloneproject/Instagram/entity/chat/Room.java
@@ -1,0 +1,19 @@
+package cloneproject.Instagram.entity.chat;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "rooms")
+public class Room {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "room_id")
+    private Long id;
+}

--- a/src/main/java/cloneproject/Instagram/entity/chat/RoomMember.java
+++ b/src/main/java/cloneproject/Instagram/entity/chat/RoomMember.java
@@ -2,6 +2,7 @@ package cloneproject.Instagram.entity.chat;
 
 import cloneproject.Instagram.entity.member.Member;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -10,19 +11,25 @@ import javax.persistence.*;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "rooms")
-public class Room {
+@Table(name = "room_members")
+public class RoomMember {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "room_id")
+    @Column(name = "room_member_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
-    public Room(Member member) {
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id")
+    private Room room;
+
+    @Builder
+    public RoomMember(Member member, Room room) {
         this.member = member;
+        this.room = room;
     }
 }

--- a/src/main/java/cloneproject/Instagram/entity/chat/RoomUnreadMember.java
+++ b/src/main/java/cloneproject/Instagram/entity/chat/RoomUnreadMember.java
@@ -5,22 +5,18 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
-import java.time.LocalDateTime;
 
 @Getter
 @Entity
-@EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "join_rooms")
-public class JoinRoom {
+@Table(name = "room_unread_members")
+public class RoomUnreadMember {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "join_room_id")
+    @Column(name = "room_unread_member_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -31,12 +27,8 @@ public class JoinRoom {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @CreatedDate
-    @Column(name = "join_room_created_date")
-    private LocalDateTime createdDate;
-
     @Builder
-    public JoinRoom(Room room, Member member) {
+    public RoomUnreadMember(Room room, Member member) {
         this.room = room;
         this.member = member;
     }

--- a/src/main/java/cloneproject/Instagram/exception/ChatRoomNotFoundException.java
+++ b/src/main/java/cloneproject/Instagram/exception/ChatRoomNotFoundException.java
@@ -1,0 +1,10 @@
+package cloneproject.Instagram.exception;
+
+import cloneproject.Instagram.dto.error.ErrorCode;
+
+public class ChatRoomNotFoundException extends BusinessException {
+
+    public ChatRoomNotFoundException() {
+        super(ErrorCode.CHAT_ROOM_NOT_FOUND);
+    }
+}

--- a/src/main/java/cloneproject/Instagram/exception/JoinRoomNotFoundException.java
+++ b/src/main/java/cloneproject/Instagram/exception/JoinRoomNotFoundException.java
@@ -1,0 +1,10 @@
+package cloneproject.Instagram.exception;
+
+import cloneproject.Instagram.dto.error.ErrorCode;
+
+public class JoinRoomNotFoundException extends BusinessException {
+
+    public JoinRoomNotFoundException() {
+        super(ErrorCode.JOIN_ROOM_NOT_FOUND);
+    }
+}

--- a/src/main/java/cloneproject/Instagram/repository/chat/JoinRoomRepository.java
+++ b/src/main/java/cloneproject/Instagram/repository/chat/JoinRoomRepository.java
@@ -1,0 +1,11 @@
+package cloneproject.Instagram.repository.chat;
+
+import cloneproject.Instagram.entity.chat.JoinRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface JoinRoomRepository extends JpaRepository<JoinRoom, Long>, JoinRoomRepositoryQuerydsl {
+    Optional<JoinRoom> findByMemberIdAndRoomId(Long memberId, Long roomId);
+    void deleteByMemberIdAndRoomId(Long memberId, Long roomId);
+}

--- a/src/main/java/cloneproject/Instagram/repository/chat/JoinRoomRepositoryQuerydsl.java
+++ b/src/main/java/cloneproject/Instagram/repository/chat/JoinRoomRepositoryQuerydsl.java
@@ -1,0 +1,9 @@
+package cloneproject.Instagram.repository.chat;
+
+import cloneproject.Instagram.dto.chat.JoinRoomDTO;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface JoinRoomRepositoryQuerydsl {
+    Page<JoinRoomDTO> findJoinRoomDTOPagebyMemberId(Long memberId, Pageable pageable);
+}

--- a/src/main/java/cloneproject/Instagram/repository/chat/JoinRoomRepositoryQuerydslImpl.java
+++ b/src/main/java/cloneproject/Instagram/repository/chat/JoinRoomRepositoryQuerydslImpl.java
@@ -1,0 +1,20 @@
+package cloneproject.Instagram.repository.chat;
+
+import cloneproject.Instagram.dto.chat.JoinRoomDTO;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+@RequiredArgsConstructor
+public class JoinRoomRepositoryQuerydslImpl implements JoinRoomRepositoryQuerydsl {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<JoinRoomDTO> findJoinRoomDTOPagebyMemberId(Long memberId, Pageable pageable) {
+
+        return new PageImpl<>(null);
+    }
+}

--- a/src/main/java/cloneproject/Instagram/repository/chat/MessageImageRepository.java
+++ b/src/main/java/cloneproject/Instagram/repository/chat/MessageImageRepository.java
@@ -1,0 +1,7 @@
+package cloneproject.Instagram.repository.chat;
+
+import cloneproject.Instagram.entity.chat.MessageImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MessageImageRepository extends JpaRepository<MessageImage, Long> {
+}

--- a/src/main/java/cloneproject/Instagram/repository/chat/MessageLikeRepository.java
+++ b/src/main/java/cloneproject/Instagram/repository/chat/MessageLikeRepository.java
@@ -1,0 +1,7 @@
+package cloneproject.Instagram.repository.chat;
+
+import cloneproject.Instagram.entity.chat.MessageLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MessageLikeRepository extends JpaRepository<MessageLike, Long> {
+}

--- a/src/main/java/cloneproject/Instagram/repository/chat/MessageRepository.java
+++ b/src/main/java/cloneproject/Instagram/repository/chat/MessageRepository.java
@@ -1,0 +1,7 @@
+package cloneproject.Instagram.repository.chat;
+
+import cloneproject.Instagram.entity.chat.Message;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MessageRepository extends JpaRepository<Message, Long> {
+}

--- a/src/main/java/cloneproject/Instagram/repository/chat/RoomMemberRepository.java
+++ b/src/main/java/cloneproject/Instagram/repository/chat/RoomMemberRepository.java
@@ -1,0 +1,7 @@
+package cloneproject.Instagram.repository.chat;
+
+import cloneproject.Instagram.entity.chat.RoomMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoomMemberRepository extends JpaRepository<RoomMember, Long> {
+}

--- a/src/main/java/cloneproject/Instagram/repository/chat/RoomRepository.java
+++ b/src/main/java/cloneproject/Instagram/repository/chat/RoomRepository.java
@@ -1,0 +1,7 @@
+package cloneproject.Instagram.repository.chat;
+
+import cloneproject.Instagram.entity.chat.Room;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoomRepository extends JpaRepository<Room, Long> {
+}

--- a/src/main/java/cloneproject/Instagram/repository/chat/RoomUnreadMemberRepository.java
+++ b/src/main/java/cloneproject/Instagram/repository/chat/RoomUnreadMemberRepository.java
@@ -1,0 +1,12 @@
+package cloneproject.Instagram.repository.chat;
+
+import cloneproject.Instagram.entity.chat.RoomUnreadMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RoomUnreadMemberRepository extends JpaRepository<RoomUnreadMember, Long> {
+    void deleteByRoomIdAndMemberId(Long roomId, Long memberId);
+    Optional<RoomUnreadMember> findByRoomIdAndMemberId(Long roomId, Long memberId);
+    long countByRoomId(Long roomId);
+}

--- a/src/main/java/cloneproject/Instagram/service/ChatService.java
+++ b/src/main/java/cloneproject/Instagram/service/ChatService.java
@@ -1,0 +1,89 @@
+package cloneproject.Instagram.service;
+
+import cloneproject.Instagram.dto.chat.*;
+import cloneproject.Instagram.entity.chat.Room;
+import cloneproject.Instagram.entity.chat.RoomMember;
+import cloneproject.Instagram.entity.member.Member;
+import cloneproject.Instagram.exception.JoinRoomNotFoundException;
+import cloneproject.Instagram.exception.MemberDoesNotExistException;
+import cloneproject.Instagram.exception.ChatRoomNotFoundException;
+import cloneproject.Instagram.repository.MemberRepository;
+import cloneproject.Instagram.repository.chat.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.springframework.data.domain.Sort.Direction.DESC;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChatService {
+
+    private final RoomRepository roomRepository;
+    private final RoomMemberRepository roomMemberRepository;
+    private final RoomUnreadMemberRepository roomUnreadMemberRepository;
+    private final MessageRepository messageRepository;
+    private final MessageLikeRepository messageLikeRepository;
+    private final MessageImageRepository messageImageRepository;
+    private final MemberRepository memberRepository;
+    private final JoinRoomRepository joinRoomRepository;
+
+    @Transactional
+    public ChatRoomCreateResponse createRoom(String username) {
+        final Long memberId = Long.valueOf(SecurityContextHolder.getContext().getAuthentication().getName());
+        final Member inviter = memberRepository.findById(memberId).orElseThrow(MemberDoesNotExistException::new);
+        final Member guest = memberRepository.findByUsername(username).orElseThrow(MemberDoesNotExistException::new);
+
+        // TODO: feat(대상과 이미 존재하는 채팅방이 있는지 검증)
+
+        final Room room = roomRepository.save(new Room(inviter));
+        // TODO: refactor(batch insert)
+        roomMemberRepository.save(new RoomMember(inviter, room));
+        roomMemberRepository.save(new RoomMember(guest, room));
+
+        return new ChatRoomCreateResponse(true, room.getId(), List.of(new Opponent(inviter)));
+    }
+
+
+    public ChatRoomInquireResponse inquireRoom(Long roomId) {
+        final Room room = roomRepository.findById(roomId).orElseThrow(ChatRoomNotFoundException::new);
+        final Long memberId = Long.valueOf(SecurityContextHolder.getContext().getAuthentication().getName());
+        final Member member = memberRepository.findById(memberId).orElseThrow(MemberDoesNotExistException::new);
+
+        final long unseenCount = roomUnreadMemberRepository.countByRoomId(room.getId());
+        if (roomUnreadMemberRepository.findByRoomIdAndMemberId(room.getId(), member.getId()).isEmpty())
+            return new ChatRoomInquireResponse(false, unseenCount);
+
+        roomUnreadMemberRepository.deleteByRoomIdAndMemberId(room.getId(), member.getId());
+        return new ChatRoomInquireResponse(true, unseenCount - 1);
+    }
+
+    public JoinRoomDeleteResponse deleteJoinRoom(Long roomId) {
+        final Room room = roomRepository.findById(roomId).orElseThrow(ChatRoomNotFoundException::new);
+        final Long memberId = Long.valueOf(SecurityContextHolder.getContext().getAuthentication().getName());
+        final Member member = memberRepository.findById(memberId).orElseThrow(MemberDoesNotExistException::new);
+
+        if (joinRoomRepository.findByMemberIdAndRoomId(member.getId(), room.getId()).isEmpty())
+            throw new JoinRoomNotFoundException();
+        joinRoomRepository.deleteByMemberIdAndRoomId(member.getId(), room.getId());
+
+        return new JoinRoomDeleteResponse(true);
+    }
+
+    /*public Page<JoinRoomDTO> getJoinRooms(int page) {
+        final Long memberId = Long.valueOf(SecurityContextHolder.getContext().getAuthentication().getName());
+        final Member member = memberRepository.findById(memberId).orElseThrow(MemberDoesNotExistException::new);
+
+        page = (page == 0 ? 0 : page - 1);
+        Pageable pageable = PageRequest.of(page, 10, Sort.by(DESC, "id"));
+        return JoinRoomRepository.findJoinRoomDTOPagebyMemberId(member.getId(), pageable);
+    }*/
+}


### PR DESCRIPTION
## 변경 사항
### DM 관련 엔티티 추가
- 이슈 참고해주세요. 토요일 코테 끝나고 나서 다시 수정하겠습니다ㅠㅠ
### 채팅방 생성 API
- 새로운 메시지에서 대상을 선택하고 다음을 클릭하는 시점에 요청
- 채팅을 보내는 시점에 JoinRoom 엔티티가 생성
    - 채팅을 보내지 않으면, JoinRoom 엔티티가 생성되지 않아, 새로고침 시 채팅방 목록 조회 불가
    - 그러나, 채팅방 자체는 생성되어 있음 -> Inviter가 자신
- RoomMember 엔티티에 참여자 정보를 저장함
### 채팅방 조회 API
- 임의의 채팅방을 선택하면, 읽지 않음 카운팅을 감소시켜 주는 API
- 웹소켓에서 채팅 메시지를 받을 때 마다 자동으로 호출되도록 해야 함
- 채팅 메시지를 보낼 때 마다 RoomUnreadMember 엔티티에 RoomMember에 존재하는 모든 회원을 insert하고, 채팅 메시지를 받는 회원은 RoomUnreadMember에서 제거하는 방식
### 채팅방 삭제 API
- JoinRoom 엔티티에서 본인을 제거

### 해결한 이슈
- Resolve: #73 

### Comment
- 30분 뒤에 보성->인천(자취방)으로 이동해야해서 구현하던 부분까지 일단 PR 올렸습니다..
- 토요일 오후에 바로 채팅방 목록 조회 API도 구현해서 새로 PR 올리겠습니다!
- 만약 피드백 없으시면 다훈님이 merge하시고 배포해주시면 감사하겠습니다.
    - 피드백 있으시면 카톡 부탁드려요!