### PR TITLE
MemberRepository 테스트

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     implementation group: 'it.ozimov', name: 'embedded-redis', version: '0.7.2'
 	runtimeOnly 'mysql:mysql-connector-java'
 	annotationProcessor 'org.projectlombok:lombok'
+	testImplementation 'com.h2database:h2'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 }

--- a/src/main/java/cloneproject/Instagram/controller/MemberAuthController.java
+++ b/src/main/java/cloneproject/Instagram/controller/MemberAuthController.java
@@ -2,7 +2,6 @@ package cloneproject.Instagram.controller;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
-import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
 

--- a/src/main/java/cloneproject/Instagram/dto/error/ErrorCode.java
+++ b/src/main/java/cloneproject/Instagram/dto/error/ErrorCode.java
@@ -20,6 +20,7 @@ public enum ErrorCode {
     NO_AUTHORITY(403, "M004", "권한이 없습니다."),
     ACCOUNT_DOES_NOT_MATCH(401, "M005", "계정정보가 일치하지 않습니다."),
     UPLOAD_PROFILE_IMAGE_FAIL(400, "M006", "회원 이미지를 업로드 하는 중 실패했습니다."),
+    NO_CONFIRM_EMAIL(400, "M007", "인증 이메일 전송을 먼저 해야합니다."),
     
     // FOLLOW
     ALREADY_FOLLOW(400, "F001", "이미 팔로우한 유저입니다."),

--- a/src/main/java/cloneproject/Instagram/dto/member/FollowerDTO.java
+++ b/src/main/java/cloneproject/Instagram/dto/member/FollowerDTO.java
@@ -3,12 +3,10 @@ package cloneproject.Instagram.dto.member;
 import com.querydsl.core.annotations.QueryProjection;
 
 import cloneproject.Instagram.vo.Image;
-import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
-// @AllArgsConstructor
 @NoArgsConstructor
 public class FollowerDTO {
     

--- a/src/main/java/cloneproject/Instagram/dto/member/MiniProfileResponse.java
+++ b/src/main/java/cloneproject/Instagram/dto/member/MiniProfileResponse.java
@@ -7,7 +7,6 @@ import java.util.stream.Collectors;
 
 import com.querydsl.core.annotations.QueryProjection;
 
-import cloneproject.Instagram.dto.post.MemberPostDTO;
 import cloneproject.Instagram.dto.post.MiniProfilePostDTO;
 import cloneproject.Instagram.dto.post.PostImageDTO;
 import cloneproject.Instagram.vo.Image;

--- a/src/main/java/cloneproject/Instagram/dto/post/MiniProfilePostDTO.java
+++ b/src/main/java/cloneproject/Instagram/dto/post/MiniProfilePostDTO.java
@@ -3,7 +3,6 @@ package cloneproject.Instagram.dto.post;
 
 import com.querydsl.core.annotations.QueryProjection;
 
-import cloneproject.Instagram.vo.Image;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/cloneproject/Instagram/exception/NoConfirmEmailException.java
+++ b/src/main/java/cloneproject/Instagram/exception/NoConfirmEmailException.java
@@ -1,0 +1,9 @@
+package cloneproject.Instagram.exception;
+
+import cloneproject.Instagram.dto.error.ErrorCode;
+
+public class NoConfirmEmailException extends BusinessException{
+    public NoConfirmEmailException(){
+        super(ErrorCode.NO_CONFIRM_EMAIL);
+    }
+}

--- a/src/main/java/cloneproject/Instagram/repository/MemberRepositoryQuerydsl.java
+++ b/src/main/java/cloneproject/Instagram/repository/MemberRepositoryQuerydsl.java
@@ -3,13 +3,9 @@ package cloneproject.Instagram.repository;
 
 import java.util.List;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-
 import cloneproject.Instagram.dto.member.MiniProfileResponse;
 import cloneproject.Instagram.dto.member.SearchedMemberDTO;
 import cloneproject.Instagram.dto.member.UserProfileResponse;
-import cloneproject.Instagram.dto.post.MemberPostDTO;
 import cloneproject.Instagram.entity.member.Member;
 
 public interface MemberRepositoryQuerydsl {

--- a/src/main/java/cloneproject/Instagram/repository/MemberRepositoryQuerydslImpl.java
+++ b/src/main/java/cloneproject/Instagram/repository/MemberRepositoryQuerydslImpl.java
@@ -38,13 +38,12 @@ public class MemberRepositoryQuerydslImpl implements MemberRepositoryQuerydsl{
                                                 .select(follow.member.username)
                                                 .from(follow)
                                                 .where(follow.followMember.username.eq(username)
-                                                        .and(follow.member.id.ne(loginedUserId)
                                                         .and(follow.member.id.in(
                                                             JPAExpressions
                                                                 .select(follow.followMember.id)
                                                                 .from(follow)
                                                                 .where(follow.member.id.eq(loginedUserId))
-                                                        ))))
+                                                        )))
                                                 .fetchFirst();
 
         final UserProfileResponse result = queryFactory.select(new QUserProfileResponse(
@@ -98,13 +97,12 @@ public class MemberRepositoryQuerydslImpl implements MemberRepositoryQuerydsl{
                                                 .select(follow.member.username)
                                                 .from(follow)
                                                 .where(follow.followMember.username.eq(username)
-                                                        .and(follow.member.id.ne(loginedUserId)
                                                         .and(follow.member.id.in(
                                                             JPAExpressions
                                                                 .select(follow.followMember.id)
                                                                 .from(follow)
                                                                 .where(follow.member.id.eq(loginedUserId))
-                                                        ))))
+                                                        )))
                                                 .fetchFirst();
 
         final MiniProfileResponse result = queryFactory.select(new QMiniProfileResponse(
@@ -210,7 +208,12 @@ public class MemberRepositoryQuerydslImpl implements MemberRepositoryQuerydsl{
                                             ))
                                             .from(follow)
                                             .where(follow.followMember.username.in(resultUsernames)
-                                                        .and(follow.member.id.ne(loginedUserId)))
+                                                        .and(follow.member.id.in(
+                                                            JPAExpressions
+                                                                .select(follow.followMember.id)
+                                                                .from(follow)
+                                                                .where(follow.member.id.eq(loginedUserId))
+                                                        )))
                                             .fetch();
         if(follows.isEmpty()){
             return result;

--- a/src/main/java/cloneproject/Instagram/repository/MemberRepositoryQuerydslImpl.java
+++ b/src/main/java/cloneproject/Instagram/repository/MemberRepositoryQuerydslImpl.java
@@ -38,7 +38,13 @@ public class MemberRepositoryQuerydslImpl implements MemberRepositoryQuerydsl{
                                                 .select(follow.member.username)
                                                 .from(follow)
                                                 .where(follow.followMember.username.eq(username)
-                                                        .and(follow.member.id.ne(loginedUserId)))
+                                                        .and(follow.member.id.ne(loginedUserId)
+                                                        .and(follow.member.id.in(
+                                                            JPAExpressions
+                                                                .select(follow.followMember.id)
+                                                                .from(follow)
+                                                                .where(follow.member.id.eq(loginedUserId))
+                                                        ))))
                                                 .fetchFirst();
 
         final UserProfileResponse result = queryFactory.select(new QUserProfileResponse(
@@ -92,7 +98,13 @@ public class MemberRepositoryQuerydslImpl implements MemberRepositoryQuerydsl{
                                                 .select(follow.member.username)
                                                 .from(follow)
                                                 .where(follow.followMember.username.eq(username)
-                                                            .and(follow.member.id.ne(loginedUserId)))
+                                                        .and(follow.member.id.ne(loginedUserId)
+                                                        .and(follow.member.id.in(
+                                                            JPAExpressions
+                                                                .select(follow.followMember.id)
+                                                                .from(follow)
+                                                                .where(follow.member.id.eq(loginedUserId))
+                                                        ))))
                                                 .fetchFirst();
 
         final MiniProfileResponse result = queryFactory.select(new QMiniProfileResponse(

--- a/src/main/java/cloneproject/Instagram/service/BlockService.java
+++ b/src/main/java/cloneproject/Instagram/service/BlockService.java
@@ -1,8 +1,6 @@
 package cloneproject.Instagram.service;
 
-import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;

--- a/src/main/java/cloneproject/Instagram/service/EmailCodeService.java
+++ b/src/main/java/cloneproject/Instagram/service/EmailCodeService.java
@@ -9,7 +9,9 @@ import org.springframework.stereotype.Service;
 import cloneproject.Instagram.entity.redis.EmailCode;
 import cloneproject.Instagram.repository.EmailCodeRedisRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RequiredArgsConstructor 
 @Service
 public class EmailCodeService {
@@ -38,9 +40,9 @@ public class EmailCodeService {
         return true;
     }
 
-    public EmailCode findByUsername(String username){
+    public Optional<EmailCode> findByUsername(String username){
         Optional<EmailCode> emailCode = emailCodeRedisRepository.findByUsername(username);
-        return emailCode.orElseThrow(null);
+        return emailCode;
     }
 
     public void deleteEmailCode(EmailCode emailCode){

--- a/src/test/java/cloneproject/Instagram/repository/MemberRepositoryTest.java
+++ b/src/test/java/cloneproject/Instagram/repository/MemberRepositoryTest.java
@@ -1,63 +1,188 @@
 package cloneproject.Instagram.repository;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.TestPropertySource;
 
+import cloneproject.Instagram.dto.member.MiniProfileResponse;
+import cloneproject.Instagram.dto.member.SearchedMemberDTO;
+import cloneproject.Instagram.dto.member.UserProfileResponse;
+import cloneproject.Instagram.entity.member.Follow;
 import cloneproject.Instagram.entity.member.Member;
 
 @DataJpaTest
-@ExtendWith(SpringExtension.class)
-@AutoConfigureTestDatabase(replace = Replace.NONE)
 @DisplayName("Member Repository")
+@TestPropertySource("classpath:application-test.yml")
 public class MemberRepositoryTest {
     
 
     @Autowired
     private MemberRepository memberRepository;
+    @Autowired
+    private FollowRepository followRepository;
+
+    private Member savedMemberOne;
+    private Member savedMemberTwo;
+    private Member savedMemberThree;
+    private static Long loginedId;
     
-    @Nested
-    @DisplayName("save 메서드는")
-    class Describe_save{
+    @BeforeEach
+    void prepare(){
+        memberRepository.deleteAll();
+        final Member givenMemberOne =  Member.builder()
+                                        .username("dlwlrma")
+                                        .name("이지금")
+                                        .password("1234")
+                                        .email("123@gmail.com")
+                                        .build();
+        final Member givenMemberTwo =  Member.builder()
+                                        .username("dlwlrma1")
+                                        .name("이지금")
+                                        .password("1234")
+                                        .email("123@gmail.com")
+                                        .build();
+        final Member givenMemberThree =  Member.builder()
+                                        .username("dlwldms")
+                                        .name("이지은")
+                                        .password("1234")
+                                        .email("123@gmail.com")
+                                        .build();
+        savedMemberOne = memberRepository.save(givenMemberOne);
+        savedMemberTwo = memberRepository.save(givenMemberTwo);
+        savedMemberThree = memberRepository.save(givenMemberThree);
 
-        // TODO querydsl 테스트 추가
-        @BeforeEach
-        void prepare(){
-            memberRepository.deleteAll();
-        }
-
-        @Nested
-        @DisplayName("멤버 객체가 주어지면")
-        class Context_given_member{
-            final Member givenMember =  Member.builder()
-                                            .username("testusername")
-                                            .name("testname")
-                                            .password("1234")
-                                            .email("123@gmail.com")
-                                            .build();
-            
-            @Test
-            @DisplayName("주어진 멤버를 저장한 뒤, 저장된 멤버를 반환한다.")
-            void it_save_member_and_return_saved_member(){
-                assertNull(givenMember.getId(), "저장전 id는 없어야 한다");
-                final Member savedMember = memberRepository.save(givenMember);
-                
-                assertNotNull(savedMember.getId(), "저장후 id는 존재해야 한다");
-                assertEquals(savedMember.getUsername(), givenMember.getUsername(), "저장된 정보가 일치해야 한다");
-            }
-        }
+        Follow follow = Follow.builder()
+                                .member(savedMemberOne)
+                                .followMember(savedMemberTwo)
+                                .build();
+        followRepository.save(follow);
+        follow = Follow.builder()
+                                .member(savedMemberThree)
+                                .followMember(savedMemberOne)
+                                .build();
+        followRepository.save(follow);
+        follow = Follow.builder()
+                                .member(savedMemberOne)
+                                .followMember(savedMemberThree)
+                                .build();
+        followRepository.save(follow);
+        follow = Follow.builder()
+                                .member(savedMemberThree)
+                                .followMember(savedMemberTwo)
+                                .build();
+        followRepository.save(follow);
+        loginedId = savedMemberOne.getId();
 
     }
+
+    @Nested
+    @DisplayName("getUserProfile 메서드는")
+    class Describe_getUserProfile{
+        @Nested
+        @DisplayName("로그인한 상태로 요청하면")
+        class Context_logined{
+            @Test
+            @DisplayName("정상적으로 결과를 반환한다")
+            void it_returns_well(){
+                UserProfileResponse userProfileResponse = memberRepository.getUserProfile(loginedId, savedMemberTwo.getUsername());
+                assertEquals(savedMemberTwo.getUsername(), userProfileResponse.getMemberUsername());
+                assertEquals(savedMemberTwo.getName(), userProfileResponse.getMemberName());
+                assertEquals(2L, userProfileResponse.getMemberFollowersCount());
+                assertEquals(savedMemberThree.getUsername(), userProfileResponse.getFollowingMemberFollow());
+                assertTrue(userProfileResponse.isFollowing());
+            }
+        }
+        @Nested
+        @DisplayName("로그인하지 않은 상태로 요청하면")
+        class Context_unlogined{
+            @Test
+            @DisplayName("정상적으로 결과를 반환하나, 특정 결과가 고정된다")
+            void it_returns_well(){
+                UserProfileResponse userProfileResponse = memberRepository.getUserProfile(-1L, savedMemberTwo.getUsername());
+                assertEquals(savedMemberTwo.getUsername(), userProfileResponse.getMemberUsername());
+                assertEquals(savedMemberTwo.getName(), userProfileResponse.getMemberName());
+                assertEquals(2L, userProfileResponse.getMemberFollowersCount());
+                assertNull(userProfileResponse.getFollowingMemberFollow());
+                assertFalse(userProfileResponse.isFollowing());
+            }
+        }
+    }
+    @Nested
+    @DisplayName("getMiniProfile 메서드는")
+    class Describe_getMiniProfile{
+        @Nested
+        @DisplayName("로그인한 상태로 요청하면")
+        class Context_logined{
+            @Test
+            @DisplayName("정상적으로 결과를 반환한다")
+            void it_returns_well(){
+                MiniProfileResponse miniProfileResponse = memberRepository.getMiniProfile(loginedId, savedMemberTwo.getUsername());
+                assertEquals(savedMemberTwo.getUsername(), miniProfileResponse.getMemberUsername());
+                assertEquals(savedMemberTwo.getName(), miniProfileResponse.getMemberName());
+                assertEquals(2L, miniProfileResponse.getMemberFollowersCount());
+                assertEquals(savedMemberThree.getUsername(), miniProfileResponse.getFollowingMemberFollow());
+                assertTrue(miniProfileResponse.isFollowing());
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("searchMember 메서드는")
+    class Describe_searchMember{
+        @Nested
+        @DisplayName("dlwl를 검색하면")
+        class Context_dlwl{
+            @Test
+            @DisplayName("3명의 유저가 검색된다")
+            void it_returns_three_users(){
+                List<SearchedMemberDTO> searchedMemberDTOs = memberRepository.searchMember(loginedId, "dlwl");
+                assertEquals(3, searchedMemberDTOs.size());
+                assertEquals(savedMemberOne.getUsername(), searchedMemberDTOs.get(0).getUsername());
+                assertEquals(savedMemberThree.getUsername(), searchedMemberDTOs.get(1).getFollowingMemberFollow().get(0).getMemberUsername());
+            }
+        }
+        @Nested
+        @DisplayName("dlwlrma를 검색하면")
+        class Context_dlwlrma{
+            @Test
+            @DisplayName("2명의 유저가 검색된다")
+            void it_returns_two_users(){
+                List<SearchedMemberDTO> searchedMemberDTOs = memberRepository.searchMember(loginedId, "dlwlrma");
+                assertEquals(2, searchedMemberDTOs.size());
+                assertEquals(savedMemberOne.getUsername(), searchedMemberDTOs.get(0).getUsername());
+                assertEquals(savedMemberThree.getUsername(), searchedMemberDTOs.get(1).getFollowingMemberFollow().get(0).getMemberUsername());
+            }
+        }
+    }
+    @Nested
+    @DisplayName("findAllByUsernames 메서드는")
+    class Describe_findAllByUsernames{
+        @Nested
+        @DisplayName("2개의 username을 넘기면")
+        class Context_two_usernames{
+            @Test
+            @DisplayName("2명의 유저가 리턴된다")
+            void it_returns_two_users(){
+                List<String> usernameList = new ArrayList<>();
+                usernameList.add(savedMemberOne.getUsername());
+                usernameList.add(savedMemberTwo.getUsername());
+                List<Member> members = memberRepository.findAllByUsernames(usernameList);
+                assertEquals(2, members.size());
+            }
+        }
+    }
+
     
 }

--- a/src/test/java/cloneproject/Instagram/service/MemberServiceTest.java
+++ b/src/test/java/cloneproject/Instagram/service/MemberServiceTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import cloneproject.Instagram.WithMockCustomUser;


### PR DESCRIPTION
## `MemberRepository` 테스트 작성
### `build.gradle` 수정
- `Repository` 테스트 시 기존의 DB를 이용하는 것은 좋지 않은 방법이라 판단
- 따라서 `h2database`를 테스트할 때만 사용하기로 결정
-> `dependencies`에 추가
### 테스트
- JPA 자체에서 지원하는 메서드는 제외
- querydsl등과 같이 직접 작성한 로직만 테스트 작성
- 유저/미니프로필 조회, 검색, `findAllByUsernames`만 테스트
- `MemberPost` 관련 API는 `MemberRepository`에 포함되어 있으나 코드가 너무 길어져서 따로 테스트 작성할 예정
## 문제 수정
### 유저 검색, 프로필 조회 시 일부로직 수정
- `followingMemberFollow`의 문제 수정
- 팔로잉 중인 유저만 출력이 되어야하나 전체 유저가 대상이었음
-> 의도한 대로 동작하도록 로직 수정
### `EmailCode` 수정
- `EmailCode` 전송을 하지않고 회원가입을 시도하는 경우 500 에러 발생
- 내부에서 검증하는 로직을 구현했으나 정상적으로 동작하지 않고 있었음
-> 정상적으로 동작하도록 수정
### 불필요한 import문 삭제
- 구현하기로 맡은 API의 불필요한 import문 삭제
- 그 외 API는 merge conflict의 우려가 있어 건드리지 않았으니 직접 해주시면 감사하겠습니다! @seonpilKim 