### PR TITLE
좋아요, 알림, 멘션 관련 API 업데이트 및 채팅 API 에러 해결

### DIFF
--- a/src/main/java/cloneproject/Instagram/controller/AlarmController.java
+++ b/src/main/java/cloneproject/Instagram/controller/AlarmController.java
@@ -1,10 +1,13 @@
 package cloneproject.Instagram.controller;
 
-import java.util.List;
-
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import cloneproject.Instagram.dto.alarm.AlarmDTO;
@@ -15,21 +18,28 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 
+import javax.validation.constraints.NotNull;
+
 @Api(tags = "알림 API")
+@Validated
 @RestController
 @RequiredArgsConstructor
 public class AlarmController {
 
     private final AlarmService alarmService;
 
-    @ApiOperation(value = "알림 목록 조회")
+    @ApiOperation(value = "알림 목록 페이징 조회")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "page", value = "페이지", example = "1", required = true),
+            @ApiImplicitParam(name = "size", value = "페이지당 개수", example = "10", required = true)
+    })
     @GetMapping(value = "/alarms")
-    public ResponseEntity<ResultResponse> getAlarms(){
-        List<AlarmDTO> alarms = alarmService.getAlarms();
+    public ResponseEntity<ResultResponse> getAlarms(
+            @NotNull(message = "page는 필수입니다.") @RequestParam int page,
+            @NotNull(message = "size는 필수입니다.") @RequestParam int size) {
+        Page<AlarmDTO> alarms = alarmService.getAlarms(page, size);
 
         ResultResponse result = ResultResponse.of(ResultCode.GET_ALARMS_SUCCESS, alarms);
         return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
     }
-
-    
 }

--- a/src/main/java/cloneproject/Instagram/dto/alarm/AlarmContentDTO.java
+++ b/src/main/java/cloneproject/Instagram/dto/alarm/AlarmContentDTO.java
@@ -1,0 +1,22 @@
+package cloneproject.Instagram.dto.alarm;
+
+import cloneproject.Instagram.dto.member.MenuMemberDTO;
+import cloneproject.Instagram.entity.alarms.Alarm;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class AlarmContentDTO extends AlarmDTO {
+
+    private Long postId;
+    private String postImageUrl;
+    private String content;
+
+    public AlarmContentDTO(Alarm alarm) {
+        super(alarm.getId(), alarm.getType().name(), alarm.getType().getMessage(), new MenuMemberDTO(alarm.getAgent()), alarm.getCreatedDate());
+        this.postId = alarm.getPost().getId();
+        this.postImageUrl = alarm.getPost().getPostImages().get(0).getImage().getImageUrl();
+        this.content = alarm.getPost().getContent();
+    }
+}

--- a/src/main/java/cloneproject/Instagram/dto/alarm/AlarmDTO.java
+++ b/src/main/java/cloneproject/Instagram/dto/alarm/AlarmDTO.java
@@ -1,45 +1,20 @@
 package cloneproject.Instagram.dto.alarm;
 
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
-
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.querydsl.core.annotations.QueryProjection;
-
-import cloneproject.Instagram.util.DateUtil;
+import cloneproject.Instagram.dto.member.MenuMemberDTO;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Data
 @NoArgsConstructor
-public class AlarmDTO implements Comparable<AlarmDTO>{
+@AllArgsConstructor
+public class AlarmDTO {
 
-    @JsonIgnore
     private Long id;
     private String type;
-    private String alarmMessage;
-    private String agentUsername;
-    private String targetUsername;
-    private Map<String, Long> itemIds;
-    private String createdAt;
-
-    @Override
-    public int compareTo(AlarmDTO alarmDTO) {
-         return this.id.compareTo(alarmDTO.id); 
-    }
-
-    @QueryProjection
-    public AlarmDTO(Long id, AlarmType type, String agentUsername, String targetUsername, Long itemId, Date createdAt){
-        this.itemIds = new HashMap<>();
-
-        this.id = id;
-        this.type = type.toString();
-        this.alarmMessage = type.getAlarmMesasge();
-        this.agentUsername = agentUsername;
-        this.targetUsername = targetUsername;
-        this.itemIds.put(type.getFirstItemType(), itemId);
-        this.createdAt = DateUtil.convertDateToString(createdAt);
-    }
-
+    private String message;
+    private MenuMemberDTO agent;
+    private LocalDateTime createdDate;
 }

--- a/src/main/java/cloneproject/Instagram/dto/alarm/AlarmFollowDTO.java
+++ b/src/main/java/cloneproject/Instagram/dto/alarm/AlarmFollowDTO.java
@@ -1,0 +1,20 @@
+package cloneproject.Instagram.dto.alarm;
+
+import cloneproject.Instagram.dto.member.MenuMemberDTO;
+import cloneproject.Instagram.entity.alarms.Alarm;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class AlarmFollowDTO extends AlarmDTO {
+
+    private boolean isFollowing;
+
+    public AlarmFollowDTO(Alarm alarm, boolean isFollowing) {
+        super(alarm.getId(), alarm.getType().name(), alarm.getType().getMessage(), new MenuMemberDTO(alarm.getAgent()), alarm.getCreatedDate());
+        this.isFollowing = isFollowing;
+    }
+}

--- a/src/main/java/cloneproject/Instagram/dto/alarm/AlarmType.java
+++ b/src/main/java/cloneproject/Instagram/dto/alarm/AlarmType.java
@@ -6,14 +6,16 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum AlarmType {
-    
-    POST_LIKES_ALARM("agentUsername이 targetUsername(나)의 postId인 포스트를 좋아합니다", "postId"),
-    POST_COMMENT_ALARM("agentUsername이 targetUsername(나)의 postId인 포스트에 댓글을 남겼습니다.", "postId"),
-    COMMENT_LIKES_ALARM("agentUsername이 targetUsername(나)의 postId인 포스트에 댓글을 남겼습니다.", "postId"),
-    MEMBER_FOLLOW_ALARM("agentUsername이 targetUsername(나)를 팔로우 합니다", "followId"),
-    MEMBER_TAGGED_ALARM("agentUsername이 postId인 포스트에서 targetUsername(나)를 태그했습니다", "postId");
 
-    private String alarmMesasge;
-    private String firstItemType;
+    FOLLOW("{agent.username}님이 회원님을 팔로우하기 시작했습니다."),
 
+    LIKE_POST("{agent.username}님이 회원님의 사진을 좋아합니다."),
+    MENTION_POST("{agent.username}님이 게시물에서 회원님을 언급했습니다: {post.content}"),
+
+    COMMENT("{agent.username}님이 댓글을 남겼습니다: {comment.content}"),
+    LIKE_COMMENT("{agent.username}님이 회원님의 댓글을 좋아합니다: {comment.content}"),
+    MENTION_COMMENT("{agent.username}님이 댓글에서 회원님을 언급했습니다: {comment.content}"),
+    ;
+
+    private String message;
 }

--- a/src/main/java/cloneproject/Instagram/dto/error/ErrorCode.java
+++ b/src/main/java/cloneproject/Instagram/dto/error/ErrorCode.java
@@ -55,13 +55,19 @@ public enum ErrorCode {
     BOOKMARK_NOT_FOUND(400, "P013", "아직 해당 게시물을 저장하지 않았습니다."),
     COMMENT_NOT_FOUND(400, "P014", "존재하지 않는 댓글입니다."),
     COMMENT_CANT_DELETE(400, "P015", "타인이 작성한 댓글은 삭제할 수 없습니다."),
+    COMMENT_LIKE_ALREADY_EXIST(400, "P016", "해당 댓글에 이미 좋아요를 누른 회원입니다."),
+    COMMENT_LIKE_NOT_FOUND(400, "P017", "해당 댓글에 좋아요를 누르지 않은 회원입니다."),
 
     // Chat
     CHAT_ROOM_NOT_FOUND(400, "C001", "존재하지 않는 채팅방입니다."),
     JOIN_ROOM_NOT_FOUND(400, "C002", "해당 채팅방에 참여하지 않은 회원입니다."),
 
     // FILE
-    CANT_CONVERT_FILE(500, "FI001", "파일을 변환할수 없습니다");
+    CANT_CONVERT_FILE(500, "FI001", "파일을 변환할수 없습니다"),
+
+    // Alarm
+    MISMATCHED_ALARM_TYPE(400, "A001", "알람 형식이 올바르지 않습니다.")
+    ;
     ;
 
     private int status;

--- a/src/main/java/cloneproject/Instagram/dto/member/LikeMembersDTO.java
+++ b/src/main/java/cloneproject/Instagram/dto/member/LikeMembersDTO.java
@@ -1,0 +1,28 @@
+package cloneproject.Instagram.dto.member;
+
+import cloneproject.Instagram.vo.Image;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class LikeMembersDTO {
+
+    private String username;
+    private String name;
+    private Image image;
+    private boolean isFollowing;
+    private boolean isFollower;
+    private boolean hasStory;
+
+    @QueryProjection
+    public LikeMembersDTO(String username, String name, Image image, boolean isFollowing, boolean isFollower, boolean hasStory) {
+        this.username = username;
+        this.name = name;
+        this.image = image;
+        this.isFollowing = isFollowing;
+        this.isFollower = isFollower;
+        this.hasStory = hasStory;
+    }
+}

--- a/src/main/java/cloneproject/Instagram/dto/result/ResultCode.java
+++ b/src/main/java/cloneproject/Instagram/dto/result/ResultCode.java
@@ -65,8 +65,8 @@ public enum ResultCode {
     GET_REPLY_PAGE_SUCCESS(200, "P014", "게시물 답글 페이지 조회 성공"),
     GET_POST_LIKES_SUCCESS(200, "P015", "게시물 좋아요한 사람 목록 페이지 조회 성공"),
     LIKE_COMMENT_SUCCESS(200, "P016", "댓글 좋아요 성공"),
-    UNLIKE_COMMENT_SUCCESS(200, "P016", "댓글 좋아요 취소 성공"),
-    GET_COMMENT_LIKES_SUCCESS(200, "P017", "댓글 좋아요한 사람 목록 페이지 조회 성공"),
+    UNLIKE_COMMENT_SUCCESS(200, "P017", "댓글 좋아요 취소 성공"),
+    GET_COMMENT_LIKES_SUCCESS(200, "P018", "댓글 좋아요한 사람 목록 페이지 조회 성공"),
 
     // CHAT
     CREATE_CHAT_ROOM_SUCCESS(200, "C001", "채팅방 생성 성공"),

--- a/src/main/java/cloneproject/Instagram/dto/result/ResultCode.java
+++ b/src/main/java/cloneproject/Instagram/dto/result/ResultCode.java
@@ -63,6 +63,10 @@ public enum ResultCode {
     DELETE_COMMENT_SUCCESS(200, "P012", "게시물 댓글 삭제 성공"),
     GET_COMMENT_PAGE_SUCCESS(200, "P013", "게시물 댓글 페이지 조회 성공"),
     GET_REPLY_PAGE_SUCCESS(200, "P014", "게시물 답글 페이지 조회 성공"),
+    GET_POST_LIKES_SUCCESS(200, "P015", "게시물 좋아요한 사람 목록 페이지 조회 성공"),
+    LIKE_COMMENT_SUCCESS(200, "P016", "댓글 좋아요 성공"),
+    UNLIKE_COMMENT_SUCCESS(200, "P016", "댓글 좋아요 취소 성공"),
+    GET_COMMENT_LIKES_SUCCESS(200, "P017", "댓글 좋아요한 사람 목록 페이지 조회 성공"),
 
     // CHAT
     CREATE_CHAT_ROOM_SUCCESS(200, "C001", "채팅방 생성 성공"),

--- a/src/main/java/cloneproject/Instagram/entity/alarms/Alarm.java
+++ b/src/main/java/cloneproject/Instagram/entity/alarms/Alarm.java
@@ -1,20 +1,12 @@
 package cloneproject.Instagram.entity.alarms;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EntityListeners;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
+import cloneproject.Instagram.entity.comment.Comment;
+import cloneproject.Instagram.entity.member.Follow;
+import cloneproject.Instagram.entity.post.Post;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -49,19 +41,29 @@ public class Alarm {
     @JoinColumn(name = "alarm_target_id")
     private Member target;
 
-    @Column(name = "alarm_item_id")
-    private Long itemId;
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id")
+    private Comment comment;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "follow_id")
+    private Follow follow;
 
     @CreatedDate
-    @Column(name = "alarm_created_at")
-    private Date createdAt;
+    @Column(name = "alarm_created_date")
+    private LocalDateTime createdDate;
     
     @Builder
-    public Alarm(AlarmType type, Member agent, Member target, Long itemId){
+    public Alarm(AlarmType type, Member agent, Member target, Post post, Comment comment, Follow follow) {
         this.type = type;
         this.agent = agent;
         this.target = target;
-        this.itemId = itemId;
+        this.post = post;
+        this.comment = comment;
+        this.follow = follow;
     }
-
 }

--- a/src/main/java/cloneproject/Instagram/entity/member/MemberStory.java
+++ b/src/main/java/cloneproject/Instagram/entity/member/MemberStory.java
@@ -1,0 +1,35 @@
+package cloneproject.Instagram.entity.member;
+
+import cloneproject.Instagram.entity.story.Story;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@Entity
+@Table(name = "member_stories")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberStory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_story_id")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "story_id")
+    private Story story;
+
+    @Builder
+    public MemberStory(Member member, Story story) {
+        this.member = member;
+        this.story = story;
+    }
+}

--- a/src/main/java/cloneproject/Instagram/entity/mention/Mention.java
+++ b/src/main/java/cloneproject/Instagram/entity/mention/Mention.java
@@ -1,0 +1,60 @@
+package cloneproject.Instagram.entity.mention;
+
+import cloneproject.Instagram.entity.comment.Comment;
+import cloneproject.Instagram.entity.member.Member;
+import cloneproject.Instagram.entity.post.Post;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "mentions")
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Mention {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "mention_id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "mention_type")
+    private MentionType type;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "agent_id")
+    private Member agent;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "target_id")
+    private Member target;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id")
+    private Comment comment;
+
+    @CreatedDate
+    @Column(name = "mention_create_date")
+    private LocalDateTime createdDate;
+
+    @Builder
+    public Mention(MentionType type, Member agent, Member target, Post post, Comment comment) {
+        this.type = type;
+        this.agent = agent;
+        this.target = target;
+        this.post = post;
+        this.comment = comment;
+    }
+}

--- a/src/main/java/cloneproject/Instagram/entity/mention/MentionType.java
+++ b/src/main/java/cloneproject/Instagram/entity/mention/MentionType.java
@@ -1,0 +1,5 @@
+package cloneproject.Instagram.entity.mention;
+
+public enum MentionType {
+    POST, COMMENT
+}

--- a/src/main/java/cloneproject/Instagram/entity/post/Post.java
+++ b/src/main/java/cloneproject/Instagram/entity/post/Post.java
@@ -35,6 +35,7 @@ public class Post {
     private String content;
 
     @CreatedDate
+    @Column(name = "post_upload_date")
     private LocalDateTime uploadDate;
 
     @OneToMany(mappedBy = "post", orphanRemoval = true)

--- a/src/main/java/cloneproject/Instagram/exception/CommentLikeAlreadyExistException.java
+++ b/src/main/java/cloneproject/Instagram/exception/CommentLikeAlreadyExistException.java
@@ -1,0 +1,10 @@
+package cloneproject.Instagram.exception;
+
+import cloneproject.Instagram.dto.error.ErrorCode;
+
+public class CommentLikeAlreadyExistException extends BusinessException {
+
+    public CommentLikeAlreadyExistException() {
+        super(ErrorCode.COMMENT_LIKE_ALREADY_EXIST);
+    }
+}

--- a/src/main/java/cloneproject/Instagram/exception/CommentLikeNotFoundException.java
+++ b/src/main/java/cloneproject/Instagram/exception/CommentLikeNotFoundException.java
@@ -1,0 +1,10 @@
+package cloneproject.Instagram.exception;
+
+import cloneproject.Instagram.dto.error.ErrorCode;
+
+public class CommentLikeNotFoundException extends BusinessException{
+
+    public CommentLikeNotFoundException() {
+        super(ErrorCode.COMMENT_LIKE_NOT_FOUND);
+    }
+}

--- a/src/main/java/cloneproject/Instagram/exception/MismatchedAlarmTypeException.java
+++ b/src/main/java/cloneproject/Instagram/exception/MismatchedAlarmTypeException.java
@@ -1,0 +1,10 @@
+package cloneproject.Instagram.exception;
+
+import cloneproject.Instagram.dto.error.ErrorCode;
+
+public class MismatchedAlarmTypeException extends BusinessException {
+
+    public MismatchedAlarmTypeException() {
+        super(ErrorCode.MISMATCHED_ALARM_TYPE);
+    }
+}

--- a/src/main/java/cloneproject/Instagram/repository/AlarmRepository.java
+++ b/src/main/java/cloneproject/Instagram/repository/AlarmRepository.java
@@ -1,11 +1,25 @@
 package cloneproject.Instagram.repository;
 
+import cloneproject.Instagram.dto.alarm.AlarmType;
+import cloneproject.Instagram.entity.comment.Comment;
+import cloneproject.Instagram.entity.member.Follow;
+import cloneproject.Instagram.entity.member.Member;
+import cloneproject.Instagram.entity.post.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import cloneproject.Instagram.entity.alarms.Alarm;
 
-public interface AlarmRepository extends JpaRepository<Alarm, Long>, AlarmRepositoryQuerydsl{
-    
-    void deleteAllByTargetId(Long targetId);
+import java.util.List;
 
+public interface AlarmRepository extends JpaRepository<Alarm, Long>, AlarmRepositoryQuerydsl, AlarmRepositoryJdbc {
+
+    void deleteByTypeAndAgentAndTargetAndPost(AlarmType type, Member agent, Member target, Post post);
+
+    void deleteByTypeAndAgentAndTargetAndComment(AlarmType type, Member agent, Member target, Comment comment);
+
+    void deleteByTypeAndAgentAndTargetAndFollow(AlarmType type, Member agent, Member target, Follow follow);
+
+    List<Alarm> findAllByCommentAndTypeIn(Comment comment, List<AlarmType> alarmTypes);
+
+    List<Alarm> findAllByPost(Post post);
 }

--- a/src/main/java/cloneproject/Instagram/repository/AlarmRepositoryJdbc.java
+++ b/src/main/java/cloneproject/Instagram/repository/AlarmRepositoryJdbc.java
@@ -1,0 +1,15 @@
+package cloneproject.Instagram.repository;
+
+import cloneproject.Instagram.entity.comment.Comment;
+import cloneproject.Instagram.entity.member.Member;
+import cloneproject.Instagram.entity.post.Post;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface AlarmRepositoryJdbc {
+
+    void saveMentionPostAlarms(Member agent, List<Member> targets, Post post, LocalDateTime now);
+
+    void saveMentionCommentAlarms(Member agent, List<Member> targets, Post post, Comment comment, LocalDateTime now);
+}

--- a/src/main/java/cloneproject/Instagram/repository/AlarmRepositoryJdbcImpl.java
+++ b/src/main/java/cloneproject/Instagram/repository/AlarmRepositoryJdbcImpl.java
@@ -1,0 +1,71 @@
+package cloneproject.Instagram.repository;
+
+import cloneproject.Instagram.dto.alarm.AlarmType;
+import cloneproject.Instagram.entity.comment.Comment;
+import cloneproject.Instagram.entity.member.Member;
+import cloneproject.Instagram.entity.post.Post;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@RequiredArgsConstructor
+public class AlarmRepositoryJdbcImpl implements AlarmRepositoryJdbc {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Override
+    public void saveMentionPostAlarms(Member agent, List<Member> targets, Post post, LocalDateTime now) {
+        final String sql =
+                "INSERT INTO alarms (`alarm_created_date`, `alarm_type`, `alarm_agent_id`, `post_id`, `alarm_target_id`) " +
+                        "VALUES(?, ?, ?, ?, ?)";
+
+        jdbcTemplate.batchUpdate(
+                sql,
+                new BatchPreparedStatementSetter() {
+                    @Override
+                    public void setValues(PreparedStatement ps, int i) throws SQLException {
+                        ps.setString(1, now.toString());
+                        ps.setString(2, AlarmType.MENTION_POST.name());
+                        ps.setString(3, agent.getId().toString());
+                        ps.setString(4, post.getId().toString());
+                        ps.setString(5, targets.get(i).getId().toString());
+                    }
+
+                    @Override
+                    public int getBatchSize() {
+                        return targets.size();
+                    }
+                });
+    }
+
+    @Override
+    public void saveMentionCommentAlarms(Member agent, List<Member> targets, Post post, Comment comment, LocalDateTime now) {
+        final String sql =
+                "INSERT INTO alarms (`alarm_created_date`, `alarm_type`, `alarm_agent_id`, `comment_id`, `post_id`, `alarm_target_id`) " +
+                        "VALUES(?, ?, ?, ?, ?, ?)";
+
+        jdbcTemplate.batchUpdate(
+                sql,
+                new BatchPreparedStatementSetter() {
+                    @Override
+                    public void setValues(PreparedStatement ps, int i) throws SQLException {
+                        ps.setString(1, now.toString());
+                        ps.setString(2, AlarmType.MENTION_COMMENT.name());
+                        ps.setString(3, agent.getId().toString());
+                        ps.setString(4, comment.getId().toString());
+                        ps.setString(5, post.getId().toString());
+                        ps.setString(6, targets.get(i).getId().toString());
+                    }
+
+                    @Override
+                    public int getBatchSize() {
+                        return targets.size();
+                    }
+                });
+    }
+}

--- a/src/main/java/cloneproject/Instagram/repository/AlarmRepositoryQuerydsl.java
+++ b/src/main/java/cloneproject/Instagram/repository/AlarmRepositoryQuerydsl.java
@@ -1,11 +1,10 @@
 package cloneproject.Instagram.repository;
 
-import java.util.List;
-
 import cloneproject.Instagram.dto.alarm.AlarmDTO;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface AlarmRepositoryQuerydsl {
     
-    public List<AlarmDTO> getAlarms(Long loginedMemberId);
-
+    Page<AlarmDTO> getAlarmDtoPageByMemberId(Pageable pageable, Long memberId);
 }

--- a/src/main/java/cloneproject/Instagram/repository/AlarmRepositoryQuerydslImpl.java
+++ b/src/main/java/cloneproject/Instagram/repository/AlarmRepositoryQuerydslImpl.java
@@ -1,62 +1,75 @@
 package cloneproject.Instagram.repository;
 
-import java.util.List;
+import cloneproject.Instagram.dto.alarm.AlarmContentDTO;
+import cloneproject.Instagram.dto.alarm.AlarmFollowDTO;
+import cloneproject.Instagram.dto.alarm.AlarmType;
+import cloneproject.Instagram.entity.alarms.Alarm;
+import cloneproject.Instagram.entity.member.Follow;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import cloneproject.Instagram.dto.alarm.AlarmDTO;
-import cloneproject.Instagram.dto.alarm.QAlarmDTO;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import static cloneproject.Instagram.entity.alarms.QAlarm.alarm;
+import static cloneproject.Instagram.entity.member.QFollow.follow;
+import static cloneproject.Instagram.entity.member.QMember.member;
+import static cloneproject.Instagram.entity.post.QPost.post;
+import static cloneproject.Instagram.entity.post.QPostImage.postImage;
 
 @RequiredArgsConstructor
-public class AlarmRepositoryQuerydslImpl implements AlarmRepositoryQuerydsl{
-    
+public class AlarmRepositoryQuerydslImpl implements AlarmRepositoryQuerydsl {
+
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<AlarmDTO> getAlarms(Long loginedMemberId){
+    public Page<AlarmDTO> getAlarmDtoPageByMemberId(Pageable pageable, Long memberId) {
+        final List<Alarm> alarms = queryFactory
+                .selectFrom(alarm)
+                .innerJoin(alarm.agent, member).fetchJoin()
+                .leftJoin(alarm.post, post).fetchJoin()
+                .leftJoin(post.postImages, postImage).fetchJoin()
+                .where(alarm.target.id.eq(memberId))
+                .orderBy(alarm.id.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
 
+        final List<Long> agentIds = alarms.stream()
+                .filter(a -> a.getType().equals(AlarmType.FOLLOW))
+                .map(a -> a.getAgent().getId())
+                .collect(Collectors.toList());
+        final Map<Long, Follow> followMap = queryFactory
+                .selectFrom(follow)
+                .where(
+                        follow.member.id.eq(memberId).and(
+                                follow.followMember.id.in(agentIds)
+                        )
+                )
+                .fetch()
+                .stream()
+                .collect(Collectors.toMap(f -> f.getFollowMember().getId(), f -> f));
 
-        // * 주석 처리한 부분은 로직이 복잡해 보류됨 참고 : Issue #76
-        // Map<Long, AlarmDTO> resultAboutComment = queryFactory
-        //                             .from(alarm)
-        //                             .where(alarm.target.id.eq(loginedMemberId).and(alarm.type.eq(AlarmType.POST_COMMENT_ALARM)))
-        //                             .transform(GroupBy.groupBy(alarm.id).as(new QAlarmDTO(
-        //                                 alarm.id,
-        //                                 alarm.type, 
-        //                                 alarm.agent.username, 
-        //                                 alarm.target.username, 
-        //                                 alarm.itemId, 
-        //                                 alarm.createdAt)));
+        final List<AlarmDTO> content = alarms.stream()
+                .map(a -> {
+                    if (a.getType().equals(AlarmType.FOLLOW))
+                        return new AlarmFollowDTO(a, followMap.containsKey(a.getAgent().getId()));
+                    else
+                        return new AlarmContentDTO(a);
+                })
+                .collect(Collectors.toList());
 
-        // Map<Long, Long> postIds = queryFactory
-        //                             .from(alarm)
-        //                             .where(alarm.target.id.eq(loginedMemberId).and(alarm.type.eq(AlarmType.POST_COMMENT_ALARM)))
-        //                             .transform(GroupBy.groupBy(alarm.id).as(
-        //                                 JPAExpressions
-        //                                     .select(comment.post.id)
-        //                                     .from(comment)
-        //                                     .where(comment.id.eq(alarm.itemId))        
-        //                             ));
-        
-        // resultAboutComment.forEach((key, alarm)->alarm.getItemIds().put("postId", postIds.get(key)));
+        final long total = queryFactory
+                .selectFrom(alarm)
+                .where(alarm.target.id.eq(memberId))
+                .fetchCount();
 
-        List<AlarmDTO> result = queryFactory
-                                    .select(new QAlarmDTO(
-                                        alarm.id,
-                                        alarm.type, 
-                                        alarm.agent.username, 
-                                        alarm.target.username, 
-                                        alarm.itemId, 
-                                        alarm.createdAt))
-
-                                    .from(alarm)
-                                    .where(alarm.target.id.eq(loginedMemberId))
-                                    // .where(alarm.target.id.eq(loginedMemberId).and(alarm.type.ne(AlarmType.POST_COMMENT_ALARM)))
-                                    .fetch();
-
-        // result.addAll(resultAboutComment.values());
-        return result;
+        return new PageImpl<>(content, pageable, total);
     }
-
 }

--- a/src/main/java/cloneproject/Instagram/repository/AlarmRepositoryQuerydslImpl.java
+++ b/src/main/java/cloneproject/Instagram/repository/AlarmRepositoryQuerydslImpl.java
@@ -22,6 +22,7 @@ import static cloneproject.Instagram.entity.member.QFollow.follow;
 import static cloneproject.Instagram.entity.member.QMember.member;
 import static cloneproject.Instagram.entity.post.QPost.post;
 import static cloneproject.Instagram.entity.post.QPostImage.postImage;
+import static com.querydsl.core.group.GroupBy.groupBy;
 
 @RequiredArgsConstructor
 public class AlarmRepositoryQuerydslImpl implements AlarmRepositoryQuerydsl {
@@ -46,15 +47,13 @@ public class AlarmRepositoryQuerydslImpl implements AlarmRepositoryQuerydsl {
                 .map(a -> a.getAgent().getId())
                 .collect(Collectors.toList());
         final Map<Long, Follow> followMap = queryFactory
-                .selectFrom(follow)
+                .from(follow)
                 .where(
                         follow.member.id.eq(memberId).and(
                                 follow.followMember.id.in(agentIds)
                         )
                 )
-                .fetch()
-                .stream()
-                .collect(Collectors.toMap(f -> f.getFollowMember().getId(), f -> f));
+                .transform(groupBy(follow.followMember.id).as(follow));
 
         final List<AlarmDTO> content = alarms.stream()
                 .map(a -> {

--- a/src/main/java/cloneproject/Instagram/repository/BookmarkRepository.java
+++ b/src/main/java/cloneproject/Instagram/repository/BookmarkRepository.java
@@ -1,10 +1,13 @@
 package cloneproject.Instagram.repository;
 
+import cloneproject.Instagram.entity.member.Member;
 import cloneproject.Instagram.entity.post.Bookmark;
+import cloneproject.Instagram.entity.post.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
-    Optional<Bookmark> findByMemberIdAndPostId(Long memberId, Long postId);
+
+    Optional<Bookmark> findByMemberAndPost(Member member, Post post);
 }

--- a/src/main/java/cloneproject/Instagram/repository/CommentLikeRepository.java
+++ b/src/main/java/cloneproject/Instagram/repository/CommentLikeRepository.java
@@ -1,0 +1,18 @@
+package cloneproject.Instagram.repository;
+
+import cloneproject.Instagram.entity.comment.Comment;
+import cloneproject.Instagram.entity.comment.CommentLike;
+import cloneproject.Instagram.entity.member.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> {
+
+    List<CommentLike> findAllByCommentIn(List<Comment> comments);
+
+    List<CommentLike> findAllByComment(Comment comment);
+
+    Optional<CommentLike> findByMemberAndComment(Member member, Comment comment);
+}

--- a/src/main/java/cloneproject/Instagram/repository/MemberPostRepositoryQuerydslImpl.java
+++ b/src/main/java/cloneproject/Instagram/repository/MemberPostRepositoryQuerydslImpl.java
@@ -80,7 +80,12 @@ public class MemberPostRepositoryQuerydslImpl implements MemberPostRepositoryQue
                                             .orderBy(post.id.desc())
                                             .distinct()
                                             .fetch();
-        
+
+        final long total = queryFactory
+                .selectFrom(post)
+                .where(post.member.username.eq(username))
+                .fetchCount();
+
         final List<Long> postIds = posts.stream()
                                     .map(MemberPostDTO::getPostId)
                                     .collect(Collectors.toList());
@@ -101,7 +106,7 @@ public class MemberPostRepositoryQuerydslImpl implements MemberPostRepositoryQue
         posts.forEach(p->p.setImageUrl(postImageDTOMap.get(p.getPostId()).get(0).getPostImageUrl()));    
                             
         
-        return new PageImpl<>(posts, pageable, posts.size());
+        return new PageImpl<>(posts, pageable, total);
     }
 
     @Override
@@ -118,7 +123,7 @@ public class MemberPostRepositoryQuerydslImpl implements MemberPostRepositoryQue
                                             .orderBy(bookmark.post.id.desc())
                                             .distinct()
                                             .fetch();
-        
+
         final List<Long> postIds = posts.stream()
                                     .map(MemberPostDTO::getPostId)
                                     .collect(Collectors.toList());
@@ -155,7 +160,12 @@ public class MemberPostRepositoryQuerydslImpl implements MemberPostRepositoryQue
                                             .orderBy(bookmark.post.id.desc())
                                             .distinct()
                                             .fetch();
-        
+
+        final long total = queryFactory
+                .selectFrom(bookmark)
+                .where(bookmark.member.id.eq(loginedUserId))
+                .fetchCount();
+
         final List<Long> postIds = posts.stream()
                                     .map(MemberPostDTO::getPostId)
                                     .collect(Collectors.toList());
@@ -176,7 +186,7 @@ public class MemberPostRepositoryQuerydslImpl implements MemberPostRepositoryQue
         posts.forEach(p->p.setImageUrl(postImageDTOMap.get(p.getPostId()).get(0).getPostImageUrl()));    
                             
         
-        return new PageImpl<>(posts, pageable, posts.size());
+        return new PageImpl<>(posts, pageable, total);
     }
 
     @Override
@@ -230,7 +240,12 @@ public class MemberPostRepositoryQuerydslImpl implements MemberPostRepositoryQue
                                             .orderBy(postTag.postImage.post.id.desc())
                                             .distinct()
                                             .fetch();
-        
+
+        final long total = queryFactory
+                .selectFrom(postTag)
+                .where(postTag.tag.username.eq(username))
+                .fetchCount();
+
         final List<Long> postIds = posts.stream()
                                     .map(MemberPostDTO::getPostId)
                                     .collect(Collectors.toList());
@@ -251,7 +266,7 @@ public class MemberPostRepositoryQuerydslImpl implements MemberPostRepositoryQue
         posts.forEach(p->p.setImageUrl(postImageDTOMap.get(p.getPostId()).get(0).getPostImageUrl()));    
                             
         
-        return new PageImpl<>(posts, pageable, posts.size());
+        return new PageImpl<>(posts, pageable, total);
     }
     
 }

--- a/src/main/java/cloneproject/Instagram/repository/MemberRepository.java
+++ b/src/main/java/cloneproject/Instagram/repository/MemberRepository.java
@@ -9,9 +9,15 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 import cloneproject.Instagram.entity.member.Member;
 
-public interface MemberRepository extends JpaRepository<Member, Long>, JpaSpecificationExecutor<Member>, MemberPostRepositoryQuerydsl,MemberRepositoryQuerydsl{
-    public Optional<Member> findByUsername(String username);
-    public Optional<Member> findById(Long id);
-    public List<Member> findAll(Specification<Member> spec);
-    public boolean existsByUsername(String username);
+public interface MemberRepository extends JpaRepository<Member, Long>, JpaSpecificationExecutor<Member>, MemberPostRepositoryQuerydsl, MemberRepositoryQuerydsl {
+
+    Optional<Member> findByUsername(String username);
+
+    Optional<Member> findById(Long id);
+
+    List<Member> findAll(Specification<Member> spec);
+
+    boolean existsByUsername(String username);
+
+    List<Member> findAllByUsernameIn(List<String> usernames);
 }

--- a/src/main/java/cloneproject/Instagram/repository/MemberRepositoryQuerydslImpl.java
+++ b/src/main/java/cloneproject/Instagram/repository/MemberRepositoryQuerydslImpl.java
@@ -1,16 +1,9 @@
 package cloneproject.Instagram.repository;
 
+import cloneproject.Instagram.dto.member.*;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
-import cloneproject.Instagram.dto.member.FollowDTO;
-import cloneproject.Instagram.dto.member.MiniProfileResponse;
-import cloneproject.Instagram.dto.member.QFollowDTO;
-import cloneproject.Instagram.dto.member.QMiniProfileResponse;
-import cloneproject.Instagram.dto.member.QSearchedMemberDTO;
-import cloneproject.Instagram.dto.member.QUserProfileResponse;
-import cloneproject.Instagram.dto.member.SearchedMemberDTO;
-import cloneproject.Instagram.dto.member.UserProfileResponse;
 import cloneproject.Instagram.dto.post.PostImageDTO;
 import cloneproject.Instagram.dto.post.QPostImageDTO;
 import cloneproject.Instagram.entity.member.Member;

--- a/src/main/java/cloneproject/Instagram/repository/MentionRepository.java
+++ b/src/main/java/cloneproject/Instagram/repository/MentionRepository.java
@@ -1,0 +1,15 @@
+package cloneproject.Instagram.repository;
+
+import cloneproject.Instagram.entity.comment.Comment;
+import cloneproject.Instagram.entity.mention.Mention;
+import cloneproject.Instagram.entity.post.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MentionRepository extends JpaRepository<Mention, Long>, MentionRepositoryJdbc {
+
+    List<Mention> findAllByPost(Post post);
+
+    List<Mention> findAllByComment(Comment comment);
+}

--- a/src/main/java/cloneproject/Instagram/repository/MentionRepositoryJdbc.java
+++ b/src/main/java/cloneproject/Instagram/repository/MentionRepositoryJdbc.java
@@ -1,0 +1,13 @@
+package cloneproject.Instagram.repository;
+
+import cloneproject.Instagram.entity.member.Member;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface MentionRepositoryJdbc {
+
+    void savePostMentionsBatch(Long memberId, List<Member> mentionedMembers, Long postId, LocalDateTime now);
+
+    void saveCommentMentionsBatch(Long memberId, List<Member> mentionedMembers, Long postId, Long commentId, LocalDateTime now);
+}

--- a/src/main/java/cloneproject/Instagram/repository/MentionRepositoryJdbcImpl.java
+++ b/src/main/java/cloneproject/Instagram/repository/MentionRepositoryJdbcImpl.java
@@ -1,0 +1,72 @@
+package cloneproject.Instagram.repository;
+
+import cloneproject.Instagram.entity.member.Member;
+import cloneproject.Instagram.entity.mention.MentionType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@RequiredArgsConstructor
+public class MentionRepositoryJdbcImpl implements MentionRepositoryJdbc {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Override
+    public void savePostMentionsBatch(Long memberId, List<Member> mentionedMembers, Long postId, LocalDateTime now) {
+        final String sql =
+                "INSERT INTO mentions (`mention_create_date`, `mention_type`, `agent_id`, `comment_id`, `post_id`, `target_id`) " +
+                        "VALUES(?, ?, ?, ?, ?, ?)";
+
+        jdbcTemplate.batchUpdate(
+                sql,
+                new BatchPreparedStatementSetter() {
+                    @Override
+                    public void setValues(PreparedStatement ps, int i) throws SQLException {
+                        ps.setString(1, now.toString());
+                        ps.setString(2, MentionType.POST.name());
+                        ps.setString(3, memberId.toString());
+                        ps.setString(4, null);
+                        ps.setString(5, postId.toString());
+                        ps.setString(6, mentionedMembers.get(i).getId().toString());
+                    }
+
+                    @Override
+                    public int getBatchSize() {
+                        return mentionedMembers.size();
+                    }
+                }
+        );
+    }
+
+    @Override
+    public void saveCommentMentionsBatch(Long memberId, List<Member> mentionedMembers, Long postId, Long commentId, LocalDateTime now) {
+        final String sql =
+                "INSERT INTO mentions (`mention_create_date`, `mention_type`, `agent_id`, `comment_id`, `post_id`, `target_id`) " +
+                        "VALUES(?, ?, ?, ?, ?, ?)";
+
+        jdbcTemplate.batchUpdate(
+                sql,
+                new BatchPreparedStatementSetter() {
+                    @Override
+                    public void setValues(PreparedStatement ps, int i) throws SQLException {
+                        ps.setString(1, now.toString());
+                        ps.setString(2, MentionType.COMMENT.name());
+                        ps.setString(3, memberId.toString());
+                        ps.setString(4, commentId.toString());
+                        ps.setString(5, postId.toString());
+                        ps.setString(6, mentionedMembers.get(i).getId().toString());
+                    }
+
+                    @Override
+                    public int getBatchSize() {
+                        return mentionedMembers.size();
+                    }
+                }
+        );
+    }
+}

--- a/src/main/java/cloneproject/Instagram/repository/PostImageRepository.java
+++ b/src/main/java/cloneproject/Instagram/repository/PostImageRepository.java
@@ -1,10 +1,14 @@
 package cloneproject.Instagram.repository;
 
+import cloneproject.Instagram.entity.post.Post;
 import cloneproject.Instagram.entity.post.PostImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface PostImageRepository extends JpaRepository<PostImage, Long> {
+
     List<PostImage> findAllByPostId(Long postId);
+
+    List<PostImage> findAllByPost(Post post);
 }

--- a/src/main/java/cloneproject/Instagram/repository/PostLikeRepository.java
+++ b/src/main/java/cloneproject/Instagram/repository/PostLikeRepository.java
@@ -1,10 +1,16 @@
 package cloneproject.Instagram.repository;
 
+import cloneproject.Instagram.entity.member.Member;
+import cloneproject.Instagram.entity.post.Post;
 import cloneproject.Instagram.entity.post.PostLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
-public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
-    Optional<PostLike> findByMemberIdAndPostId(Long memberId, Long postId);
+public interface PostLikeRepository extends JpaRepository<PostLike, Long>, PostLikeRepositoryQuerydsl {
+
+    List<PostLike> findAllByPost(Post post);
+
+    Optional<PostLike> findByMemberAndPost(Member member, Post post);
 }

--- a/src/main/java/cloneproject/Instagram/repository/PostLikeRepositoryQuerydsl.java
+++ b/src/main/java/cloneproject/Instagram/repository/PostLikeRepositoryQuerydsl.java
@@ -1,0 +1,12 @@
+package cloneproject.Instagram.repository;
+
+import cloneproject.Instagram.dto.member.LikeMembersDTO;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface PostLikeRepositoryQuerydsl {
+
+    Page<LikeMembersDTO> findLikeMembersDtoPageByPostIdAndMemberId(Pageable pageable, Long postId, Long memberId);
+
+    Page<LikeMembersDTO> findLikeMembersDtoPageByCommentIdAndMemberId(Pageable pageable, Long commentId, Long memberId);
+}

--- a/src/main/java/cloneproject/Instagram/repository/PostLikeRepositoryQuerydslImpl.java
+++ b/src/main/java/cloneproject/Instagram/repository/PostLikeRepositoryQuerydslImpl.java
@@ -1,0 +1,130 @@
+package cloneproject.Instagram.repository;
+
+import cloneproject.Instagram.dto.member.LikeMembersDTO;
+import cloneproject.Instagram.dto.member.QLikeMembersDTO;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static cloneproject.Instagram.entity.comment.QCommentLike.commentLike;
+import static cloneproject.Instagram.entity.member.QFollow.follow;
+import static cloneproject.Instagram.entity.member.QMember.member;
+import static cloneproject.Instagram.entity.member.QMemberStory.memberStory;
+import static cloneproject.Instagram.entity.post.QPostLike.postLike;
+import static cloneproject.Instagram.entity.story.QStory.story;
+
+@RequiredArgsConstructor
+public class PostLikeRepositoryQuerydslImpl implements PostLikeRepositoryQuerydsl {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<LikeMembersDTO> findLikeMembersDtoPageByPostIdAndMemberId(Pageable pageable, Long postId, Long memberId) {
+        final List<LikeMembersDTO> likeMembersDTOs = queryFactory
+                .select(new QLikeMembersDTO(
+                        postLike.member.username,
+                        postLike.member.name,
+                        postLike.member.image,
+                        JPAExpressions
+                                .selectFrom(follow)
+                                .where(
+                                        follow.member.id.eq(memberId)
+                                                .and(follow.followMember.eq(postLike.member))
+                                )
+                                .exists(),
+                        JPAExpressions
+                                .selectFrom(follow)
+                                .where(
+                                        follow.member.eq(postLike.member)
+                                                .and(follow.followMember.id.eq(memberId))
+                                )
+                                .exists(),
+                        JPAExpressions
+                                .selectFrom(memberStory)
+                                .innerJoin(memberStory.story, story)
+                                .where(
+                                        memberStory.member.id.eq(memberId)
+                                                .and(memberStory.story.uploadDate.after(LocalDateTime.now().minusHours(24)))
+                                )
+                                .exists()
+                ))
+                .from(postLike)
+                .innerJoin(postLike.member, member)
+                .where(
+                        postLike.post.id.eq(postId)
+                                .and(postLike.member.id.ne(memberId))
+                )
+                .orderBy(postLike.id.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        final long total = queryFactory
+                .selectFrom(postLike)
+                .where(
+                        postLike.post.id.eq(postId)
+                                .and(postLike.member.id.ne(memberId))
+                )
+                .fetchCount();
+
+        return new PageImpl<>(likeMembersDTOs, pageable, total);
+    }
+
+    @Override
+    public Page<LikeMembersDTO> findLikeMembersDtoPageByCommentIdAndMemberId(Pageable pageable, Long commentId, Long memberId) {
+        final List<LikeMembersDTO> likeMembersDTOs = queryFactory
+                .select(new QLikeMembersDTO(
+                        commentLike.member.username,
+                        commentLike.member.name,
+                        commentLike.member.image,
+                        JPAExpressions
+                                .selectFrom(follow)
+                                .where(
+                                        follow.member.id.eq(memberId)
+                                                .and(follow.followMember.eq(commentLike.member))
+                                )
+                                .exists(),
+                        JPAExpressions
+                                .selectFrom(follow)
+                                .where(
+                                        follow.member.eq(commentLike.member)
+                                                .and(follow.followMember.id.eq(memberId))
+                                )
+                                .exists(),
+                        JPAExpressions
+                                .selectFrom(memberStory)
+                                .innerJoin(memberStory.story, story)
+                                .where(
+                                        memberStory.member.id.eq(memberId)
+                                                .and(memberStory.story.uploadDate.after(LocalDateTime.now().minusHours(24)))
+                                )
+                                .exists()
+                ))
+                .from(commentLike)
+                .innerJoin(commentLike.member, member)
+                .where(
+                        commentLike.comment.id.eq(commentId)
+                                .and(commentLike.member.id.ne(memberId))
+                )
+                .orderBy(commentLike.id.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        final long total = queryFactory
+                .selectFrom(commentLike)
+                .where(
+                        commentLike.comment.id.eq(commentId)
+                                .and(commentLike.member.id.ne(memberId))
+                )
+                .fetchCount();
+
+        return new PageImpl<>(likeMembersDTOs, pageable, total);
+    }
+}

--- a/src/main/java/cloneproject/Instagram/repository/PostTagRepository.java
+++ b/src/main/java/cloneproject/Instagram/repository/PostTagRepository.java
@@ -1,7 +1,12 @@
 package cloneproject.Instagram.repository;
 
+import cloneproject.Instagram.entity.post.PostImage;
 import cloneproject.Instagram.entity.post.PostTag;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PostTagRepository extends JpaRepository<PostTag, Long> {
+
+    List<PostTag> findAllByPostImageIn(List<PostImage> postImages);
 }

--- a/src/main/java/cloneproject/Instagram/repository/post/CommentRepository.java
+++ b/src/main/java/cloneproject/Instagram/repository/post/CommentRepository.java
@@ -1,14 +1,21 @@
 package cloneproject.Instagram.repository.post;
 
 import cloneproject.Instagram.entity.comment.Comment;
+import cloneproject.Instagram.entity.post.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CommentRepository extends JpaRepository<Comment, Long>, CommentRepositoryQuerydsl{
 
-    @Query(value = "select p from Comment p join fetch p.member where p.id = :id")
+    @Query(value = "select c from Comment c join fetch c.member where c.id = :id")
     Optional<Comment> findWithMemberById(@Param("id") Long id);
+
+    @Query(value = "select c from Comment c join fetch c.post p join fetch p.member where c.id = :id")
+    Optional<Comment> findWithPostAndMemberById(@Param("id") Long id);
+
+    List<Comment> findAllByPost(Post post);
 }

--- a/src/main/java/cloneproject/Instagram/repository/post/CommentRepositoryQuerydslImpl.java
+++ b/src/main/java/cloneproject/Instagram/repository/post/CommentRepositoryQuerydslImpl.java
@@ -44,7 +44,12 @@ public class CommentRepositoryQuerydslImpl implements CommentRepositoryQuerydsl 
                 .limit(pageable.getPageSize())
                 .fetch();
 
-        return new PageImpl<>(commentDTOs, pageable, commentDTOs.size());
+        final long total = queryFactory
+                .selectFrom(comment)
+                .where(comment.post.id.eq(postId).and(comment.id.eq(comment.parent.id)))
+                .fetchCount();
+
+        return new PageImpl<>(commentDTOs, pageable, total);
     }
 
     @Override
@@ -71,6 +76,11 @@ public class CommentRepositoryQuerydslImpl implements CommentRepositoryQuerydsl 
                 .limit(pageable.getPageSize())
                 .fetch();
 
-        return new PageImpl<>(commentDTOs, pageable, commentDTOs.size());
+        final long total = queryFactory
+                .selectFrom(comment)
+                .where(comment.parent.id.eq(commentId))
+                .fetchCount();
+
+        return new PageImpl<>(commentDTOs, pageable, total);
     }
 }

--- a/src/main/java/cloneproject/Instagram/repository/post/PostRepository.java
+++ b/src/main/java/cloneproject/Instagram/repository/post/PostRepository.java
@@ -2,18 +2,16 @@ package cloneproject.Instagram.repository.post;
 
 import cloneproject.Instagram.entity.post.Post;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryQuerydsl, PostRepositoryJdbc {
 
     Optional<Post> findByIdAndMemberId(Long postId, Long memberId);
-    Page<Post> findByMemberId(Long memberId, Pageable pageable);
-    List<Post> findTop3ByMemberIdOrderByUploadDateDesc(Long memberId);    
-    int countByMemberId(Long memberId);
 
+    @Query("select p from Post p join fetch p.member where p.id = :postId")
+    Optional<Post> findWithMemberById(@Param("postId") Long postId);
 }

--- a/src/main/java/cloneproject/Instagram/repository/post/RecentCommentRepository.java
+++ b/src/main/java/cloneproject/Instagram/repository/post/RecentCommentRepository.java
@@ -1,11 +1,17 @@
 package cloneproject.Instagram.repository.post;
 
 import cloneproject.Instagram.entity.comment.RecentComment;
+import cloneproject.Instagram.entity.post.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface RecentCommentRepository extends JpaRepository<RecentComment, Long> {
 
-    List<RecentComment> findAllByPostId(Long postId);
+    @Query("select rc from RecentComment rc join fetch rc.comment where rc.post.id = :id")
+    List<RecentComment> findAllWithCommentByPostId(@Param("id") Long id);
+
+    List<RecentComment> findAllByPost(Post post);
 }

--- a/src/main/java/cloneproject/Instagram/service/AlarmService.java
+++ b/src/main/java/cloneproject/Instagram/service/AlarmService.java
@@ -1,8 +1,12 @@
 package cloneproject.Instagram.service;
 
-import java.util.Collections;
-import java.util.List;
-
+import cloneproject.Instagram.entity.comment.Comment;
+import cloneproject.Instagram.entity.member.Follow;
+import cloneproject.Instagram.entity.post.Post;
+import cloneproject.Instagram.exception.MismatchedAlarmTypeException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,35 +20,102 @@ import cloneproject.Instagram.repository.AlarmRepository;
 import cloneproject.Instagram.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static cloneproject.Instagram.dto.alarm.AlarmType.*;
+
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class AlarmService {
-    
+
     private final AlarmRepository alarmRepository;
     private final MemberRepository memberRepository;
 
-    @Transactional
-    public List<AlarmDTO> getAlarms(){
+    public Page<AlarmDTO> getAlarms(int page, int size) {
         final String memberId = SecurityContextHolder.getContext().getAuthentication().getName();
-        List<AlarmDTO> result = alarmRepository.getAlarms(Long.valueOf(memberId));
-        // alarmRepository.deleteAllByTargetId(Long.valueOf(memberId));
-        Collections.sort(result);
-        Collections.reverse(result);
-        return result;
+        page = (page == 0 ? 0 : page - 1);
+        final Pageable pageable = PageRequest.of(page, size);
+        return alarmRepository.getAlarmDtoPageByMemberId(pageable, Long.valueOf(memberId));
     }
 
     @Transactional
-    public void alert(AlarmType type, Member target, Long itemId){
-        final String memberId = SecurityContextHolder.getContext().getAuthentication().getName();
-        Member agent = memberRepository.findById(Long.valueOf(memberId))
-                        .orElseThrow(MemberDoesNotExistException::new);
-        Alarm alarm = Alarm.builder()
-                            .type(type)
-                            .agent(agent)
-                            .target(target)
-                            .itemId(itemId)
-                            .build();
+    public void alert(Member target, Follow follow) {
+        final Alarm alarm = Alarm.builder()
+                .type(FOLLOW)
+                .agent(getAgent())
+                .target(target)
+                .follow(follow)
+                .build();
+
         alarmRepository.save(alarm);
     }
 
+    @Transactional
+    public void alert(AlarmType type, Member target, Post post) {
+        if (!type.equals(LIKE_POST))
+            throw new MismatchedAlarmTypeException();
+
+        final Alarm alarm = Alarm.builder()
+                .type(type)
+                .agent(getAgent())
+                .target(target)
+                .post(post)
+                .build();
+
+        alarmRepository.save(alarm);
+    }
+
+    @Transactional
+    public void alertBatch(AlarmType type, List<Member> targets, Post post) {
+        if (!type.equals(MENTION_POST))
+            throw new MismatchedAlarmTypeException();
+
+        alarmRepository.saveMentionPostAlarms(getAgent(), targets, post, LocalDateTime.now());
+    }
+
+    @Transactional
+    public void alertBatch(AlarmType type, List<Member> targets, Post post, Comment comment) {
+        if (!type.equals(MENTION_COMMENT))
+            throw new MismatchedAlarmTypeException();
+
+        alarmRepository.saveMentionCommentAlarms(getAgent(), targets, post, comment, LocalDateTime.now());
+    }
+
+    @Transactional
+    public void alert(AlarmType type, Member target, Post post, Comment comment) {
+        if (!type.equals(COMMENT) && !type.equals(LIKE_COMMENT) && !type.equals(MENTION_COMMENT))
+            throw new MismatchedAlarmTypeException();
+
+        final Alarm alarm = Alarm.builder()
+                .type(type)
+                .agent(getAgent())
+                .target(target)
+                .post(post)
+                .comment(comment)
+                .build();
+
+        alarmRepository.save(alarm);
+    }
+
+    @Transactional
+    public void delete(AlarmType type, Member target, Post post) {
+        alarmRepository.deleteByTypeAndAgentAndTargetAndPost(type, getAgent(), target, post);
+    }
+    @Transactional
+    public void delete(AlarmType type, Member target, Comment comment) {
+        alarmRepository.deleteByTypeAndAgentAndTargetAndComment(type, getAgent(), target, comment);
+    }
+
+    @Transactional
+    public void delete(Member target, Follow follow) {
+        alarmRepository.deleteByTypeAndAgentAndTargetAndFollow(FOLLOW, getAgent(), target, follow);
+    }
+
+    private Member getAgent() {
+        final String memberId = SecurityContextHolder.getContext().getAuthentication().getName();
+        return memberRepository.findById(Long.valueOf(memberId))
+                .orElseThrow(MemberDoesNotExistException::new);
+    }
 }

--- a/src/main/java/cloneproject/Instagram/service/MemberService.java
+++ b/src/main/java/cloneproject/Instagram/service/MemberService.java
@@ -1,8 +1,5 @@
 package cloneproject.Instagram.service;
 
-
-
-import java.io.IOException;
 import java.util.List;
 
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -14,7 +11,6 @@ import cloneproject.Instagram.dto.member.*;
 import cloneproject.Instagram.entity.member.Gender;
 import cloneproject.Instagram.entity.member.Member;
 import cloneproject.Instagram.exception.MemberDoesNotExistException;
-import cloneproject.Instagram.exception.UploadProfileImageFailException;
 import cloneproject.Instagram.exception.UseridAlreadyExistException;
 import cloneproject.Instagram.repository.MemberRepository;
 import cloneproject.Instagram.util.AuthUtil;
@@ -84,12 +80,7 @@ public class MemberService {
         Image originalImage = member.getImage();
         s3Uploader.deleteImage("member", originalImage);
 
-        Image image;
-        try{
-            image = s3Uploader.uploadImage(uploadedImage, "member");
-        }catch(IOException e){
-            throw new UploadProfileImageFailException();
-        }
+        Image image = s3Uploader.uploadImage(uploadedImage, "member");
         member.uploadImage(image);
         memberRepository.save(member);
     }

--- a/src/main/java/cloneproject/Instagram/util/StringExtractUtil.java
+++ b/src/main/java/cloneproject/Instagram/util/StringExtractUtil.java
@@ -1,0 +1,40 @@
+package cloneproject.Instagram.util;
+
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Component
+public class StringExtractUtil {
+
+    public List<String> extractMentions(String input, List<String> usernames) {
+        final Set<String> mentions = new HashSet<>();
+        final String regex = "@[0-9a-zA-Z가-힣ㄱ-ㅎ]+";
+        final Pattern pattern = Pattern.compile(regex);
+        final Matcher matcher = pattern.matcher(input);
+
+        while (matcher.find())
+            mentions.add(matcher.group().substring(1));
+        for (String username : usernames)
+            mentions.remove(username);
+
+        return new ArrayList<>(mentions);
+    }
+
+    public List<String> extractHashtags(String input) {
+        final Set<String> hashtags = new HashSet<>();
+        final String regex = "#[0-9a-zA-Z가-힣ㄱ-ㅎ_]+";
+        final Pattern pattern = Pattern.compile(regex);
+        final Matcher matcher = pattern.matcher(input);
+
+        while (matcher.find())
+            hashtags.add(matcher.group().substring(1));
+
+        return new ArrayList<>(hashtags);
+    }
+}


### PR DESCRIPTION
## 변경 사항

### 알림 엔티티 수정
- Post, Comment, Follow 1:1 연관관계 추가
 댓글 삭제 시, 해당 댓글과 연관된 모든 알림을 삭제해야 함.
기존의 설계로는 알림 엔티티에 댓글 pk를 따로 저장하지 않아 위의 작업이 불가능하였음.
위의 작업을 수행하기 위해 null 값을 감안하며, Post, Comment, Follow 연관관계를 추가함 -> 조회 시 left outer join 사용

- AlarmType 수정
 itemType은 필요가 없어서 제거함.
 이미지에 회원을 태그하는 알림은 인스타에 존재하지 않음 -> 따로 DM으로 전송되는 방식
따라서 태그 알림 타입 제거함.
 인스타 알림과 동일하게 종류들을 재설계 하였으며, 메시지도 인스타와 통일시킴

### 알림 조회 -> 페이징 조회로 변경
- 조회 방식 변경
 인스타에서 알림 조회 시 페이징 방식으로 조회함.
따라서 페이징 방식으로 변경하였음

- 조회 타입에 따라 다른 DTO 응답
 팔로우 응답의 경우, 해당 회원을 팔로잉한 여부를 추가로 표현함.
 나머지 응답의 경우, 해당 게시물의 이미지와 내용(게시물 or 댓글)을 추가로 표현함.
 공통 데이터는 부모 클래스 DTO에, 위의 두 가지 경우는 각각 자식 클래스 DTO에 넣고, 다형성을 이용하여 응답

### 멘션 엔티티 추가, 게시물 or 댓글 작성 시 멘션 알림 추가
- 멘션 엔티티 추가
 멘션은 게시물과 댓글에서만 가능하므로 MentionType은 POST, COMMENT만 추가함.

- 게시물 or 댓글 작성 시 멘션, 멘션 알림 엔티티 추가
 content를 파싱하여 멘션한 회원들을 추출하는 StringExtractUtil을 추가함.
 멘션한 회원들마다 각각 멘션 엔티티와 멘션 알림 엔티티 추가 -> JdbcTemplate을 이용하여 batch update

- AlarmService 알람 추가/삭제 메소드 업데이트
 알람 타입별로 추가/삭제하는 메소드를 추가함.
 멘션의 경우 여러 명이 될 수 있으므로 JdbcTemplate을 이용하여 batch update

### 댓글 좋아요/취소, 게시물/댓글 좋아요한 사람 목록 조회 API 추가 등
- 좋아요한 사람 목록 조회
 본인도 좋아요한 사람 중 한 명이라도, 본인 정보는 목록에 포함되지 않음 (인스타방식)

- 게시글/댓글 좋아요/취소 시 알람 추가/제거

- 회원 목록 조회 시, 스토리 여부 포함
 24시간 이내에 스토리를 올린 경우 hasStory를 true로 응답 데이터 추가
기본적으로 스토리를 추가하면, Story(보관함)와 MemberStory 엔티티를 각각 추가하고, MemberStory는 회원, 스토리와 각각 1:1 연관관계를 가진다.
회원 목록 조회 시, MemberStory에 스토리가 등록되어 있다면, 해당 스토리 업로드 시간과 현재 시간을 비교하여 24시간 이내면 hasStory를 true로 설정

- find__By{entity}Id -> find__By{entity} 변경
 첫 번째 방식은 left outer join으로 조회하고, 두 번째 방식은 inner join으로 조회하므로 성능상 후자가 유리하므로 변경함.

- 엔티티 삭제 시, 연관 엔티티 제거 로직 추가 (batch)
 팔로우와 좋아요는 1:1 매핑이므로 delete 쿼리 한 번 발생
 게시물과 댓글은 1:N 매핑인 연관관계가 여러 개 존재하므로 batch delete로 처리함.

### 페이지 조회 시, total size 불일치 해결
- PageImpl 생성자의 마지막 인자에 전체 사이즈를 넣어줘야 함

### S3Uploader 예외 throw-> 내부에서 catch하도록 변경
- 업로드가 안되는 건 AWS와의 통신 문제이며 서버 문제이므로 500 응답 처리로 변경
try-catch 구문이 불필요하게 중복 작성하는 문제로 try-catch 구문을 S3Uploader 내부로 이동

### 채팅방 목록/채팅 메시지 목록 조회 API 응답 데이터 오류 해결
- 채팅방 목록 조회 API 응답 데이터 오류
 읽지 않은 채팅방이 존재하면, 모든 채팅방이 읽지 않음으로 응답이 생성됨
where 절에 조건을 추가하여 해결함.

- 채팅 메시지 목록 조회 API 응답: 채팅 메시지 꼬임 현상
 매우 빠르게 채팅을 전송하면, 초단위로 저장되기 때문에 밀리초는 생략되어 순서 꼬임 현상이 발생함
날짜 순이 아닌, id 순으로 정렬함으로써 해결함.

## 해결 이슈
- Resolve: #74
- Resolve: #91 
- Resolve: #92 
- Resolve: #102 
- Resolve: #105 
- Resolve: #106 