### PR TITLE
채팅방 메시지 전송 API 로직 수정 등

### DIFF
--- a/src/main/java/cloneproject/Instagram/controller/ChatController.java
+++ b/src/main/java/cloneproject/Instagram/controller/ChatController.java
@@ -5,6 +5,7 @@ import cloneproject.Instagram.dto.result.ResultResponse;
 import cloneproject.Instagram.service.ChatService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -19,6 +20,7 @@ import javax.validation.constraints.NotNull;
 import static cloneproject.Instagram.dto.result.ResultCode.*;
 
 @Api(tags = "채팅 API")
+@Validated
 @RestController
 @RequiredArgsConstructor
 public class ChatController {
@@ -28,40 +30,44 @@ public class ChatController {
     @ApiOperation(value = "채팅방 생성")
     @ApiImplicitParam(name = "username", value = "상대방 username", example = "dlwlrma1", required = true)
     @PostMapping("/chat/rooms")
-    public ResponseEntity<ResultResponse> createChatRoom(
-            @Validated @NotBlank(message = "상대방 username은 필수입니다.") @RequestParam String username) {
+    public ResponseEntity<ResultResponse> createChatRoom(@NotBlank(message = "상대방 username은 필수입니다.") @RequestParam String username) {
         final ChatRoomCreateResponse response = chatService.createRoom(username);
 
         return ResponseEntity.ok(ResultResponse.of(CREATE_CHAT_ROOM_SUCCESS, response));
     }
 
     @ApiOperation(value = "채팅방 조회")
+    @ApiImplicitParam(name = "roomId", value = "채팅방 PK", example = "1", required = true)
     @DeleteMapping("/chat/rooms/{roomId}")
-    public ResponseEntity<ResultResponse> inquireChatRoom(@PathVariable Long roomId) {
+    public ResponseEntity<ResultResponse> inquireChatRoom(@NotNull(message = "채팅방 PK는 필수입니다.") @PathVariable Long roomId) {
         final ChatRoomInquireResponse response = chatService.inquireRoom(roomId);
 
         return ResponseEntity.ok(ResultResponse.of(INQUIRE_CHAT_ROOM_SUCCESS, response));
     }
 
     @ApiOperation(value = "채팅방 삭제")
+    @ApiImplicitParam(name = "roomId", value = "채팅방 PK", example = "1", required = true)
     @DeleteMapping("/chat/rooms/hide")
-    public ResponseEntity<ResultResponse> hideChatRoom(
-            @Validated @NotNull(message = "채팅방 PK는 필수입니다.") @RequestParam Long roomId) {
+    public ResponseEntity<ResultResponse> hideChatRoom(@NotNull(message = "채팅방 PK는 필수입니다.") @RequestParam Long roomId) {
         final JoinRoomDeleteResponse response = chatService.deleteJoinRoom(roomId);
 
         return ResponseEntity.ok(ResultResponse.of(DELETE_JOIN_ROOM_SUCCESS, response));
     }
 
     @ApiOperation(value = "채팅방 목록 페이징 조회", notes = "페이지당 10개씩 조회할 수 있습니다.")
+    @ApiImplicitParam(name = "page", value = "페이지", example = "1", required = true)
     @GetMapping("/chat/rooms")
-    public ResponseEntity<ResultResponse> getJoinRooms(
-            @Validated @NotNull(message = "페이지는 필수입니다.") @RequestParam Integer page) {
+    public ResponseEntity<ResultResponse> getJoinRooms(@NotNull(message = "페이지는 필수입니다.") @RequestParam Integer page) {
         final Page<JoinRoomDTO> response = chatService.getJoinRooms(page);
 
         return ResponseEntity.ok(ResultResponse.of(GET_JOIN_ROOMS_SUCCESS, response));
     }
 
     @ApiOperation(value = "채팅방 메시지 목록 페이징 조회", notes = "페이지당 10개씩 조회할 수 있습니다.")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "roomId", value = "채팅방 PK", example = "1", required = true),
+            @ApiImplicitParam(name = "page", value = "페이지", example = "1", required = true)
+    })
     @GetMapping("/chat/rooms/{roomId}/messages")
     public ResponseEntity<ResultResponse> getChatMessages(
             @NotNull(message = "채팅방 PK는 필수입니다.") @PathVariable Long roomId,
@@ -72,12 +78,12 @@ public class ChatController {
     }
 
     @MessageMapping("/messages")
-    public void sendChatMessage(@Validated @RequestBody MessageRequest request) {
+    public void sendChatMessage(@RequestBody MessageRequest request) {
         chatService.sendMessage(request);
     }
 
     @MessageMapping("/messages/indicate")
-    public void indicate(@Validated @RequestBody IndicateRequest request) {
+    public void indicate(@RequestBody IndicateRequest request) {
         chatService.indicate(request);
     }
 }

--- a/src/main/java/cloneproject/Instagram/entity/chat/Message.java
+++ b/src/main/java/cloneproject/Instagram/entity/chat/Message.java
@@ -39,6 +39,7 @@ public class Message {
     @Column(name = "message_created_date")
     private LocalDateTime createdDate;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "message_type")
     private MessageType type;
 

--- a/src/main/java/cloneproject/Instagram/repository/chat/JoinRoomRepositoryQuerydsl.java
+++ b/src/main/java/cloneproject/Instagram/repository/chat/JoinRoomRepositoryQuerydsl.java
@@ -5,5 +5,5 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface JoinRoomRepositoryQuerydsl {
-    Page<JoinRoomDTO> findJoinRoomDTOPagebyMemberId(Long memberId, Pageable pageable);
+    Page<JoinRoomDTO> findJoinRoomDTOPageByMemberId(Long memberId, Pageable pageable);
 }

--- a/src/main/java/cloneproject/Instagram/repository/chat/JoinRoomRepositoryQuerydslImpl.java
+++ b/src/main/java/cloneproject/Instagram/repository/chat/JoinRoomRepositoryQuerydslImpl.java
@@ -28,7 +28,7 @@ public class JoinRoomRepositoryQuerydslImpl implements JoinRoomRepositoryQueryds
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<JoinRoomDTO> findJoinRoomDTOPagebyMemberId(Long memberId, Pageable pageable) {
+    public Page<JoinRoomDTO> findJoinRoomDTOPageByMemberId(Long memberId, Pageable pageable) {
         // TODO: WebSocket 이용 메시지 송/수신하는 시점부터 쿼리 확인 필요
         final List<JoinRoomDTO> joinRoomDTOs = queryFactory
                 .select(new QJoinRoomDTO(


### PR DESCRIPTION
## 변경 사항
### 채팅방 메시지 전송 API 로직 수정
- RoomUnreadMember 엔티티가 존재하지 않는 경우에만 생성
### MessageType DB 저장 형식 수정
- Ordinal-> String
- ✅Message 테이블 초기화 후에 배포 부탁드립니다.
### 기타
- Swagger 어노테이션 추가 및 @Validated 컨트롤러 레벨에 추가
- 메소드 명 Camel Case 적용 -> `findJoinRoomDTOPageByMemberId`

## 해결 이슈
- Resolve #97 