### PR TITLE
게시물 목록 조회 API, 채팅방 생성 API, 채팅방 목록 조회 API 응답 데이터 추가

### DIFF
--- a/src/main/java/cloneproject/Instagram/dto/chat/ChatRoomCreateResponse.java
+++ b/src/main/java/cloneproject/Instagram/dto/chat/ChatRoomCreateResponse.java
@@ -15,5 +15,5 @@ public class ChatRoomCreateResponse {
     private boolean status;
     private Long chatRoomId;
     private MemberSimpleInfo inviter;
-    private List<MemberSimpleInfo> invitees = new ArrayList<>();
+    private List<MemberSimpleInfo> members = new ArrayList<>();
 }

--- a/src/main/java/cloneproject/Instagram/dto/chat/JoinRoomDTO.java
+++ b/src/main/java/cloneproject/Instagram/dto/chat/JoinRoomDTO.java
@@ -19,7 +19,7 @@ public class JoinRoomDTO {
     private MessageDTO lastMessage;
     private boolean unreadFlag;
     private MemberSimpleInfo inviter;
-    private List<MemberSimpleInfo> invitees = new ArrayList<>();
+    private List<MemberSimpleInfo> members = new ArrayList<>();
 
     @QueryProjection
     public JoinRoomDTO(Long roomId, Message message, boolean unreadFlag, Member member) {

--- a/src/main/java/cloneproject/Instagram/dto/comment/CommentDTO.java
+++ b/src/main/java/cloneproject/Instagram/dto/comment/CommentDTO.java
@@ -15,6 +15,7 @@ public class CommentDTO {
 
     @JsonIgnore
     private Long postId;
+
     private Long id;
     private MenuMemberDTO member;
     private String content;

--- a/src/main/java/cloneproject/Instagram/dto/post/PostDTO.java
+++ b/src/main/java/cloneproject/Instagram/dto/post/PostDTO.java
@@ -1,5 +1,6 @@
 package cloneproject.Instagram.dto.post;
 
+import cloneproject.Instagram.dto.comment.CommentDTO;
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -27,6 +28,7 @@ public class PostDTO {
     private boolean postBookmarkFlag;
     private boolean postLikeFlag;
     private String followingMemberUsernameLikedPost;
+    private List<CommentDTO> recentComments = new ArrayList<>();
 
     @QueryProjection
     public PostDTO(Long postId, String postContent, LocalDateTime postUploadDate, String memberUsername, String memberNickname, String memberImageUrl, int postCommentsCount, int postLikesCount, boolean postBookmarkFlag, boolean postLikeFlag) {

--- a/src/main/java/cloneproject/Instagram/entity/comment/RecentComment.java
+++ b/src/main/java/cloneproject/Instagram/entity/comment/RecentComment.java
@@ -1,0 +1,41 @@
+package cloneproject.Instagram.entity.comment;
+
+import cloneproject.Instagram.entity.member.Member;
+import cloneproject.Instagram.entity.post.Post;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@Entity
+@Table(name = "recent_comments")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RecentComment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "recent_comment_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id")
+    private Comment comment;
+
+    @Builder
+    public RecentComment(Member member, Post post, Comment comment) {
+        this.member = member;
+        this.post = post;
+        this.comment = comment;
+    }
+}

--- a/src/main/java/cloneproject/Instagram/repository/chat/JoinRoomRepositoryQuerydslImpl.java
+++ b/src/main/java/cloneproject/Instagram/repository/chat/JoinRoomRepositoryQuerydslImpl.java
@@ -62,7 +62,7 @@ public class JoinRoomRepositoryQuerydslImpl implements JoinRoomRepositoryQueryds
         final Map<Long, List<RoomMember>> roomMemberMap = roomMembers.stream()
                 .collect(Collectors.groupingBy(r -> r.getRoom().getId()));
 
-        joinRoomDTOs.forEach(j -> j.setInvitees(
+        joinRoomDTOs.forEach(j -> j.setMembers(
                 roomMemberMap.get(j.getRoomId())
                         .stream()
                         .map(r -> new MemberSimpleInfo(r.getMember()))

--- a/src/main/java/cloneproject/Instagram/repository/post/RecentCommentRepository.java
+++ b/src/main/java/cloneproject/Instagram/repository/post/RecentCommentRepository.java
@@ -1,0 +1,11 @@
+package cloneproject.Instagram.repository.post;
+
+import cloneproject.Instagram.entity.comment.RecentComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface RecentCommentRepository extends JpaRepository<RecentComment, Long> {
+
+    List<RecentComment> findAllByPostId(Long postId);
+}

--- a/src/main/java/cloneproject/Instagram/service/ChatService.java
+++ b/src/main/java/cloneproject/Instagram/service/ChatService.java
@@ -51,7 +51,7 @@ public class ChatService {
         for (RoomMember inviterRoom : inviterRooms) {
             for (RoomMember inviteeRoom : inviteeRooms) {
                 if (inviterRoom.getRoom().getId().equals(inviteeRoom.getRoom().getId()))
-                    return new ChatRoomCreateResponse(true, inviterRoom.getRoom().getId(), new MemberSimpleInfo(inviter), List.of(new MemberSimpleInfo(invitee)));
+                    return new ChatRoomCreateResponse(true, inviterRoom.getRoom().getId(), new MemberSimpleInfo(inviter), List.of(new MemberSimpleInfo(inviter), new MemberSimpleInfo(invitee)));
             }
         }
 
@@ -60,7 +60,7 @@ public class ChatService {
         roomMemberRepository.save(new RoomMember(inviter, room));
         roomMemberRepository.save(new RoomMember(invitee, room));
 
-        return new ChatRoomCreateResponse(true, room.getId(), new MemberSimpleInfo(inviter), List.of(new MemberSimpleInfo(invitee)));
+        return new ChatRoomCreateResponse(true, room.getId(), new MemberSimpleInfo(inviter), List.of(new MemberSimpleInfo(inviter), new MemberSimpleInfo(invitee)));
     }
 
     @Transactional


### PR DESCRIPTION
## 변경 사항
### 게시물 목록 조회 API 응답 데이터 추가
- RecentComment 엔티티를 추가하여, 각 게시물의 최신 댓글 2개를 저장
- 각 게시물마다 댓글 목록을 조회하여 최신 댓글 2개를 구하는 쿼리는 N + 1번 쿼리가 발생하므로, RecentComment 테이블에 최신 댓글을 유지함으로써, 한 번의 쿼리로 각 게시물마다 최신 댓글을 가져오기 위함
- 댓글 작성 API 로직 추가
### 채팅방 생성 API, 채팅방 목록 조회 API 응답 데이터 수정
- invitees -> members로 변경
- 초대자를 포함한 모든 참여자를 members에 담아서 응답

## 해결 이슈
- Resolve: #90 
- Resolve: #100 