### PR TITLE
Fix: JoinRoom 중복 체크 로직 정상화

### DIFF
--- a/src/main/java/cloneproject/Instagram/service/ChatService.java
+++ b/src/main/java/cloneproject/Instagram/service/ChatService.java
@@ -120,7 +120,7 @@ public class ChatService {
         for (RoomMember roomMember : roomMembers) {
             final Member member = roomMember.getMember();
             roomUnreadMemberRepository.save(new RoomUnreadMember(room, member));
-            final Optional<JoinRoom> joinRoom = joinRoomRepository.findByMemberIdAndRoomId(room.getId(), member.getId());
+            final Optional<JoinRoom> joinRoom = joinRoomRepository.findByMemberIdAndRoomId(member.getId(), room.getId());
             if (joinRoom.isPresent())
                 joinRoom.get().update();
             else


### PR DESCRIPTION
## 변경 사항
- `joinRoomRepository.findByMemberIdAndRoomId(member.getId(), room.getId());`
    - 인자 두 개의 순서를 올바르게 배치함

## 해결 이슈
- Resolve: #95 