### PR TITLE
채팅방 목록 페이징 조회 API 추가

### DIFF
--- a/src/main/java/cloneproject/Instagram/controller/ChatController.java
+++ b/src/main/java/cloneproject/Instagram/controller/ChatController.java
@@ -1,8 +1,8 @@
 package cloneproject.Instagram.controller;
 
 import cloneproject.Instagram.dto.chat.ChatRoomCreateResponse;
-import cloneproject.Instagram.dto.chat.JoinRoomDTO;
 import cloneproject.Instagram.dto.chat.ChatRoomInquireResponse;
+import cloneproject.Instagram.dto.chat.JoinRoomDTO;
 import cloneproject.Instagram.dto.chat.JoinRoomDeleteResponse;
 import cloneproject.Instagram.dto.result.ResultResponse;
 import cloneproject.Instagram.service.ChatService;
@@ -54,12 +54,12 @@ public class ChatController {
         return ResponseEntity.ok(ResultResponse.of(DELETE_JOIN_ROOM_SUCCESS, response));
     }
 
-    /*@ApiOperation(value = "채팅방 목록 페이징 조회", notes = "1페이지당 10개씩 조회할 수 있습니다.")
+    @ApiOperation(value = "채팅방 목록 페이징 조회", notes = "1페이지당 10개씩 조회할 수 있습니다.")
     @GetMapping("/chat/rooms")
     public ResponseEntity<ResultResponse> getJoinRooms(
             @Validated @NotNull(message = "페이지는 필수입니다.") @RequestParam Integer page) {
         final Page<JoinRoomDTO> response = chatService.getJoinRooms(page);
 
         return ResponseEntity.ok(ResultResponse.of(GET_JOIN_ROOMS_SUCCESS, response));
-    }*/
+    }
 }

--- a/src/main/java/cloneproject/Instagram/dto/chat/ChatRoomCreateResponse.java
+++ b/src/main/java/cloneproject/Instagram/dto/chat/ChatRoomCreateResponse.java
@@ -1,6 +1,5 @@
 package cloneproject.Instagram.dto.chat;
 
-import cloneproject.Instagram.entity.member.Member;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,5 +14,6 @@ public class ChatRoomCreateResponse {
 
     private boolean status;
     private Long chatRoomId;
-    private List<Opponent> opponents = new ArrayList<>();
+    private MemberSimpleInfo inviter;
+    private List<MemberSimpleInfo> invitees = new ArrayList<>();
 }

--- a/src/main/java/cloneproject/Instagram/dto/chat/JoinRoomDTO.java
+++ b/src/main/java/cloneproject/Instagram/dto/chat/JoinRoomDTO.java
@@ -1,19 +1,29 @@
 package cloneproject.Instagram.dto.chat;
 
-import lombok.AllArgsConstructor;
+import cloneproject.Instagram.entity.member.Member;
+import com.querydsl.core.annotations.QueryProjection;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Getter
-@AllArgsConstructor
+@Setter
 @NoArgsConstructor
 public class JoinRoomDTO {
 
     private Long chatRoomId;
     private MessageDTO lastMessage;
-    private Long unseenCount;
-    private List<Opponent> opponents = new ArrayList<>();
+    private boolean unreadFlag;
+    private MemberSimpleInfo inviter;
+    private List<MemberSimpleInfo> invitees = new ArrayList<>();
+
+    @QueryProjection
+    public JoinRoomDTO(Long chatRoomId, boolean unreadFlag, Member member) {
+        this.chatRoomId = chatRoomId;
+        this.unreadFlag = unreadFlag;
+        this.inviter = new MemberSimpleInfo(member);
+    }
 }

--- a/src/main/java/cloneproject/Instagram/dto/chat/MemberSimpleInfo.java
+++ b/src/main/java/cloneproject/Instagram/dto/chat/MemberSimpleInfo.java
@@ -6,13 +6,13 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-public class Opponent {
+public class MemberSimpleInfo {
 
     private String username;
     private String name;
     private String imageUrl;
 
-    public Opponent(Member member) {
+    public MemberSimpleInfo(Member member) {
         this.username = member.getUsername();
         this.name = member.getName();
         this.imageUrl = member.getImage().getImageUrl();

--- a/src/main/java/cloneproject/Instagram/dto/chat/MessageDTO.java
+++ b/src/main/java/cloneproject/Instagram/dto/chat/MessageDTO.java
@@ -2,6 +2,7 @@ package cloneproject.Instagram.dto.chat;
 
 import cloneproject.Instagram.entity.chat.Message;
 import cloneproject.Instagram.entity.chat.MessageType;
+import com.querydsl.core.annotations.QueryProjection;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -14,6 +15,7 @@ public class MessageDTO {
     private String content;
     private Long userId;
 
+    @QueryProjection
     public MessageDTO(Message message) {
         this.messageId = message.getId();
         this.messageType = message.getType();

--- a/src/main/java/cloneproject/Instagram/entity/chat/JoinRoom.java
+++ b/src/main/java/cloneproject/Instagram/entity/chat/JoinRoom.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
@@ -34,6 +35,10 @@ public class JoinRoom {
     @CreatedDate
     @Column(name = "join_room_created_date")
     private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    @Column(name = "join_room_last_message_date")
+    private LocalDateTime lastMessageDate;
 
     @Builder
     public JoinRoom(Room room, Member member) {

--- a/src/main/java/cloneproject/Instagram/entity/chat/Room.java
+++ b/src/main/java/cloneproject/Instagram/entity/chat/Room.java
@@ -6,6 +6,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Entity
@@ -21,6 +23,12 @@ public class Room {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    @OneToMany(mappedBy = "room")
+    private List<RoomUnreadMember> roomUnreadMembers = new ArrayList<>();
+
+    @OneToMany(mappedBy = "room")
+    private List<RoomMember> roomMembers = new ArrayList<>();
 
     public Room(Member member) {
         this.member = member;

--- a/src/main/java/cloneproject/Instagram/repository/chat/JoinRoomRepositoryQuerydslImpl.java
+++ b/src/main/java/cloneproject/Instagram/repository/chat/JoinRoomRepositoryQuerydslImpl.java
@@ -1,11 +1,25 @@
 package cloneproject.Instagram.repository.chat;
 
 import cloneproject.Instagram.dto.chat.JoinRoomDTO;
+import cloneproject.Instagram.dto.chat.MemberSimpleInfo;
+import cloneproject.Instagram.dto.chat.QJoinRoomDTO;
+import cloneproject.Instagram.entity.chat.*;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static cloneproject.Instagram.entity.chat.QJoinRoom.joinRoom;
+import static cloneproject.Instagram.entity.chat.QRoom.room;
+import static cloneproject.Instagram.entity.chat.QRoomMember.roomMember;
+import static cloneproject.Instagram.entity.chat.QRoomUnreadMember.roomUnreadMember;
+import static cloneproject.Instagram.entity.member.QMember.member;
 
 @RequiredArgsConstructor
 public class JoinRoomRepositoryQuerydslImpl implements JoinRoomRepositoryQuerydsl {
@@ -14,7 +28,44 @@ public class JoinRoomRepositoryQuerydslImpl implements JoinRoomRepositoryQueryds
 
     @Override
     public Page<JoinRoomDTO> findJoinRoomDTOPagebyMemberId(Long memberId, Pageable pageable) {
+        // TODO: WebSocket 이용 메시지 송/수신하는 시점부터 쿼리 확인 필요
+        final List<JoinRoomDTO> joinRoomDTOs = queryFactory
+                .select(new QJoinRoomDTO(
+                        joinRoom.room.id,
+                        JPAExpressions
+                                .selectFrom(roomUnreadMember)
+                                .where(roomUnreadMember.member.id.eq(memberId))
+                                .exists(),
+                        joinRoom.room.member
+                ))
+                .from(joinRoom)
+                .innerJoin(joinRoom.room, room)
+                .innerJoin(room.member, member)
+                .where(joinRoom.member.id.eq(memberId))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(joinRoom.lastMessageDate.desc()) // TODO: DB에 메시지 저장하는 시점부터 테스트 필요
+                .fetch();
 
-        return new PageImpl<>(null);
+        final List<Long> roomIds = joinRoomDTOs.stream()
+                .map(JoinRoomDTO::getChatRoomId)
+                .collect(Collectors.toList());
+
+        final List<RoomMember> roomMembers = queryFactory
+                .selectFrom(roomMember)
+                .where(roomMember.room.id.in(roomIds))
+                .join(roomMember.member, member).fetchJoin()
+                .fetch();
+        final Map<Long, List<RoomMember>> roomMemberMap = roomMembers.stream()
+                .collect(Collectors.groupingBy(r -> r.getRoom().getId()));
+
+        joinRoomDTOs.forEach(j -> j.setInvitees(
+                roomMemberMap.get(j.getChatRoomId())
+                        .stream()
+                        .map(r -> new MemberSimpleInfo(r.getMember()))
+                        .collect(Collectors.toList())));
+        // TODO: lastMessage 주입
+
+        return new PageImpl<>(joinRoomDTOs, pageable, joinRoomDTOs.size());
     }
 }

--- a/src/main/java/cloneproject/Instagram/repository/chat/RoomMemberRepository.java
+++ b/src/main/java/cloneproject/Instagram/repository/chat/RoomMemberRepository.java
@@ -3,5 +3,8 @@ package cloneproject.Instagram.repository.chat;
 import cloneproject.Instagram.entity.chat.RoomMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface RoomMemberRepository extends JpaRepository<RoomMember, Long> {
+    List<RoomMember> findAllByMemberId(Long memberId);
 }


### PR DESCRIPTION
## 변경 사항
### 채팅방 목록 페이징 조회 API 추가
- 1페이지당 채팅방 10개씩 조회
- {채팅방 PK, 최근 메시지 정보, 읽음 여부, 채팅방 개설자 정보, 채팅방 피초대자 정보}
    ![image](https://user-images.githubusercontent.com/68049320/152082534-45bced0d-2dfe-48c6-a107-4ae0751edea9.png)
    - 최근 메시지 정보는 WebSocket 연동 후, 추가할 예정
    - 현재 api 호출 시, 쿼리 총 2번 발생

### 채팅방 생성 API 로직 수정
- 해당 유저들로 이루어진 채팅방이 존재한다면, 채팅방을 따로 생성하지 않고 해당 채팅방 PK를 응답
    - ❗각 유저들이 속한 채팅방들을 하나씩 비교하는 방식 ->`O(Nⁿ)`
    - ❗단톡방에 속한 유저 수가 많을 수록, 각 유저들이 속한 채팅방 수가 많을 수록 비효율적

> [채팅 API 정리](https://lilac-freeze-4ae.notion.site/DM-d9e9ffb84504464e9f4c7c896543cef9)
## 해결한 이슈
- Resolve: #77 