### PR TITLE
댓글 작성/삭제/조회 API 추가

### DIFF
--- a/src/main/java/cloneproject/Instagram/config/WebSecurityConfig.java
+++ b/src/main/java/cloneproject/Instagram/config/WebSecurityConfig.java
@@ -80,8 +80,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter{
                 .antMatchers("/login", "/accounts", "/swagger-resources/**", "/swagger-ui/**").permitAll()
 
                 //게시물
-                .antMatchers("/posts", "/posts/**").hasAuthority("ROLE_USER")
-                .antMatchers("/posts/like", "/posts/recent", "/posts/save").hasAuthority("ROLE_USER")
+                .antMatchers("/posts", "/posts/**", "/comments/**").hasAuthority("ROLE_USER")
 
                 // 유저 포스트
                 .antMatchers("/accounts/**/posts", "/accounts/**/posts/recent", "/accounts/**/posts/tagged", "/accounts/**/posts/tagged/recent").permitAll()
@@ -99,7 +98,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter{
                 .antMatchers("/**/block").hasAuthority("ROLE_USER")
 
                 // DM
-                .antMatchers("/chat/rooms", "/chat/rooms/**").hasAuthority("ROLE_USER");
+                .antMatchers("/chat/rooms/**").hasAuthority("ROLE_USER");
 
     }
 

--- a/src/main/java/cloneproject/Instagram/dto/comment/CommentCreateRequest.java
+++ b/src/main/java/cloneproject/Instagram/dto/comment/CommentCreateRequest.java
@@ -1,0 +1,28 @@
+package cloneproject.Instagram.dto.comment;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+@ApiModel(description = "게시물 댓글 작성 요청 데이터 모델")
+@Getter
+@NoArgsConstructor
+public class CommentCreateRequest {
+
+    @ApiModelProperty(value = "게시물 PK", example = "1", required = true)
+    @NotNull(message = "게시물 PK는 필수입니다.")
+    private Long postId;
+
+    @ApiModelProperty(value = "댓글 부모 PK", example = "1", required = true)
+    private Long parentId;
+
+    @ApiModelProperty(value = "댓글 내용", example = "댓글", required = true)
+    @NotBlank(message = "댓글 내용은 필수입니다.")
+    @Length(max = 100, message = "최대 100자까지 입력 가능합니다.")
+    private String content;
+}

--- a/src/main/java/cloneproject/Instagram/dto/comment/CommentCreateResponse.java
+++ b/src/main/java/cloneproject/Instagram/dto/comment/CommentCreateResponse.java
@@ -1,0 +1,13 @@
+package cloneproject.Instagram.dto.comment;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CommentCreateResponse {
+
+    private Long commentId;
+}

--- a/src/main/java/cloneproject/Instagram/dto/comment/CommentDTO.java
+++ b/src/main/java/cloneproject/Instagram/dto/comment/CommentDTO.java
@@ -1,5 +1,7 @@
 package cloneproject.Instagram.dto.comment;
 
+import cloneproject.Instagram.dto.member.MenuMemberDTO;
+import cloneproject.Instagram.entity.member.Member;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.Data;
@@ -14,7 +16,7 @@ public class CommentDTO {
     @JsonIgnore
     private Long postId;
     private Long id;
-    private String username;
+    private MenuMemberDTO member;
     private String content;
     private LocalDateTime uploadDate;
     private int commentLikesCount;
@@ -22,10 +24,10 @@ public class CommentDTO {
     private int repliesCount;
 
     @QueryProjection
-    public CommentDTO(Long postId, Long id, String username, String content, LocalDateTime uploadDate, int commentLikesCount, boolean commentLikeFlag, int repliesCount) {
+    public CommentDTO(Long postId, Long id, Member member, String content, LocalDateTime uploadDate, int commentLikesCount, boolean commentLikeFlag, int repliesCount) {
         this.postId = postId;
         this.id = id;
-        this.username = username;
+        this.member = new MenuMemberDTO(member);
         this.content = content;
         this.uploadDate = uploadDate;
         this.commentLikesCount = commentLikesCount;

--- a/src/main/java/cloneproject/Instagram/dto/error/ErrorCode.java
+++ b/src/main/java/cloneproject/Instagram/dto/error/ErrorCode.java
@@ -52,6 +52,8 @@ public enum ErrorCode {
     POST_LIKE_ALREADY_EXIST(400, "P011", "해당 게시물에 이미 좋아요를 누른 회원입니다."),
     BOOKMARK_ALREADY_EXIST(400, "P012", "이미 해당 게시물을 저장하였습니다."),
     BOOKMARK_NOT_FOUND(400, "P013", "아직 해당 게시물을 저장하지 않았습니다."),
+    COMMENT_NOT_FOUND(400, "P014", "존재하지 않는 댓글입니다."),
+    COMMENT_CANT_DELETE(400, "P015", "타인이 작성한 댓글은 삭제할 수 없습니다."),
 
     // Chat
     CHAT_ROOM_NOT_FOUND(400, "C001", "존재하지 않는 채팅방입니다."),

--- a/src/main/java/cloneproject/Instagram/dto/member/MenuMemberDTO.java
+++ b/src/main/java/cloneproject/Instagram/dto/member/MenuMemberDTO.java
@@ -1,27 +1,36 @@
 package cloneproject.Instagram.dto.member;
 
+import cloneproject.Instagram.entity.member.Member;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @ApiModel("상단 메뉴 유저 프로필 모델")
 @Getter
 @Builder
 @AllArgsConstructor
+@NoArgsConstructor
 public class MenuMemberDTO {
 
     @ApiModelProperty(value = "DB상 유저의 ID(PK)", example = "1")
-    Long memberId;
+    private Long memberId;
 
     @ApiModelProperty(value = "유저네임", example = "dlwlrma")
-    String memberUsername;
+    private String memberUsername;
 
     @ApiModelProperty(value = "프로필사진 URL", example = "https://drive.google.com/file/d/1Gu0DcGCJNs4Vo0bz2U9U6v01d_VwKijs/view?usp=sharing")
-    String memberImageUrl;
+    private String memberImageUrl;
 
     @ApiModelProperty(value = "이름", example = "이지금")
-    String memberName;
-    
+    private String memberName;
+
+    public MenuMemberDTO(Member member) {
+        this.memberId = member.getId();
+        this.memberUsername = member.getUsername();
+        this.memberImageUrl = member.getImage().getImageUrl();
+        this.memberName = member.getName();
+    }
 }

--- a/src/main/java/cloneproject/Instagram/dto/result/ResultCode.java
+++ b/src/main/java/cloneproject/Instagram/dto/result/ResultCode.java
@@ -59,6 +59,10 @@ public enum ResultCode {
     UNLIKE_POST_SUCCESS(200, "P009", "게시물 좋아요 취소 성공"),
     SAVE_POST_SUCCESS(200, "P010", "게시물 저장 성공"),
     UNSAVE_POST_SUCCESS(200, "P011", "게시물 저장 취소 성공"),
+    CREATE_COMMENT_SUCCESS(200, "P012", "게시물 댓글 생성 성공"),
+    DELETE_COMMENT_SUCCESS(200, "P012", "게시물 댓글 삭제 성공"),
+    GET_COMMENT_PAGE_SUCCESS(200, "P013", "게시물 댓글 페이지 조회 성공"),
+    GET_REPLY_PAGE_SUCCESS(200, "P014", "게시물 답글 페이지 조회 성공"),
 
     // CHAT
     CREATE_CHAT_ROOM_SUCCESS(200, "C001", "채팅방 생성 성공"),

--- a/src/main/java/cloneproject/Instagram/exception/CommentCantDeleteException.java
+++ b/src/main/java/cloneproject/Instagram/exception/CommentCantDeleteException.java
@@ -1,0 +1,10 @@
+package cloneproject.Instagram.exception;
+
+import cloneproject.Instagram.dto.error.ErrorCode;
+
+public class CommentCantDeleteException extends BusinessException {
+
+    public CommentCantDeleteException() {
+        super(ErrorCode.COMMENT_CANT_DELETE);
+    }
+}

--- a/src/main/java/cloneproject/Instagram/exception/CommentNotFoundException.java
+++ b/src/main/java/cloneproject/Instagram/exception/CommentNotFoundException.java
@@ -1,0 +1,10 @@
+package cloneproject.Instagram.exception;
+
+import cloneproject.Instagram.dto.error.ErrorCode;
+
+public class CommentNotFoundException extends BusinessException {
+
+    public CommentNotFoundException() {
+        super(ErrorCode.COMMENT_NOT_FOUND);
+    }
+}

--- a/src/main/java/cloneproject/Instagram/repository/chat/JoinRoomRepository.java
+++ b/src/main/java/cloneproject/Instagram/repository/chat/JoinRoomRepository.java
@@ -11,6 +11,6 @@ import java.util.Optional;
 public interface JoinRoomRepository extends JpaRepository<JoinRoom, Long>, JoinRoomRepositoryQuerydsl {
     Optional<JoinRoom> findByMemberIdAndRoomId(Long memberId, Long roomId);
     void deleteByMemberIdAndRoomId(Long memberId, Long roomId);
-    @Query(value = "select j from JoinRoom j where j.room.id = :id join fetch f.member", nativeQuery = true)
+    @Query(value = "select j from JoinRoom j join fetch j.member where j.room.id = :id")
     List<JoinRoom> findAllByRoomId(@Param("id") Long id);
 }

--- a/src/main/java/cloneproject/Instagram/repository/post/CommentRepository.java
+++ b/src/main/java/cloneproject/Instagram/repository/post/CommentRepository.java
@@ -1,0 +1,14 @@
+package cloneproject.Instagram.repository.post;
+
+import cloneproject.Instagram.entity.comment.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface CommentRepository extends JpaRepository<Comment, Long>, CommentRepositoryQuerydsl{
+
+    @Query(value = "select p from Comment p join fetch p.member where p.id = :id")
+    Optional<Comment> findWithMemberById(@Param("id") Long id);
+}

--- a/src/main/java/cloneproject/Instagram/repository/post/CommentRepositoryQuerydsl.java
+++ b/src/main/java/cloneproject/Instagram/repository/post/CommentRepositoryQuerydsl.java
@@ -1,0 +1,11 @@
+package cloneproject.Instagram.repository.post;
+
+import cloneproject.Instagram.dto.comment.CommentDTO;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CommentRepositoryQuerydsl {
+
+    Page<CommentDTO> findCommentDtoPage(Long memberId, Long postId, Pageable pageable);
+    Page<CommentDTO> findReplyDtoPage(Long memberId, Long commentId, Pageable pageable);
+}

--- a/src/main/java/cloneproject/Instagram/repository/post/CommentRepositoryQuerydslImpl.java
+++ b/src/main/java/cloneproject/Instagram/repository/post/CommentRepositoryQuerydslImpl.java
@@ -1,0 +1,76 @@
+package cloneproject.Instagram.repository.post;
+
+import cloneproject.Instagram.dto.comment.CommentDTO;
+import cloneproject.Instagram.dto.comment.QCommentDTO;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+import static cloneproject.Instagram.entity.comment.QComment.comment;
+import static cloneproject.Instagram.entity.comment.QCommentLike.commentLike;
+import static cloneproject.Instagram.entity.member.QMember.member;
+
+@RequiredArgsConstructor
+public class CommentRepositoryQuerydslImpl implements CommentRepositoryQuerydsl {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<CommentDTO> findCommentDtoPage(Long memberId, Long postId, Pageable pageable) {
+        final List<CommentDTO> commentDTOs = queryFactory
+                .select(new QCommentDTO(
+                        comment.post.id,
+                        comment.id,
+                        comment.member,
+                        comment.content,
+                        comment.uploadDate,
+                        comment.commentLikes.size(),
+                        JPAExpressions
+                                .selectFrom(commentLike)
+                                .where(commentLike.comment.eq(comment).and(commentLike.member.id.eq(memberId)))
+                                .exists(),
+                        comment.children.size()
+                ))
+                .from(comment)
+                .where(comment.post.id.eq(postId).and(comment.id.eq(comment.parent.id)))
+                .innerJoin(comment.member, member)
+                .orderBy(comment.id.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        return new PageImpl<>(commentDTOs, pageable, commentDTOs.size());
+    }
+
+    @Override
+    public Page<CommentDTO> findReplyDtoPage(Long memberId, Long commentId, Pageable pageable) {
+        final List<CommentDTO> commentDTOs = queryFactory
+                .select(new QCommentDTO(
+                        comment.post.id,
+                        comment.id,
+                        comment.member,
+                        comment.content,
+                        comment.uploadDate,
+                        comment.commentLikes.size(),
+                        JPAExpressions
+                                .selectFrom(commentLike)
+                                .where(commentLike.comment.eq(comment).and(commentLike.member.id.eq(memberId)))
+                                .exists(),
+                        comment.children.size()
+                ))
+                .from(comment)
+                .where(comment.parent.id.eq(commentId))
+                .innerJoin(comment.member, member)
+                .orderBy(comment.id.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        return new PageImpl<>(commentDTOs, pageable, commentDTOs.size());
+    }
+}

--- a/src/main/java/cloneproject/Instagram/repository/post/PostRepositoryQuerydslImpl.java
+++ b/src/main/java/cloneproject/Instagram/repository/post/PostRepositoryQuerydslImpl.java
@@ -303,7 +303,7 @@ public class PostRepositoryQuerydslImpl implements PostRepositoryQuerydsl {
                 .select(new QCommentDTO(
                         comment.post.id,
                         comment.id,
-                        comment.member.username,
+                        comment.member,
                         comment.content,
                         comment.uploadDate,
                         comment.commentLikes.size(),
@@ -314,7 +314,8 @@ public class PostRepositoryQuerydslImpl implements PostRepositoryQuerydsl {
                         comment.children.size()
                 ))
                 .from(comment)
-                .where(comment.post.id.eq(postId))
+                .where(comment.post.id.eq(postId).and(comment.id.eq(comment.parent.id)))
+                .innerJoin(comment.member, QMember.member)
                 .orderBy(comment.id.desc())
                 .limit(10)
                 .fetch();


### PR DESCRIPTION
## 변경 사항
### 댓글 작성 API 
- 댓글인 경우 `parentId = 0`, 답글인 경우 `parentId = {commentId}` 으로 요청
### 댓글 삭제 API 
### 댓글 페이징 조회 API 
- 10개씩 페이징 조회
- 게시물 조회 시, 최근 댓글 10개를 같이 응답해주므로 2페이지부터 요청
- 댓글만 조회 가능 -> 답글은 아래 API를 호출해야함
### 답글 페이징 조회 API 
- 10개씩 페이징 조회

## 해결 이슈
- Resolve: #89 