### PR TITLE
WebSocket 설정, 채팅 메시지 전송 기능 추가

### DIFF
--- a/src/main/java/cloneproject/Instagram/config/WebSocketConfig.java
+++ b/src/main/java/cloneproject/Instagram/config/WebSocketConfig.java
@@ -1,0 +1,25 @@
+package cloneproject.Instagram.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/sub");
+        registry.setApplicationDestinationPrefixes("/pub");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws-connection")
+                .setAllowedOriginPatterns("*")
+                .withSockJS();
+    }
+}

--- a/src/main/java/cloneproject/Instagram/controller/ChatController.java
+++ b/src/main/java/cloneproject/Instagram/controller/ChatController.java
@@ -1,9 +1,6 @@
 package cloneproject.Instagram.controller;
 
-import cloneproject.Instagram.dto.chat.ChatRoomCreateResponse;
-import cloneproject.Instagram.dto.chat.ChatRoomInquireResponse;
-import cloneproject.Instagram.dto.chat.JoinRoomDTO;
-import cloneproject.Instagram.dto.chat.JoinRoomDeleteResponse;
+import cloneproject.Instagram.dto.chat.*;
 import cloneproject.Instagram.dto.result.ResultResponse;
 import cloneproject.Instagram.service.ChatService;
 import io.swagger.annotations.Api;
@@ -12,6 +9,8 @@ import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -26,6 +25,7 @@ import static cloneproject.Instagram.dto.result.ResultCode.*;
 public class ChatController {
 
     private final ChatService chatService;
+    private final SimpMessagingTemplate messagingTemplate;
 
     @ApiOperation(value = "채팅방 생성")
     @ApiImplicitParam(name = "username", value = "상대방 username", example = "dlwlrma1", required = true)
@@ -61,5 +61,11 @@ public class ChatController {
         final Page<JoinRoomDTO> response = chatService.getJoinRooms(page);
 
         return ResponseEntity.ok(ResultResponse.of(GET_JOIN_ROOMS_SUCCESS, response));
+    }
+
+    @MessageMapping("/messages")
+    public void chat(@Validated MessageRequest request) {
+        chatService.sendMessage(request);
+        messagingTemplate.convertAndSend("/sub/rooms/" + request.getRoomId(), request);
     }
 }

--- a/src/main/java/cloneproject/Instagram/dto/chat/MessageDTO.java
+++ b/src/main/java/cloneproject/Instagram/dto/chat/MessageDTO.java
@@ -6,20 +6,24 @@ import com.querydsl.core.annotations.QueryProjection;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Getter
 @NoArgsConstructor
 public class MessageDTO {
 
     private Long messageId;
     private MessageType messageType;
+    private LocalDateTime messageDate;
+    private Long senderId;
     private String content;
-    private Long userId;
 
     @QueryProjection
     public MessageDTO(Message message) {
         this.messageId = message.getId();
         this.messageType = message.getType();
         this.content = message.getContent();
-        this.userId = message.getMember().getId();
+        this.senderId = message.getMember().getId();
+        this.messageDate = message.getCreatedDate();
     }
 }

--- a/src/main/java/cloneproject/Instagram/dto/chat/MessageRequest.java
+++ b/src/main/java/cloneproject/Instagram/dto/chat/MessageRequest.java
@@ -1,0 +1,25 @@
+package cloneproject.Instagram.dto.chat;
+
+import cloneproject.Instagram.entity.chat.MessageType;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+
+@Getter
+@NoArgsConstructor
+public class MessageRequest {
+
+    @NotNull(message = "채팅방 PK는 필수입니다.")
+    private Long roomId;
+
+    @NotNull(message = "메시지를 보내는 회원 PK는 필수입니다.")
+    private Long senderId;
+
+    @NotEmpty(message = "채팅 메시지는 필수입니다.")
+    private String content;
+
+    @NotNull(message = "채팅 메시지 타입은 필수입니다.")
+    private MessageType messageType;
+}

--- a/src/main/java/cloneproject/Instagram/entity/chat/JoinRoom.java
+++ b/src/main/java/cloneproject/Instagram/entity/chat/JoinRoom.java
@@ -45,4 +45,8 @@ public class JoinRoom {
         this.room = room;
         this.member = member;
     }
+
+    public void update() {
+        this.lastMessageDate = LocalDateTime.now();
+    }
 }

--- a/src/main/java/cloneproject/Instagram/repository/chat/RoomMemberRepository.java
+++ b/src/main/java/cloneproject/Instagram/repository/chat/RoomMemberRepository.java
@@ -7,4 +7,5 @@ import java.util.List;
 
 public interface RoomMemberRepository extends JpaRepository<RoomMember, Long> {
     List<RoomMember> findAllByMemberId(Long memberId);
+    List<RoomMember> findAllByRoomId(Long roomId);
 }


### PR DESCRIPTION
## 변경 사항
### WebSocket 설정
- 클라이언트에서 다음과 같이 WebSocket 연결
```javascript
function connect() {
    var socket = new WebSocket('/ws-connection');
    stompClient = Stomp.over(socket);
    stompClient.connect({}, function () {
        setConnected(true);
        stompClient.subscribe('/sub/rooms/5', function (greeting) {
            console.log(greeting.body);
        });
    });
}
```
- 모든 origin에 연결을 허용함
- 클라이언트의 브라우저에서 WebSocket으로 프로토콜 업그레이드 지원을 하지 않는 경우, fallback 옵션을 추가하기 위해 `withSockJS()` 옵션 추가
- WebSocket 지원 브라우저    
    ![image](https://user-images.githubusercontent.com/68049320/152144039-bad9ec80-4abc-4800-a047-e0c0c4ce9fac.png)
- SockJS 관련 자료
    ![image](https://user-images.githubusercontent.com/68049320/152144282-684039f2-72cf-410f-a942-816659e96518.png)

### 채팅 메시지 전송 기능
- WebSocket STOMP 설정
    ![image](https://user-images.githubusercontent.com/68049320/152144504-6d487c6e-0eb8-41e4-817c-c8c2fb06dfb1.png)
- ChatController MessageMapping
    ![image](https://user-images.githubusercontent.com/68049320/152144454-2f7a6bba-fa20-4513-bf9f-971c508b622a.png)
- 클라이언트가 메시지를 보낼 때, `/pub/messages` 경로로 전달
- 메시지를 받을 때는 `/sub/rooms/{roomId}`를 구독하고 있어야 함
- 메시지 전달 시, 해당 방의 모든 참여자를 RoomUnreadMember 엔티티에 추가하여 안읽음 상태로 전환
    - 또한, JoinRoom 엔티티에 모두 추가하되, 이미 추가된 유저는 lastMessageDate만 수정
- 클라이언트 메시지 전송 예시
```javascript
function sendMessage() {
    stompClient.send("/pub/messages", {}, JSON.stringify({
        'message': $("#name").val(),
        'senderId': 7,
        'receiverId': 14,
        'roomId': 5
    }));
}
```
## 해결한 이슈
- Resolve: #81 