### PR TITLE
MemberService 테스트 작성

### DIFF
--- a/src/main/java/cloneproject/Instagram/controller/MemberAuthController.java
+++ b/src/main/java/cloneproject/Instagram/controller/MemberAuthController.java
@@ -25,13 +25,16 @@ import cloneproject.Instagram.dto.member.SendConfirmationEmailRequest;
 import cloneproject.Instagram.dto.member.UpdatePasswordRequest;
 import cloneproject.Instagram.dto.result.ResultCode;
 import cloneproject.Instagram.dto.result.ResultResponse;
+import cloneproject.Instagram.exception.InvalidJwtException;
 import cloneproject.Instagram.service.MemberAuthService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Api(tags = "멤버 인증 API")
 @RestController
 @RequiredArgsConstructor
@@ -116,11 +119,13 @@ public class MemberAuthController {
     @ApiImplicitParam(name = "Authorization", value = "불필요", required = false, example = " ")
     @PostMapping(value = "/reissue")
     public ResponseEntity<ResultResponse> reissue(
-                                @CookieValue(value="refreshToken", required = true)
+                                @CookieValue(value="refreshToken", required = false)
                                 Cookie refreshCookie, HttpServletResponse response
                             ) {
+        if(refreshCookie == null){
+            throw new InvalidJwtException();
+        }
         JwtDto jwt = memberAuthService.reisuue(refreshCookie.getValue());
-
         Cookie cookie = new Cookie("refreshToken", jwt.getRefreshToken());
 
         cookie.setMaxAge(REFRESH_TOKEN_EXPIRES);

--- a/src/main/java/cloneproject/Instagram/dto/error/ErrorCode.java
+++ b/src/main/java/cloneproject/Instagram/dto/error/ErrorCode.java
@@ -14,18 +14,18 @@ public enum ErrorCode {
     INVALID_TYPE_VALUE(400, "U004", "입력 타입이 유효하지 않습니다."),
 
     // Member
-    MEMBER_DOES_NOT_EXIST(401, "M001", "존재 하지 않는 유저입니다."),
-    USERNAME_ALREADY_EXISTS(401, "M002", "이미 존재하는 사용자 이름입니다."),
+    MEMBER_DOES_NOT_EXIST(400, "M001", "존재 하지 않는 유저입니다."),
+    USERNAME_ALREADY_EXISTS(400, "M002", "이미 존재하는 사용자 이름입니다."),
     NEED_LOGIN(401, "M003", "로그인이 필요한 화면입니다."),
     NO_AUTHORITY(403, "M004", "권한이 없습니다."),
     ACCOUNT_DOES_NOT_MATCH(401, "M005", "계정정보가 일치하지 않습니다."),
     UPLOAD_PROFILE_IMAGE_FAIL(400, "M006", "회원 이미지를 업로드 하는 중 실패했습니다."),
     
     // FOLLOW
-    ALREADY_FOLLOW(401, "F001", "이미 팔로우한 유저입니다."),
-    CANT_UNFOLLOW(401, "F002", "팔로우하지 않을 유저는 언팔로우 할 수 없습니다"),
-    CANT_FOLLOW_MYSELF(401, "F003", "자기자신을 팔로우 할 수 없습니다"),
-    CANT_UNFOLLOW_MYSELF(401, "F004", "자기자신을 언팔로우 할 수 없습니다"),
+    ALREADY_FOLLOW(400, "F001", "이미 팔로우한 유저입니다."),
+    CANT_UNFOLLOW(400, "F002", "팔로우하지 않을 유저는 언팔로우 할 수 없습니다"),
+    CANT_FOLLOW_MYSELF(400, "F003", "자기자신을 팔로우 할 수 없습니다"),
+    CANT_UNFOLLOW_MYSELF(400, "F004", "자기자신을 언팔로우 할 수 없습니다"),
 
     // BLOCK
     ALREADY_BLOCK(400, "B001", "이미 차단한 유저입니다."),
@@ -58,7 +58,7 @@ public enum ErrorCode {
     JOIN_ROOM_NOT_FOUND(400, "C002", "해당 채팅방에 참여하지 않은 회원입니다."),
 
     // FILE
-    CANT_CONVERT_FILE(401, "FI001", "파일을 변환할수 없습니다");
+    CANT_CONVERT_FILE(500, "FI001", "파일을 변환할수 없습니다");
     ;
 
     private int status;

--- a/src/test/java/cloneproject/Instagram/WithMockCustomUser.java
+++ b/src/test/java/cloneproject/Instagram/WithMockCustomUser.java
@@ -1,0 +1,12 @@
+package cloneproject.Instagram;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockCustomUserSecurityContextFactory.class)
+public @interface WithMockCustomUser {
+    String first() default "1";
+}

--- a/src/test/java/cloneproject/Instagram/WithMockCustomUserSecurityContextFactory.java
+++ b/src/test/java/cloneproject/Instagram/WithMockCustomUserSecurityContextFactory.java
@@ -1,0 +1,30 @@
+package cloneproject.Instagram;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+public class WithMockCustomUserSecurityContextFactory implements WithSecurityContextFactory<WithMockCustomUser> {
+    @Override
+    public SecurityContext createSecurityContext(WithMockCustomUser customUser) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+
+            
+        Collection<GrantedAuthority> authorities = new ArrayList<GrantedAuthority>();
+        authorities.add(new SimpleGrantedAuthority("ROLE_USER"));
+
+        UserDetails principal = new User(customUser.first(), "", authorities);
+        Authentication auth = new UsernamePasswordAuthenticationToken(principal, "", authorities);
+        context.setAuthentication(auth);
+        return context;
+    }
+}

--- a/src/test/java/cloneproject/Instagram/repository/MemberRepositoryTest.java
+++ b/src/test/java/cloneproject/Instagram/repository/MemberRepositoryTest.java
@@ -1,0 +1,63 @@
+package cloneproject.Instagram.repository;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import cloneproject.Instagram.entity.member.Member;
+
+@DataJpaTest
+@ExtendWith(SpringExtension.class)
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+@DisplayName("Member Repository")
+public class MemberRepositoryTest {
+    
+
+    @Autowired
+    private MemberRepository memberRepository;
+    
+    @Nested
+    @DisplayName("save 메서드는")
+    class Describe_save{
+
+        // TODO querydsl 테스트 추가
+        @BeforeEach
+        void prepare(){
+            memberRepository.deleteAll();
+        }
+
+        @Nested
+        @DisplayName("멤버 객체가 주어지면")
+        class Context_given_member{
+            final Member givenMember =  Member.builder()
+                                            .username("testusername")
+                                            .name("testname")
+                                            .password("1234")
+                                            .email("123@gmail.com")
+                                            .build();
+            
+            @Test
+            @DisplayName("주어진 멤버를 저장한 뒤, 저장된 멤버를 반환한다.")
+            void it_save_member_and_return_saved_member(){
+                assertNull(givenMember.getId(), "저장전 id는 없어야 한다");
+                final Member savedMember = memberRepository.save(givenMember);
+                
+                assertNotNull(savedMember.getId(), "저장후 id는 존재해야 한다");
+                assertEquals(savedMember.getUsername(), givenMember.getUsername(), "저장된 정보가 일치해야 한다");
+            }
+        }
+
+    }
+    
+}

--- a/src/test/java/cloneproject/Instagram/service/MemberServiceTest.java
+++ b/src/test/java/cloneproject/Instagram/service/MemberServiceTest.java
@@ -10,9 +10,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import cloneproject.Instagram.WithMockCustomUser;
 import cloneproject.Instagram.dto.member.EditProfileRequest;
@@ -25,7 +27,7 @@ import cloneproject.Instagram.repository.EmailCodeRedisRepository;
 import cloneproject.Instagram.repository.MemberRepository;
 import cloneproject.Instagram.util.ImageUtil;
 
-@SpringBootTest
+@ExtendWith(SpringExtension.class)
 @DisplayName("Member Service")
 public class MemberServiceTest {
     

--- a/src/test/java/cloneproject/Instagram/service/MemberServiceTest.java
+++ b/src/test/java/cloneproject/Instagram/service/MemberServiceTest.java
@@ -1,0 +1,221 @@
+package cloneproject.Instagram.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import cloneproject.Instagram.WithMockCustomUser;
+import cloneproject.Instagram.dto.member.EditProfileRequest;
+import cloneproject.Instagram.dto.member.MiniProfileResponse;
+import cloneproject.Instagram.dto.member.UserProfileResponse;
+import cloneproject.Instagram.entity.member.Member;
+import cloneproject.Instagram.exception.MemberDoesNotExistException;
+import cloneproject.Instagram.exception.UseridAlreadyExistException;
+import cloneproject.Instagram.repository.EmailCodeRedisRepository;
+import cloneproject.Instagram.repository.MemberRepository;
+import cloneproject.Instagram.util.ImageUtil;
+
+@SpringBootTest
+@DisplayName("Member Service")
+public class MemberServiceTest {
+    
+    @InjectMocks
+    private MemberService memberService;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private EmailCodeRedisRepository emailCodeRedisRepository;
+
+    @BeforeEach
+    void setRepostiory(){
+        Member member = Member.builder()
+                            .username("dlwlrma")
+                            .name("이지금")
+                            .email("aaa@gmail.com")
+                            .password("1234")
+                            .build();
+
+        when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
+        when(memberRepository.findByUsername("dlwlrma")).thenReturn(Optional.of(member));
+
+    }
+    @Nested
+    @DisplayName("유저 상단 프로필 조회 API는")
+    class Describe_menu_member_profile_api{
+        
+        @Nested
+        @DisplayName("로그인 한 경우에는")
+        class Context_logined{
+            @WithMockCustomUser
+            @DisplayName("정상적으로 조회된다")
+            @Test
+            void it_load_well(){
+                assertEquals("dlwlrma", memberService.getMenuMemberProfile().getMemberUsername(), "이름이 같나");
+            }
+        }
+        @Nested
+        @DisplayName("로그인 하지 않은 경우에는")
+        class Context_unlogined{
+            @DisplayName("에러가 발생한다")
+            @Test
+            void it_occur_exception(){
+                // 실제 API에선 filter에 의해 NoAuthorityException 발생
+                // 실제론 service 진입전에 인증 검증을 하기 때문에 service에서 사용할 땐 널포인터가 발생
+                assertThrows(NullPointerException.class, ()->memberService.getMenuMemberProfile());
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("유저 프로필 조회 API는")
+    class Describe_member_profile_api{
+        
+        @Nested
+        @DisplayName("올바른 username이 주어지면")
+        class Context_correct_username{
+
+            @WithMockCustomUser
+            @DisplayName("정상적으로 조회된다")
+            @Test
+            void it_load_well(){
+                when(memberRepository.getUserProfile(1L, "dlwlrma")).thenReturn(
+                    new UserProfileResponse("dlwlrma", "이지금", "", ImageUtil.getBaseImage(),
+                    true, false, false, false, "이지금 입니다", 2L, 1L, 1L, true)
+                );
+                assertEquals("dlwlrma", memberService.getUserProfile("dlwlrma").getMemberUsername(), "이름이 같나");
+            }
+        }
+
+        @Nested
+        @DisplayName("올바르지 않은 username이 주어지면")
+        class Context_uncorrect_username{
+
+            @WithMockCustomUser
+            @DisplayName("에러가 발생한다")
+            @Test
+            void it_occur_exception(){
+                assertThrows(MemberDoesNotExistException.class, ()->memberService.getUserProfile("dlwlrma1"));
+            }
+        }
+    }
+
+
+    @Nested
+    @DisplayName("유저 미니 프로필 조회 API는")
+    class Describe_mini_profile_api{
+        
+        @Nested
+        @DisplayName("올바른 username이 주어지면")
+        class Context_correct_username{
+
+            @WithMockCustomUser
+            @DisplayName("정상적으로 조회된다")
+            @Test
+            void it_load_well(){
+                when(memberRepository.getMiniProfile(1L, "dlwlrma")).thenReturn(
+                    new MiniProfileResponse("dlwlrma", "이지금", ImageUtil.getBaseImage(),
+                    true, false, false, false, 2L, 1L, 1L, true)
+                );
+                assertEquals("dlwlrma", memberService.getMiniProfile("dlwlrma").getMemberUsername(), "이름이 같나");
+            }
+        }
+
+        @Nested
+        @DisplayName("올바르지 않은 username이 주어지면")
+        class Context_uncorrect_username{
+
+            @WithMockCustomUser
+            @DisplayName("에러가 발생한다")
+            @Test
+            void it_occur_exception(){
+                assertThrows(MemberDoesNotExistException.class, ()->memberService.getMiniProfile("dlwlrma1"));
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("유저 프로필 수정 조회 API는")
+    class Describe_get_edit_profile{
+        
+        @Nested
+        @DisplayName("로그인 한 경우에는")
+        class Context_logined{
+            @WithMockCustomUser
+            @DisplayName("정상적으로 조회된다")
+            @Test
+            void it_load_well(){
+                assertEquals("dlwlrma", memberService.getMenuMemberProfile().getMemberUsername(), "이름이 같나");
+            }
+        }
+        @Nested
+        @DisplayName("로그인 하지 않은 경우에는")
+        class Context_unlogined{
+            @DisplayName("에러가 발생한다")
+            @Test
+            void it_occur_exception(){
+                // 실제 API에선 filter에 의해 NoAuthorityException 발생
+                // 실제론 service 진입전에 인증 검증을 하기 때문에 service에서 사용할 땐 널포인터가 발생
+                assertThrows(NullPointerException.class, ()->memberService.getEditProfile());
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("유저 프로필 수정 API는")
+    class Describe_edit_profile{
+        
+        @Nested
+        @DisplayName("로그인 한 경우에는")
+        class Context_logined{
+            @WithMockCustomUser
+            @DisplayName("정상적으로 수정된다")
+            @Test
+            void it_load_well(){
+                when(memberRepository.existsByUsername("dlwlrma")).thenReturn(false);
+                EditProfileRequest editProfileRequest = new EditProfileRequest("dlwlrma", "이지금", "", "", "aaa@gmail.com", "", "FEMALE");
+                memberService.editProfile(editProfileRequest);
+                verify(memberRepository).findById(1L);
+            }
+        }
+
+        @Nested
+        @DisplayName("로그인 하지 않은 경우에는")
+        class Context_unlogined{
+            @DisplayName("에러가 발생한다")
+            @Test
+            void it_occur_exception(){
+                EditProfileRequest editProfileRequest = new EditProfileRequest("dlwlrma", "이지금", "", "", "aaa@gmail.com", "", "FEMALE");
+                assertThrows(NullPointerException.class, ()->memberService.editProfile(editProfileRequest));
+            }
+        }
+
+        @Nested
+        @DisplayName("유저네임이 중복된 경우에는")
+        class Context_duplicated_username{
+            @DisplayName("에러가 발생한다")
+            @Test
+            @WithMockCustomUser
+            void it_occur_exception(){
+                when(memberRepository.existsByUsername("dlwlrma1")).thenReturn(true);
+                EditProfileRequest editProfileRequest = new EditProfileRequest("dlwlrma1", "이지금", "", "", "aaa@gmail.com", "", "FEMALE");
+                assertThrows(UseridAlreadyExistException.class, ()->memberService.editProfile(editProfileRequest));
+            }
+        }
+
+    }
+
+    // TODO 프로필사진 UPLOAD/DELETE 는 어떻게?
+
+}


### PR DESCRIPTION
### Member 테스트 작성
- MemberService 테스트 작성
- 프로필사진 업로드, 삭제 API는 어떻게 테스트 할지? -> 실제 S3 서버에 올리는건 좋지 않은 것 같음
- MemberRepository는 공부하며 만든 하나의 테스트가 있는데 나머지 추가로 구현할 예정
### HTTP 상태코드 수정
- 회원, 팔로우 부분 상태코드 수정
### 추가) `reissue`시 예외 처리 추가
- 재발급 요청시 쿠키에 refresh token이 없는 경우 `InvalidJwtException`을 발생시키도록 수정 