### PR TITLE
채팅방 메시지 목록 페이징 조회 API 추가

### DIFF
--- a/src/main/java/cloneproject/Instagram/controller/ChatController.java
+++ b/src/main/java/cloneproject/Instagram/controller/ChatController.java
@@ -52,13 +52,23 @@ public class ChatController {
         return ResponseEntity.ok(ResultResponse.of(DELETE_JOIN_ROOM_SUCCESS, response));
     }
 
-    @ApiOperation(value = "채팅방 목록 페이징 조회", notes = "1페이지당 10개씩 조회할 수 있습니다.")
+    @ApiOperation(value = "채팅방 목록 페이징 조회", notes = "페이지당 10개씩 조회할 수 있습니다.")
     @GetMapping("/chat/rooms")
     public ResponseEntity<ResultResponse> getJoinRooms(
             @Validated @NotNull(message = "페이지는 필수입니다.") @RequestParam Integer page) {
         final Page<JoinRoomDTO> response = chatService.getJoinRooms(page);
 
         return ResponseEntity.ok(ResultResponse.of(GET_JOIN_ROOMS_SUCCESS, response));
+    }
+
+    @ApiOperation(value = "채팅방 메시지 목록 페이징 조회", notes = "페이지당 10개씩 조회할 수 있습니다.")
+    @GetMapping("/chat/rooms/{roomId}/messages")
+    public ResponseEntity<ResultResponse> getChatMessages(
+            @NotNull(message = "채팅방 PK는 필수입니다.") @PathVariable Long roomId,
+            @NotNull(message = "페이지는 필수입니다.") @RequestParam Integer page) {
+        final Page<MessageDTO> response = chatService.getChatMessages(roomId, page);
+
+        return ResponseEntity.ok(ResultResponse.of(GET_CHAT_MESSAGES_SUCCESS, response));
     }
 
     @MessageMapping("/messages")

--- a/src/main/java/cloneproject/Instagram/dto/chat/MessageDTO.java
+++ b/src/main/java/cloneproject/Instagram/dto/chat/MessageDTO.java
@@ -2,6 +2,7 @@ package cloneproject.Instagram.dto.chat;
 
 import cloneproject.Instagram.entity.chat.Message;
 import cloneproject.Instagram.entity.chat.MessageType;
+import com.querydsl.core.annotations.QueryProjection;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -20,6 +21,7 @@ public class MessageDTO {
     private MessageType messageType;
     private LocalDateTime messageDate;
 
+    @QueryProjection
     public MessageDTO(Message message) {
         this.roomId = message.getRoom().getId();
         this.messageId = message.getId();

--- a/src/main/java/cloneproject/Instagram/dto/result/ResultCode.java
+++ b/src/main/java/cloneproject/Instagram/dto/result/ResultCode.java
@@ -65,6 +65,7 @@ public enum ResultCode {
     INQUIRE_CHAT_ROOM_SUCCESS(200, "C002", "채팅방 조회 성공"),
     DELETE_JOIN_ROOM_SUCCESS(200, "C003", "참여 중인 채팅방 삭제 성공"),
     GET_JOIN_ROOMS_SUCCESS(200, "C004", "채팅방 목록 조회 성공"),
+    GET_CHAT_MESSAGES_SUCCESS(200, "C005", "채팅 메시지 목록 조회 성공"),
     ;
 
     private int status;

--- a/src/main/java/cloneproject/Instagram/repository/chat/JoinRoomRepositoryQuerydslImpl.java
+++ b/src/main/java/cloneproject/Instagram/repository/chat/JoinRoomRepositoryQuerydslImpl.java
@@ -67,7 +67,6 @@ public class JoinRoomRepositoryQuerydslImpl implements JoinRoomRepositoryQueryds
                         .stream()
                         .map(r -> new MemberSimpleInfo(r.getMember()))
                         .collect(Collectors.toList())));
-        // TODO: lastMessage 주입
 
         return new PageImpl<>(joinRoomDTOs, pageable, joinRoomDTOs.size());
     }

--- a/src/main/java/cloneproject/Instagram/repository/chat/MessageRepository.java
+++ b/src/main/java/cloneproject/Instagram/repository/chat/MessageRepository.java
@@ -3,5 +3,5 @@ package cloneproject.Instagram.repository.chat;
 import cloneproject.Instagram.entity.chat.Message;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MessageRepository extends JpaRepository<Message, Long> {
+public interface MessageRepository extends JpaRepository<Message, Long>, MessageRepositoryQuerydsl {
 }

--- a/src/main/java/cloneproject/Instagram/repository/chat/MessageRepositoryQuerydsl.java
+++ b/src/main/java/cloneproject/Instagram/repository/chat/MessageRepositoryQuerydsl.java
@@ -1,0 +1,10 @@
+package cloneproject.Instagram.repository.chat;
+
+import cloneproject.Instagram.dto.chat.MessageDTO;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface MessageRepositoryQuerydsl {
+
+    Page<MessageDTO> findMessageDTOPageByMemberIdAndRoomId(Long memberId, Long roomId, Pageable pageable);
+}

--- a/src/main/java/cloneproject/Instagram/repository/chat/MessageRepositoryQuerydslImpl.java
+++ b/src/main/java/cloneproject/Instagram/repository/chat/MessageRepositoryQuerydslImpl.java
@@ -1,0 +1,55 @@
+package cloneproject.Instagram.repository.chat;
+
+import cloneproject.Instagram.dto.chat.MessageDTO;
+import cloneproject.Instagram.dto.chat.QMessageDTO;
+import cloneproject.Instagram.entity.chat.JoinRoom;
+import cloneproject.Instagram.exception.JoinRoomNotFoundException;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+import static cloneproject.Instagram.entity.chat.QJoinRoom.joinRoom;
+import static cloneproject.Instagram.entity.chat.QMessage.message;
+import static cloneproject.Instagram.entity.chat.QRoom.room;
+import static cloneproject.Instagram.entity.member.QMember.member;
+
+@RequiredArgsConstructor
+public class MessageRepositoryQuerydslImpl implements MessageRepositoryQuerydsl {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<MessageDTO> findMessageDTOPageByMemberIdAndRoomId(Long memberId, Long roomId, Pageable pageable) {
+        final JoinRoom findJoinRoom = queryFactory
+                .selectFrom(joinRoom)
+                .where(joinRoom.member.id.eq(memberId).and(joinRoom.room.id.eq(roomId)))
+                .innerJoin(joinRoom.room, room)
+                .innerJoin(joinRoom.member, member)
+                .fetchOne();
+
+        if (findJoinRoom == null)
+            throw new JoinRoomNotFoundException();
+
+        final List<MessageDTO> messageDTOs = queryFactory
+                .select(new QMessageDTO(message))
+                .from(message)
+                .innerJoin(message.member, member)
+                .innerJoin(message.room, room)
+                .where(
+                        message.member.id.eq(findJoinRoom.getMember().getId()).and(
+                                message.room.id.eq(findJoinRoom.getRoom().getId()).and(
+                                        message.createdDate.after(findJoinRoom.getCreatedDate())
+                                )
+                        ))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(message.createdDate.desc())
+                .fetch();
+
+        return new PageImpl<>(messageDTOs, pageable, messageDTOs.size());
+    }
+}

--- a/src/main/java/cloneproject/Instagram/service/ChatService.java
+++ b/src/main/java/cloneproject/Instagram/service/ChatService.java
@@ -142,4 +142,12 @@ public class ChatService {
             }
         });
     }
+
+    public Page<MessageDTO> getChatMessages(Long roomId, Integer page) {
+        final Long memberId = Long.valueOf(SecurityContextHolder.getContext().getAuthentication().getName());
+
+        page = (page == 0 ? 0 : page - 1);
+        Pageable pageable = PageRequest.of(page, 10);
+        return messageRepository.findMessageDTOPageByMemberIdAndRoomId(memberId, roomId, pageable);
+    }
 }


### PR DESCRIPTION
## 변경 사항
### 채팅방 메시지 목록 페이징 조회 API 
- 본인이 해당 채팅방에 참가한 날짜 이후의 메시지들을 최신순으로 정렬하여 10개씩 페이징 조회
- 유저끼리 추가로 메시지를 주고 받은 후에 본 API를 호출하면 페이징이 꼬이는 현상 발생
    - 프론트단에서 새로운 메시지 수 + 조회한 메시지 수를 카운팅하여 본 API를 호출할 때 페이지를 새로 계산하여 호출해야 함.

## 해결 이슈
- Resolve: #87 