### PR TITLE
유저 저장한, 태그된 게시물 조회 API

### DIFF
--- a/src/main/java/cloneproject/Instagram/config/WebSecurityConfig.java
+++ b/src/main/java/cloneproject/Instagram/config/WebSecurityConfig.java
@@ -78,10 +78,29 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter{
                 .csrf().disable()
                 .authorizeRequests()
                 .antMatchers("/login", "/accounts", "/swagger-resources/**", "/swagger-ui/**").permitAll()
-                .antMatchers("/info", "/posts/**", "/accounts/image", "/accounts/password","/accounts/edit").hasAuthority("ROLE_USER")
-                .antMatchers("/search").hasAuthority("ROLE_USER")
-                .antMatchers("/**/follow", "/**/unfollow",  "/**/followers", "/**/following").hasAuthority("ROLE_USER")
-                .antMatchers("/admin").hasAuthority("ROLE_ADMIN");
+
+                //게시물
+                .antMatchers("/posts", "/posts/**").hasAuthority("ROLE_USER")
+                .antMatchers("/posts/like", "/posts/recent", "/posts/save").hasAuthority("ROLE_USER")
+
+                // 유저 포스트
+                .antMatchers("/accounts/**/posts", "/accounts/**/posts/recent", "/accounts/**/posts/tagged", "/accounts/**/posts/tagged/recent").permitAll()
+                .antMatchers("/accounts/**/posts/saved", "/accounts/**/posts/saved/recent").hasAuthority("ROLE_USER")
+                
+                // 유저 프로필 관련
+                .antMatchers("/accounts/**").permitAll()
+                .antMatchers("/accounts/**/mini", "/accounts/edit", "/accounts/image", "/menu/profile").hasAuthority("ROLE_USER")
+                .antMatchers("/accounts/password").hasAuthority("ROLE_USER")
+                // 유저 기타
+                .antMatchers("/search", "/alarms").hasAuthority("ROLE_USER")
+
+                // 팔로우 & 차단
+                .antMatchers("/**/follow", "/**/followers", "/**/following").hasAuthority("ROLE_USER")
+                .antMatchers("/**/block").hasAuthority("ROLE_USER")
+
+                // DM
+                .antMatchers("/chat/rooms", "/chat/rooms/**").hasAuthority("ROLE_USER");
+
     }
 
 }

--- a/src/main/java/cloneproject/Instagram/controller/BlockController.java
+++ b/src/main/java/cloneproject/Instagram/controller/BlockController.java
@@ -5,6 +5,7 @@ import javax.validation.constraints.NotBlank;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -36,7 +37,7 @@ public class BlockController {
     }
 
     @ApiOperation(value = "차단해제")
-    @PostMapping("/{blockMemberUsername}/unblock")
+    @DeleteMapping("/{blockMemberUsername}/block")
     @ApiImplicitParam(name = "blockMemberUsername", value = "차단해제할 계정의 username", required = true, example = "dlwlrma")
     public ResponseEntity<ResultResponse> unblock(@PathVariable("blockMemberUsername") @Validated
                                                 @NotBlank(message = "username이 필요합니다") String blockMemberUsername){

--- a/src/main/java/cloneproject/Instagram/controller/FollowController.java
+++ b/src/main/java/cloneproject/Instagram/controller/FollowController.java
@@ -7,6 +7,7 @@ import javax.validation.constraints.NotBlank;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -40,7 +41,7 @@ public class FollowController {
     }
 
     @ApiOperation(value = "언팔로우")
-    @PostMapping("/{followMemberUsername}/unfollow")
+    @DeleteMapping("/{followMemberUsername}/follow")
     @ApiImplicitParam(name = "followMemberUsername", value = "언팔로우할 계정의 username", required = true, example = "dlwlrma")
     public ResponseEntity<ResultResponse> unfollow(@PathVariable("followMemberUsername") @Validated
                                                 @NotBlank(message = "username이 필요합니다") String followMemberUsername){

--- a/src/main/java/cloneproject/Instagram/controller/MemberPostController.java
+++ b/src/main/java/cloneproject/Instagram/controller/MemberPostController.java
@@ -58,4 +58,51 @@ public class MemberPostController {
         return ResponseEntity.ok(ResultResponse.of(ResultCode.FIND_MEMBER_POSTS_SUCCESS, postPage));
     }
 
+    // ============== 저장 ================
+    @ApiOperation(value = "멤버 저장한 게시물 15개 조회")
+    @GetMapping("/accounts/{username}/posts/saved/recent")
+    public ResponseEntity<ResultResponse> getRecent1SavedPosts() {
+        final List<MemberPostDTO> postList = memberPostService.getRecent15SavedPostDTOs();
+
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.FIND_RECENT15_MEMBER_SAVED_POSTS_SUCCESS, postList));
+    }
+
+    @ApiOperation(value = "멤버 저장한 게시물 페이징 조회(무한스크롤)")
+    @GetMapping("/accounts/{username}/posts/saved")
+    @ApiImplicitParam(name = "page", value = "페이지", required = true, example = "1")
+    public ResponseEntity<ResultResponse> getSavedPostPage(
+            @Validated @NotNull(message = "조회할 게시물 page는 필수입니다.") @RequestParam int page) {
+        final Page<MemberPostDTO> postPage = memberPostService.getMemberSavedPostDto(3, page);
+
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.FIND_MEMBER_SAVED_POSTS_SUCCESS, postPage));
+    }
+
+    // ============== 태그 ================
+    @ApiOperation(value = "멤버 태그된 게시물 15개 조회")
+    @ApiImplicitParams({
+        @ApiImplicitParam(name = "Authorization", value = "있어도 되고 없어도됨", required = false, example = "Bearer AAA.BBB.CCC"),
+        @ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma")
+    })
+    @GetMapping("/accounts/{username}/posts/tagged/recent")
+    public ResponseEntity<ResultResponse> getRecent10TaggedPosts(
+            @PathVariable("username") @Validated @NotBlank(message="username은 필수입니다") String username) {
+        final List<MemberPostDTO> postList = memberPostService.getRecent15TaggedPostDTOs(username);
+
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.FIND_RECENT15_MEMBER_TAGGED_POSTS_SUCCESS, postList));
+    }
+
+    @ApiOperation(value = "멤버 태그된 게시물 페이징 조회(무한스크롤)")
+    @ApiImplicitParams({
+        @ApiImplicitParam(name = "Authorization", value = "있어도 되고 없어도됨", required = false, example = "Bearer AAA.BBB.CCC"),
+        @ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma"),
+        @ApiImplicitParam(name = "page", value = "페이지", required = true, example = "1")
+    })
+    @GetMapping("/accounts/{username}/posts/tagged")
+    public ResponseEntity<ResultResponse> getTaggedPostPage(
+            @PathVariable("username") @Validated @NotBlank(message="username은 필수입니다") String username,
+            @Validated @NotNull(message = "조회할 게시물 page는 필수입니다.") @RequestParam int page) {
+        final Page<MemberPostDTO> postPage = memberPostService.getMemberTaggedPostDto(username,3, page);
+
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.FIND_MEMBER_TAGGED_POSTS_SUCCESS, postPage));
+    }
 }

--- a/src/main/java/cloneproject/Instagram/dto/result/ResultCode.java
+++ b/src/main/java/cloneproject/Instagram/dto/result/ResultCode.java
@@ -41,6 +41,10 @@ public enum ResultCode {
     // MemberPost
     FIND_RECENT15_MEMBER_POSTS_SUCCESS(200, "MP001", "회원의 최근 게시물 15개 조회 성공"),
     FIND_MEMBER_POSTS_SUCCESS(200, "MP002", "회원의 게시물 조회 성공"),
+    FIND_RECENT15_MEMBER_SAVED_POSTS_SUCCESS(200, "MP003", "회원의 최근 저장한 게시물 15개 조회 성공"),
+    FIND_MEMBER_SAVED_POSTS_SUCCESS(200, "MP004", "회원의 저장한 게시물 조회 성공"),
+    FIND_RECENT15_MEMBER_TAGGED_POSTS_SUCCESS(200, "MP005", "회원의 최근 태그된 게시물 15개 조회 성공"),
+    FIND_MEMBER_TAGGED_POSTS_SUCCESS(200, "MP006", "회원의 태그된 게시물 조회 성공"),
 
 
     // POST

--- a/src/main/java/cloneproject/Instagram/repository/MemberPostRepositoryQuerydsl.java
+++ b/src/main/java/cloneproject/Instagram/repository/MemberPostRepositoryQuerydsl.java
@@ -1,0 +1,21 @@
+package cloneproject.Instagram.repository;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import cloneproject.Instagram.dto.post.MemberPostDTO;
+
+public interface MemberPostRepositoryQuerydsl {
+    
+    List<MemberPostDTO> getRecent15PostDTOs(Long loginedUserId, String username);
+    Page<MemberPostDTO> getMemberPostDto(Long loginedUserId, String username, Pageable pageable);
+
+    List<MemberPostDTO> getRecent15SavedPostDTOs(Long loginedUserId);
+    Page<MemberPostDTO> getMemberSavedPostDto(Long loginedUserId, Pageable pageable);
+
+    List<MemberPostDTO> getRecent15TaggedPostDTOs(Long loginedUserId, String username);
+    Page<MemberPostDTO> getMemberTaggedPostDto(Long loginedUserId, String username, Pageable pageable);
+    
+}

--- a/src/main/java/cloneproject/Instagram/repository/MemberPostRepositoryQuerydslImpl.java
+++ b/src/main/java/cloneproject/Instagram/repository/MemberPostRepositoryQuerydslImpl.java
@@ -1,0 +1,257 @@
+package cloneproject.Instagram.repository;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import cloneproject.Instagram.dto.post.MemberPostDTO;
+import cloneproject.Instagram.dto.post.PostImageDTO;
+import cloneproject.Instagram.dto.post.QMemberPostDTO;
+import cloneproject.Instagram.dto.post.QPostImageDTO;
+import lombok.RequiredArgsConstructor;
+
+import static cloneproject.Instagram.entity.member.QFollow.follow;
+import static cloneproject.Instagram.entity.member.QMember.member;
+import static cloneproject.Instagram.entity.member.QBlock.block;
+import static cloneproject.Instagram.entity.post.QPost.post;
+import static cloneproject.Instagram.entity.post.QPostImage.postImage;
+import static cloneproject.Instagram.entity.post.QBookmark.bookmark;
+import static cloneproject.Instagram.entity.post.QPostTag.postTag;;
+
+@RequiredArgsConstructor
+public class MemberPostRepositoryQuerydslImpl implements MemberPostRepositoryQuerydsl{
+    
+    private final JPAQueryFactory queryFactory;
+    
+    @Override
+    public List<MemberPostDTO> getRecent15PostDTOs(Long loginedUserId, String username){
+        final List<MemberPostDTO> posts = queryFactory
+                                            .select(new QMemberPostDTO(
+                                                post.id, 
+                                                post.postImages.size().gt(1), 
+                                                post.comments.size(), 
+                                                post.postLikes.size()))
+                                            .from(post, member)
+                                            .where(post.member.username.eq(username))
+                                            .limit(15)
+                                            .orderBy(post.id.desc())
+                                            .distinct()
+                                            .fetch();
+        
+        final List<Long> postIds = posts.stream()
+                                    .map(MemberPostDTO::getPostId)
+                                    .collect(Collectors.toList());
+
+        final List<PostImageDTO> postImageDTOs = queryFactory
+                                    .select(new QPostImageDTO(
+                                            postImage.post.id,
+                                            postImage.id,
+                                            postImage.image.imageUrl
+                                    ))
+                                    .from(postImage)
+                                    .where(postImage.post.id.in(postIds))
+                                    .fetch();
+
+        final Map<Long, List<PostImageDTO>> postImageDTOMap = postImageDTOs.stream()
+                                                                .collect(Collectors.groupingBy(PostImageDTO::getPostId));
+                                        
+        posts.forEach(p->p.setImageUrl(postImageDTOMap.get(p.getPostId()).get(0).getPostImageUrl()));
+        return posts;
+    }
+    
+    @Override
+    public Page<MemberPostDTO> getMemberPostDto(Long loginedUserId, String username, Pageable pageable){
+        final List<MemberPostDTO> posts = queryFactory
+                                            .select(new QMemberPostDTO(
+                                                post.id, 
+                                                post.postImages.size().gt(1), 
+                                                post.comments.size(), 
+                                                post.postLikes.size()))
+                                            .from(post)
+                                            .where(post.member.username.eq(username))
+                                            .offset(pageable.getOffset())
+                                            .limit(pageable.getPageSize())
+                                            .orderBy(post.id.desc())
+                                            .distinct()
+                                            .fetch();
+        
+        final List<Long> postIds = posts.stream()
+                                    .map(MemberPostDTO::getPostId)
+                                    .collect(Collectors.toList());
+
+        final List<PostImageDTO> postImageDTOs = queryFactory
+                                    .select(new QPostImageDTO(
+                                            postImage.post.id,
+                                            postImage.id,
+                                            postImage.image.imageUrl
+                                    ))
+                                    .from(postImage)
+                                    .where(postImage.post.id.in(postIds))
+                                    .fetch();
+
+        final Map<Long, List<PostImageDTO>> postImageDTOMap = postImageDTOs.stream()
+                                                                .collect(Collectors.groupingBy(PostImageDTO::getPostId));
+    
+        posts.forEach(p->p.setImageUrl(postImageDTOMap.get(p.getPostId()).get(0).getPostImageUrl()));    
+                            
+        
+        return new PageImpl<>(posts, pageable, posts.size());
+    }
+
+    @Override
+    public List<MemberPostDTO> getRecent15SavedPostDTOs(Long loginedUserId){
+        final List<MemberPostDTO> posts = queryFactory
+                                            .select(new QMemberPostDTO(
+                                                bookmark.post.id, 
+                                                bookmark.post.postImages.size().gt(1), 
+                                                bookmark.post.comments.size(), 
+                                                bookmark.post.postLikes.size()))
+                                            .from(bookmark)
+                                            .where(bookmark.member.id.eq(loginedUserId))
+                                            .limit(15)
+                                            .orderBy(bookmark.post.id.desc())
+                                            .distinct()
+                                            .fetch();
+        
+        final List<Long> postIds = posts.stream()
+                                    .map(MemberPostDTO::getPostId)
+                                    .collect(Collectors.toList());
+
+        final List<PostImageDTO> postImageDTOs = queryFactory
+                                    .select(new QPostImageDTO(
+                                            postImage.post.id,
+                                            postImage.id,
+                                            postImage.image.imageUrl
+                                    ))
+                                    .from(postImage)
+                                    .where(postImage.post.id.in(postIds))
+                                    .fetch();
+
+        final Map<Long, List<PostImageDTO>> postImageDTOMap = postImageDTOs.stream()
+                                                                .collect(Collectors.groupingBy(PostImageDTO::getPostId));
+                                        
+        posts.forEach(p->p.setImageUrl(postImageDTOMap.get(p.getPostId()).get(0).getPostImageUrl()));
+        return posts;
+    }
+
+    @Override
+    public Page<MemberPostDTO> getMemberSavedPostDto(Long loginedUserId, Pageable pageable){
+        final List<MemberPostDTO> posts = queryFactory
+                                            .select(new QMemberPostDTO(
+                                                bookmark.post.id, 
+                                                bookmark.post.postImages.size().gt(1), 
+                                                bookmark.post.comments.size(), 
+                                                bookmark.post.postLikes.size()))
+                                            .from(bookmark)
+                                            .where(bookmark.member.id.eq(loginedUserId))
+                                            .offset(pageable.getOffset())
+                                            .limit(pageable.getPageSize())
+                                            .orderBy(bookmark.post.id.desc())
+                                            .distinct()
+                                            .fetch();
+        
+        final List<Long> postIds = posts.stream()
+                                    .map(MemberPostDTO::getPostId)
+                                    .collect(Collectors.toList());
+
+        final List<PostImageDTO> postImageDTOs = queryFactory
+                                    .select(new QPostImageDTO(
+                                            postImage.post.id,
+                                            postImage.id,
+                                            postImage.image.imageUrl
+                                    ))
+                                    .from(postImage)
+                                    .where(postImage.post.id.in(postIds))
+                                    .fetch();
+
+        final Map<Long, List<PostImageDTO>> postImageDTOMap = postImageDTOs.stream()
+                                                                .collect(Collectors.groupingBy(PostImageDTO::getPostId));
+    
+        posts.forEach(p->p.setImageUrl(postImageDTOMap.get(p.getPostId()).get(0).getPostImageUrl()));    
+                            
+        
+        return new PageImpl<>(posts, pageable, posts.size());
+    }
+
+    @Override
+    public List<MemberPostDTO> getRecent15TaggedPostDTOs(Long loginedUserId, String username){
+        final List<MemberPostDTO> posts = queryFactory
+                                            .select(new QMemberPostDTO(
+                                                postTag.postImage.post.id, 
+                                                postTag.postImage.post.postImages.size().gt(1), 
+                                                postTag.postImage.post.comments.size(), 
+                                                postTag.postImage.post.postLikes.size()))
+                                            .from(postTag)
+                                            .where(postTag.tag.username.eq(username))
+                                            .limit(15)
+                                            .orderBy(postTag.postImage.post.id.desc())
+                                            .distinct()
+                                            .fetch();
+        
+        final List<Long> postIds = posts.stream()
+                                    .map(MemberPostDTO::getPostId)
+                                    .collect(Collectors.toList());
+
+        final List<PostImageDTO> postImageDTOs = queryFactory
+                                    .select(new QPostImageDTO(
+                                            postImage.post.id,
+                                            postImage.id,
+                                            postImage.image.imageUrl
+                                    ))
+                                    .from(postImage)
+                                    .where(postImage.post.id.in(postIds))
+                                    .fetch();
+
+        final Map<Long, List<PostImageDTO>> postImageDTOMap = postImageDTOs.stream()
+                                                                .collect(Collectors.groupingBy(PostImageDTO::getPostId));
+                                        
+        posts.forEach(p->p.setImageUrl(postImageDTOMap.get(p.getPostId()).get(0).getPostImageUrl()));
+        return posts;
+    }
+
+    @Override
+    public Page<MemberPostDTO> getMemberTaggedPostDto(Long loginedUserId, String username, Pageable pageable){
+        final List<MemberPostDTO> posts = queryFactory
+                                            .select(new QMemberPostDTO(
+                                                postTag.postImage.post.id, 
+                                                postTag.postImage.post.postImages.size().gt(1), 
+                                                postTag.postImage.post.comments.size(), 
+                                                postTag.postImage.post.postLikes.size()))
+                                            .from(postTag)
+                                            .where(postTag.tag.username.eq(username))
+                                            .offset(pageable.getOffset())
+                                            .limit(pageable.getPageSize())
+                                            .orderBy(postTag.postImage.post.id.desc())
+                                            .distinct()
+                                            .fetch();
+        
+        final List<Long> postIds = posts.stream()
+                                    .map(MemberPostDTO::getPostId)
+                                    .collect(Collectors.toList());
+
+        final List<PostImageDTO> postImageDTOs = queryFactory
+                                    .select(new QPostImageDTO(
+                                            postImage.post.id,
+                                            postImage.id,
+                                            postImage.image.imageUrl
+                                    ))
+                                    .from(postImage)
+                                    .where(postImage.post.id.in(postIds))
+                                    .fetch();
+
+        final Map<Long, List<PostImageDTO>> postImageDTOMap = postImageDTOs.stream()
+                                                                .collect(Collectors.groupingBy(PostImageDTO::getPostId));
+    
+        posts.forEach(p->p.setImageUrl(postImageDTOMap.get(p.getPostId()).get(0).getPostImageUrl()));    
+                            
+        
+        return new PageImpl<>(posts, pageable, posts.size());
+    }
+    
+}

--- a/src/main/java/cloneproject/Instagram/repository/MemberRepository.java
+++ b/src/main/java/cloneproject/Instagram/repository/MemberRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 import cloneproject.Instagram.entity.member.Member;
 
-public interface MemberRepository extends JpaRepository<Member, Long>, JpaSpecificationExecutor<Member>, MemberRepositoryQuerydsl{
+public interface MemberRepository extends JpaRepository<Member, Long>, JpaSpecificationExecutor<Member>, MemberPostRepositoryQuerydsl,MemberRepositoryQuerydsl{
     public Optional<Member> findByUsername(String username);
     public Optional<Member> findById(Long id);
     public List<Member> findAll(Specification<Member> spec);

--- a/src/main/java/cloneproject/Instagram/repository/MemberRepositoryQuerydsl.java
+++ b/src/main/java/cloneproject/Instagram/repository/MemberRepositoryQuerydsl.java
@@ -18,7 +18,5 @@ public interface MemberRepositoryQuerydsl {
     MiniProfileResponse getMiniProfile(Long loginedUserId, String username);
     List<SearchedMemberDTO> searchMember(Long loginedUserId, String text);
     List<Member> findAllByUsernames(List<String> usernames);
-    List<MemberPostDTO> getRecent15PostDTOs(Long loginedUserId, String username);
-    Page<MemberPostDTO> getMemberPostDto(Long loginedUserId, String username, Pageable pageable);
 
 }

--- a/src/main/java/cloneproject/Instagram/service/MemberPostService.java
+++ b/src/main/java/cloneproject/Instagram/service/MemberPostService.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 import cloneproject.Instagram.dto.post.MemberPostDTO;
@@ -57,4 +58,57 @@ public class MemberPostService {
         return posts;
     }
 
+    public Page<MemberPostDTO> getMemberSavedPostDto(int size, int page) {
+        page = (page == 0 ? 0 : page - 1)+5;
+        final String loginedMemberId = SecurityContextHolder.getContext().getAuthentication().getName();
+
+
+        final Pageable pageable = PageRequest.of(page, size);
+        Page<MemberPostDTO> posts = memberRepository.getMemberSavedPostDto(Long.valueOf(loginedMemberId), pageable);
+        return posts;
+
+
+    }
+    
+    public List<MemberPostDTO> getRecent15SavedPostDTOs() {
+        final String loginedMemberId = SecurityContextHolder.getContext().getAuthentication().getName();
+
+        List<MemberPostDTO> posts = memberRepository.getRecent15SavedPostDTOs(Long.valueOf(loginedMemberId));
+        return posts;
+    }
+
+    public Page<MemberPostDTO> getMemberTaggedPostDto(String username, int size, int page) {
+        page = (page == 0 ? 0 : page - 1)+5;
+        final Long loginedMemberId = AuthUtil.getLoginedMemberIdOrNull();
+
+        final Member member = memberRepository.findByUsername(username)
+                                                .orElseThrow(MemberDoesNotExistException::new);
+
+        if(blockRepository.existsByMemberIdAndBlockMemberId(loginedMemberId, member.getId()) ||
+            blockRepository.existsByMemberIdAndBlockMemberId(member.getId(), loginedMemberId)){
+            return null;
+        }
+
+        final Pageable pageable = PageRequest.of(page, size);
+        Page<MemberPostDTO> posts = memberRepository.getMemberTaggedPostDto(loginedMemberId, username, pageable);
+        return posts;
+
+
+    }
+    
+    public List<MemberPostDTO> getRecent15TaggedPostDTOs(String username) {
+        final Long loginedMemberId = AuthUtil.getLoginedMemberIdOrNull();
+
+        final Member member = memberRepository.findByUsername(username)
+                                                .orElseThrow(MemberDoesNotExistException::new);
+
+        if(blockRepository.existsByMemberIdAndBlockMemberId(loginedMemberId, member.getId()) ||
+            blockRepository.existsByMemberIdAndBlockMemberId(member.getId(), loginedMemberId)){
+            return null;
+        }
+        
+        List<MemberPostDTO> posts = memberRepository.getRecent15TaggedPostDTOs(loginedMemberId, username);
+        return posts;
+    }
+    
 }


### PR DESCRIPTION
### 저장된, 태그된 게시물 API
- 유저가 업로드한 게시물과 같은 형태로 반환
- 저장한 게시물은 본인의 것만 조회 가능

### 스프링 시큐리티 권한 설정 추가
- 누락된 권한 설정을 추가 및 정리

### 언팔로우, 차단해제 URL 수정
- 기존엔 `/{username}/unfollow`, `/{username}/unblock`으로 `POST` 매핑되어 있었는데, RESTful하지 않다고 판단
- 각각  `/{username}/follow`, `/{username}/block`으로 `DELETE` 매핑하도록 수정