### PR TITLE
Test/member controller

### DIFF
--- a/src/main/java/cloneproject/Instagram/advice/GlobalExceptionHandler.java
+++ b/src/main/java/cloneproject/Instagram/advice/GlobalExceptionHandler.java
@@ -3,12 +3,15 @@ package cloneproject.Instagram.advice;
 import cloneproject.Instagram.dto.error.ErrorCode;
 import cloneproject.Instagram.dto.error.ErrorResponse;
 import cloneproject.Instagram.exception.BusinessException;
+import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BindException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -17,8 +20,22 @@ import org.springframework.web.multipart.support.MissingServletRequestPartExcept
 import static cloneproject.Instagram.dto.error.ErrorCode.*;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 
+import javax.validation.ConstraintViolationException;
+
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    @ExceptionHandler
+    protected ResponseEntity<ErrorResponse> handleMissingServletRequestParameterException(MissingServletRequestParameterException e) {
+        final ErrorResponse response = ErrorResponse.of(INVALID_INPUT_VALUE, e.getParameterName());
+        return new ResponseEntity<>(response, BAD_REQUEST);
+    }
+
+    @ExceptionHandler
+    protected ResponseEntity<ErrorResponse> handleConstraintViolationException(ConstraintViolationException e) {
+        final ErrorResponse response = ErrorResponse.of(INVALID_INPUT_VALUE, e.getConstraintViolations());
+        return new ResponseEntity<>(response, BAD_REQUEST);
+    }
 
     @ExceptionHandler
     protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {

--- a/src/main/java/cloneproject/Instagram/controller/MemberAuthController.java
+++ b/src/main/java/cloneproject/Instagram/controller/MemberAuthController.java
@@ -2,14 +2,17 @@ package cloneproject.Instagram.controller;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
 
 import org.hibernate.validator.constraints.Length;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -35,6 +38,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Api(tags = "멤버 인증 API")
+@Validated
 @RestController
 @RequiredArgsConstructor
 public class MemberAuthController {
@@ -47,11 +51,9 @@ public class MemberAuthController {
         @ApiImplicitParam(name = "Authorization", value = "불필요", required = false, example = " "),
         @ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma")
     })
-    @PostMapping(value = "/accounts/check")
+    @GetMapping(value = "/accounts/check")
     public ResponseEntity<ResultResponse> checkUsername(
                             @RequestParam
-                            @Validated  
-                            @NotBlank(message = "username을 입력해주세요")
                             @Length(min = 4, max = 12, message = "사용자 이름은 4문자 이상 12문자 이하여야 합니다")
                             @Pattern(regexp = "^[0-9a-zA-Z]+$", message = "username엔 대소문자, 숫자만 사용할 수 있습니다.") 
                             String username) {

--- a/src/main/java/cloneproject/Instagram/controller/MemberController.java
+++ b/src/main/java/cloneproject/Instagram/controller/MemberController.java
@@ -126,9 +126,7 @@ public class MemberController {
     @ApiOperation(value = "멤버 검색")
     @ApiImplicitParam(name = "text", value = "검색내용", required = true, example = "dlwl")
     @GetMapping(value = "/search")
-    public ResponseEntity<ResultResponse> searchMember(
-        @RequestParam
-        String text) {
+    public ResponseEntity<ResultResponse> searchMember(@RequestParam String text) {
         List<SearchedMemberDTO> memberInfos = memberService.searchMember(text);
 
         ResultResponse result = ResultResponse.of(ResultCode.SEARCH_MEMBER_SUCCESS, memberInfos);

--- a/src/main/java/cloneproject/Instagram/controller/MemberController.java
+++ b/src/main/java/cloneproject/Instagram/controller/MemberController.java
@@ -62,10 +62,7 @@ public class MemberController {
         @ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma")
     })
     @GetMapping(value = "/accounts/{username}")
-    public ResponseEntity<ResultResponse> getUserProfile(
-        @PathVariable("username")
-        @Length(min = 4, max = 12, message = "사용자 이름은 4문자 이상 12문자 이하여야 합니다")
-        String username){
+    public ResponseEntity<ResultResponse> getUserProfile(@PathVariable("username") String username){
         UserProfileResponse userProfileResponse = memberService.getUserProfile(username);
 
         ResultResponse result = ResultResponse.of(ResultCode.GET_USERPROFILE_SUCCESS, userProfileResponse);
@@ -77,10 +74,7 @@ public class MemberController {
         @ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma")
     })
     @GetMapping(value = "/accounts/{username}/mini")
-    public ResponseEntity<ResultResponse> getMiniProfile(
-        @PathVariable("username")
-        @Length(min = 4, max = 12, message = "사용자 이름은 4문자 이상 12문자 이하여야 합니다")
-        String username){
+    public ResponseEntity<ResultResponse> getMiniProfile(@PathVariable("username") String username){
         MiniProfileResponse miniProfileResponse = memberService.getMiniProfile(username);
 
         ResultResponse result = ResultResponse.of(ResultCode.GET_MINIPROFILE_SUCCESS, miniProfileResponse);

--- a/src/main/java/cloneproject/Instagram/controller/MemberController.java
+++ b/src/main/java/cloneproject/Instagram/controller/MemberController.java
@@ -9,6 +9,9 @@ import io.swagger.annotations.ApiOperation;
 
 import java.util.List;
 
+import javax.validation.constraints.NotBlank;
+
+import org.hibernate.validator.constraints.Length;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -36,6 +39,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Slf4j
+@Validated
 @Api(tags = "멤버 API")
 @RestController
 @RequiredArgsConstructor
@@ -58,7 +62,10 @@ public class MemberController {
         @ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma")
     })
     @GetMapping(value = "/accounts/{username}")
-    public ResponseEntity<ResultResponse> getUserProfile(@PathVariable("username") String username){
+    public ResponseEntity<ResultResponse> getUserProfile(
+        @PathVariable("username")
+        @Length(min = 4, max = 12, message = "사용자 이름은 4문자 이상 12문자 이하여야 합니다")
+        String username){
         UserProfileResponse userProfileResponse = memberService.getUserProfile(username);
 
         ResultResponse result = ResultResponse.of(ResultCode.GET_USERPROFILE_SUCCESS, userProfileResponse);
@@ -70,7 +77,10 @@ public class MemberController {
         @ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma")
     })
     @GetMapping(value = "/accounts/{username}/mini")
-    public ResponseEntity<ResultResponse> getMiniProfile(@PathVariable("username") String username){
+    public ResponseEntity<ResultResponse> getMiniProfile(
+        @PathVariable("username")
+        @Length(min = 4, max = 12, message = "사용자 이름은 4문자 이상 12문자 이하여야 합니다")
+        String username){
         MiniProfileResponse miniProfileResponse = memberService.getMiniProfile(username);
 
         ResultResponse result = ResultResponse.of(ResultCode.GET_MINIPROFILE_SUCCESS, miniProfileResponse);
@@ -115,8 +125,11 @@ public class MemberController {
 
     @ApiOperation(value = "멤버 검색")
     @ApiImplicitParam(name = "text", value = "검색내용", required = true, example = "dlwl")
-    @PostMapping(value = "/search")
-    public ResponseEntity<ResultResponse> searchMember(@RequestParam String text) {
+    @GetMapping(value = "/search")
+    public ResponseEntity<ResultResponse> searchMember(
+        @RequestParam
+        @NotBlank(message = "text를 입력해주세요") 
+        String text) {
         List<SearchedMemberDTO> memberInfos = memberService.searchMember(text);
 
         ResultResponse result = ResultResponse.of(ResultCode.SEARCH_MEMBER_SUCCESS, memberInfos);

--- a/src/main/java/cloneproject/Instagram/controller/MemberController.java
+++ b/src/main/java/cloneproject/Instagram/controller/MemberController.java
@@ -128,7 +128,6 @@ public class MemberController {
     @GetMapping(value = "/search")
     public ResponseEntity<ResultResponse> searchMember(
         @RequestParam
-        @NotBlank(message = "text를 입력해주세요") 
         String text) {
         List<SearchedMemberDTO> memberInfos = memberService.searchMember(text);
 

--- a/src/main/java/cloneproject/Instagram/dto/error/ErrorResponse.java
+++ b/src/main/java/cloneproject/Instagram/dto/error/ErrorResponse.java
@@ -8,7 +8,10 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
+
+import javax.validation.ConstraintViolation;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -35,6 +38,14 @@ public class ErrorResponse {
 
     public static ErrorResponse of(final ErrorCode code, final BindingResult bindingResult) {
         return new ErrorResponse(code, FieldError.of(bindingResult));
+    }
+
+    public static ErrorResponse of(final ErrorCode code, final Set<ConstraintViolation<?>> constraintViolations) {
+        return new ErrorResponse(code, FieldError.of(constraintViolations));
+    }
+
+    public static ErrorResponse of(final ErrorCode code, final String missingParameterName) {
+        return new ErrorResponse(code, FieldError.of(missingParameterName, "", "parameter가 필요합니다"));
     }
 
     public static ErrorResponse of(final ErrorCode code) {
@@ -77,6 +88,16 @@ public class ErrorResponse {
                             error.getField(),
                             error.getRejectedValue() == null ? "" : error.getRejectedValue().toString(),
                             error.getDefaultMessage()))
+                    .collect(Collectors.toList());
+        }
+
+        private static List<FieldError> of(final Set<ConstraintViolation<?>> constraintViolations) {
+            List<ConstraintViolation<?>> lists = new ArrayList<>(constraintViolations);
+            return lists.stream()
+                    .map(error -> new FieldError(
+                            error.getPropertyPath().toString(),
+                            "" ,
+                            error.getMessageTemplate()))
                     .collect(Collectors.toList());
         }
     }

--- a/src/main/java/cloneproject/Instagram/dto/member/EditProfileRequest.java
+++ b/src/main/java/cloneproject/Instagram/dto/member/EditProfileRequest.java
@@ -40,7 +40,6 @@ public class EditProfileRequest {
     String memberEmail;
 
     @ApiModelProperty(value = "전화번호", example = "010-0000-0000", required = false)
-    @NotBlank(message = "휴대폰 번호를 입력해주세요")
     @Pattern(regexp = "^\\d{3}-\\d{3,4}-\\d{4}$", message = "휴대폰 번호 양식이 맞지 않습니다")
     String memberPhone;
 

--- a/src/main/java/cloneproject/Instagram/dto/member/EditProfileRequest.java
+++ b/src/main/java/cloneproject/Instagram/dto/member/EditProfileRequest.java
@@ -36,6 +36,7 @@ public class EditProfileRequest {
     String memberIntroduce;
 
     @ApiModelProperty(value = "이메일", example = "aaa@gmail.com", required = true)
+    @NotBlank(message = "이메일은 필수입니다")
     @Email(message = "이메일의 형식이 맞지 않습니다")
     String memberEmail;
 

--- a/src/test/java/cloneproject/Instagram/controller/MemberAuthControllerTest.java
+++ b/src/test/java/cloneproject/Instagram/controller/MemberAuthControllerTest.java
@@ -1,0 +1,287 @@
+package cloneproject.Instagram.controller;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import cloneproject.Instagram.advice.GlobalExceptionHandler;
+import cloneproject.Instagram.dto.member.JwtDto;
+import cloneproject.Instagram.dto.member.LoginRequest;
+import cloneproject.Instagram.dto.member.RegisterRequest;
+import cloneproject.Instagram.dto.member.SendConfirmationEmailRequest;
+import cloneproject.Instagram.dto.member.UpdatePasswordRequest;
+import cloneproject.Instagram.dto.result.ResultCode;
+import cloneproject.Instagram.dto.result.ResultResponse;
+import cloneproject.Instagram.service.MemberAuthService;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+
+import java.nio.charset.StandardCharsets;
+
+import javax.servlet.http.Cookie;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@ExtendWith(SpringExtension.class)
+@DisplayName("Member Auth Controller Test")
+public class MemberAuthControllerTest {
+    
+    @InjectMocks
+    private MemberAuthController memberAuthController;
+
+    @Mock
+    private MemberAuthService memberAuthService;
+
+    private ObjectMapper objectMapper;
+
+    private MockMvc mockMvc;
+
+
+	@BeforeEach
+	private void setup() {
+        objectMapper = new ObjectMapper();
+		mockMvc = MockMvcBuilders.standaloneSetup(memberAuthController)
+			.addFilter(new CharacterEncodingFilter(StandardCharsets.UTF_8.name(), true))
+            .setControllerAdvice(new GlobalExceptionHandler())
+			.build();
+	}
+
+    
+    @Nested
+    @DisplayName("username 중복 조회는")
+    class Describe_checkUsername{
+
+        @Nested
+        @DisplayName("올바른 parameter가 주어지면")
+        class Context_correct_parameter{
+            @Test
+            @DisplayName("처리 결과를 반환한다")
+            void it_return_success() throws Exception{
+                mockMvc.perform(get("/accounts/check")
+                        .param("username", "dlwlrma")
+                    )
+                    .andExpect(status().isOk())
+                    // Mocking된 MemberAuthService는 0을 반환하기 때문에 false가 반환됨.
+                    .andExpect(content().string(objectMapper.writeValueAsString(
+                        ResultResponse.of(ResultCode.CHECK_USERNAME_BAD, false))));
+            }  
+        }
+
+        // TODO Postman, swagger에선 에러가 정상적으로 반환되나 Test시엔 200이 반환됨.
+        // @Nested
+        // @DisplayName("잘못된 parameter가 주어지면")
+        // class Context_wrong_parameter{
+
+        //     @Test
+        //     @DisplayName("400에러가 발생한다")
+        //     void it_return_error() throws Exception{
+        //         mockMvc.perform(get("/accounts/check")
+        //                     .param("username", "aa")
+        //                 )
+        //                 .andExpect(status().isBadRequest());
+        //     }  
+            
+        // }
+    }
+    
+    @Nested
+    @DisplayName("회원 가입은")
+    class Describe_register{
+
+        @Nested
+        @DisplayName("올바른 parameters가 주어지면")
+        class Context_correct_params{
+            @Test
+            @DisplayName("성공 ResultCode를 반환한다")
+            void it_return_success() throws Exception{
+                RegisterRequest registerRequest = new RegisterRequest("dlwlrma", "이지금", "a12341234", "aaa@gmail.com", "ABC123");
+                when(memberAuthService.register(any())).thenReturn(true);
+
+                mockMvc.perform(post("/accounts")
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(registerRequest))
+                    )
+                    .andExpect(status().isOk())
+                    .andExpect(content().string(objectMapper.writeValueAsString(
+                        ResultResponse.of(ResultCode.REGISTER_SUCCESS, true))));
+            }
+        }
+
+        @Nested
+        @DisplayName("잘못된 parameters가 주어지면")
+        class Context_wrong_params{
+            @Test
+            @DisplayName("400 에러가 발생한다")
+            void it_return_error() throws Exception{
+                RegisterRequest registerRequest = new RegisterRequest("dlwlrma", "이지금", "a123", "aaa@gmail.com", "ABC123");
+
+                mockMvc.perform(post("/accounts")
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(registerRequest))
+                    )
+                    .andExpect(status().isBadRequest());
+            }
+        }
+
+    }
+
+    @Nested
+    @DisplayName("이메일코드 전송은")
+    class Describe_sendConfirmEmail{
+
+        @Nested
+        @DisplayName("올바른 parameters가 주어지면")
+        class Context_correct_params{
+            @Test
+            @DisplayName("성공 ResultCode를 반환한다")
+            void it_return_success() throws Exception{
+                SendConfirmationEmailRequest sendConfirmationEmailRequest = 
+                    new SendConfirmationEmailRequest("dlwlrma", "aaa@gmail.com");
+
+                mockMvc.perform(post("/accounts/email")
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(sendConfirmationEmailRequest))
+                    )
+                    .andExpect(status().isOk())
+                    .andExpect(content().string(objectMapper.writeValueAsString(
+                        ResultResponse.of(ResultCode.SEND_CONFIRM_EMAIL_SUCCESS, null))));
+            }
+        }
+
+        @Nested
+        @DisplayName("잘못된 parameters가 주어지면")
+        class Context_wrong_params{
+            @Test
+            @DisplayName("400 에러가 발생한다")
+            void it_return_error() throws Exception{
+                SendConfirmationEmailRequest sendConfirmationEmailRequest = 
+                new SendConfirmationEmailRequest("dlwlrma", "gmail.com");
+
+                mockMvc.perform(post("/accounts/email")
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(sendConfirmationEmailRequest))
+                    )
+                    .andExpect(status().isBadRequest());
+            }
+        }
+
+    }
+
+    @Nested
+    @DisplayName("login은")
+    class Describe_login{
+
+        @Nested
+        @DisplayName("올바른 파라미터가 주어지면")
+        class Context_correct_parameter{
+
+            @Test
+            @DisplayName("쿠키와 JSON를 통해 JWT토큰을 반환한다")
+            void it_returns_using_cookie_and_json() throws Exception{
+                LoginRequest loginRequest = new LoginRequest("dlwlrma", "a12341234");
+                JwtDto jwtDto = JwtDto.builder()
+                    .type("Bearer")
+                    .accessToken("AAA.BBB.CCC")
+                    .refreshToken("CCC.BBB.AAA")
+                    .build();
+                when(memberAuthService.login(any())).thenReturn(jwtDto);
+
+                mockMvc.perform(post("/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest))
+                    )
+                    .andExpect(cookie().value("refreshToken", jwtDto.getRefreshToken()))
+                    .andExpect(status().isOk());
+            }
+
+        }
+        
+    }
+
+    
+    @Nested
+    @DisplayName("reissue는")
+    class Describe_reissue{
+
+        @Nested
+        @DisplayName("올바른 파라미터가 주어지면")
+        class Context_correct_parameter{
+
+            @Test
+            @DisplayName("쿠키와 JSON를 통해 JWT토큰을 반환한다")
+            void it_returns_using_cookie_and_json() throws Exception{
+                JwtDto jwtDto = JwtDto.builder()
+                    .type("Bearer")
+                    .accessToken("AAA.BBB.CCC")
+                    .refreshToken("CCC.BBB.AAA")
+                    .build();
+                when(memberAuthService.reisuue("CCC.BBB.AAA")).thenReturn(jwtDto);
+
+                mockMvc.perform(post("/reissue")
+                        .cookie(new Cookie("refreshToken", "CCC.BBB.AAA"))
+                    )
+                    .andExpect(cookie().value("refreshToken", jwtDto.getRefreshToken()))
+                    .andExpect(status().isOk());
+            }
+
+        }
+        
+    }
+    
+    @Nested
+    @DisplayName("비밀번호 변경은")
+    class Describe_updatePassword{
+
+        @Nested
+        @DisplayName("올바른 parameters가 주어지면")
+        class Context_correct_params{
+            @Test
+            @DisplayName("성공 ResultCode를 반환한다")
+            void it_return_success() throws Exception{
+                UpdatePasswordRequest updatePasswordRequest = 
+                    new UpdatePasswordRequest("a12341234", "b12341234");
+
+                mockMvc.perform(put("/accounts/password")
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(updatePasswordRequest))
+                    )
+                    .andExpect(status().isOk())
+                    .andExpect(content().string(objectMapper.writeValueAsString(
+                        ResultResponse.of(ResultCode.UPDATE_PASSWORD_SUCCESS, null))));
+            }
+        }
+
+        @Nested
+        @DisplayName("잘못된 parameters가 주어지면")
+        class Context_wrong_params{
+            @Test
+            @DisplayName("400 에러가 발생한다")
+            void it_return_error() throws Exception{
+                UpdatePasswordRequest updatePasswordRequest = 
+                    new UpdatePasswordRequest("a12341234", "b1234");
+
+                    mockMvc.perform(put("/accounts/password")
+                            .contentType("application/json")
+                            .content(objectMapper.writeValueAsString(updatePasswordRequest))
+                        )
+                        .andExpect(status().isBadRequest());
+            }
+        }
+
+    }
+
+}

--- a/src/test/java/cloneproject/Instagram/controller/MemberControllerTest.java
+++ b/src/test/java/cloneproject/Instagram/controller/MemberControllerTest.java
@@ -1,0 +1,239 @@
+package cloneproject.Instagram.controller;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import cloneproject.Instagram.advice.GlobalExceptionHandler;
+import cloneproject.Instagram.dto.member.EditProfileRequest;
+import cloneproject.Instagram.dto.result.ResultCode;
+import cloneproject.Instagram.dto.result.ResultResponse;
+import cloneproject.Instagram.service.MemberService;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@ExtendWith(SpringExtension.class)
+@DisplayName("Member Controller Test")
+public class MemberControllerTest {
+    
+    @InjectMocks
+    private MemberController memberController;
+
+    @Mock
+    private MemberService memberService;
+
+    private ObjectMapper objectMapper;
+
+    private MockMvc mockMvc;
+
+
+	@BeforeEach
+	private void setup() {
+        objectMapper = new ObjectMapper();
+		mockMvc = MockMvcBuilders.standaloneSetup(memberController)
+			.addFilter(new CharacterEncodingFilter(StandardCharsets.UTF_8.name(), true))
+            .setControllerAdvice(new GlobalExceptionHandler())
+            .build();
+	}
+
+    @Nested
+    @DisplayName("메뉴 유저 프로필은")
+    class Describe_getMenuMemberProfile{
+
+        @Nested
+        @DisplayName("로그인한 상태라면")
+        class Context_logined{
+            @Test
+            @DisplayName("성공 ResultCode를 반환한다")
+            void it_return_success() throws Exception{
+                mockMvc.perform(get("/menu/profile"))
+                    .andExpect(status().isOk())
+                    .andExpect(content().string(objectMapper.writeValueAsString(
+                        ResultResponse.of(ResultCode.GET_MENU_MEMBER_SUCCESS, null))));
+            }  
+        }
+
+    }
+    
+    @Nested
+    @DisplayName("유저 프로필은")
+    class Describe_getMemberProfile{
+
+        @Nested
+        @DisplayName("올바른 username이 주어지면")
+        class Context_correct_username{
+            @Test
+            @DisplayName("성공 ResultCode를 반환한다")
+            void it_return_success() throws Exception{
+                mockMvc.perform(get("/accounts/dlwlrma"))
+                    .andExpect(status().isOk())
+                    .andExpect(content().string(objectMapper.writeValueAsString(
+                        ResultResponse.of(ResultCode.GET_USERPROFILE_SUCCESS, null))));
+            }
+        }
+
+    }
+
+    @Nested
+    @DisplayName("미니 유저 프로필은")
+    class Describe_getMiniProfile{
+        @Nested
+        @DisplayName("올바른 username이 주어지면")
+        class Context_correct_username{
+            @Test
+            @DisplayName("성공 ResultCode를 반환한다")
+            void it_return_success() throws Exception{
+                mockMvc.perform(get("/accounts/dlwlrma/mini"))
+                    .andExpect(status().isOk())
+                    .andExpect(content().string(objectMapper.writeValueAsString(
+                        ResultResponse.of(ResultCode.GET_MINIPROFILE_SUCCESS, null))));
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("이미지 업로드는")
+    class Describe_uploadImage{
+        @Nested
+        @DisplayName("올바른 파일이 주어지면")
+        class Context_correct_file{
+            @Test
+            @DisplayName("성공 ResultCode를 반환한다")
+            void it_return_success() throws Exception{
+                mockMvc.perform(multipart("/accounts/image").file(
+                        new MockMultipartFile("uploadedImage","hello.png", "png"," ".getBytes()))
+                    )
+                    .andExpect(status().isOk())
+                    .andExpect(content().string(objectMapper.writeValueAsString(
+                        ResultResponse.of(ResultCode.UPLOAD_MEMBER_IMAGE_SUCCESS, null))));
+            }
+        }
+        @Nested
+        @DisplayName("파일이 없으면")
+        class Context_no_file{
+            @Test
+            @DisplayName("400 에러가 발생한다")
+            void it_return_error() throws Exception{
+                mockMvc.perform(multipart("/accounts/image"))
+                    .andExpect(status().isBadRequest());
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("이미지 삭제는")
+    class Describe_deleteImage{
+        @Nested
+        @DisplayName("로그인한 상태라면")
+        class Context_logined{
+            @Test
+            @DisplayName("성공 ResultCode를 반환한다")
+            void it_return_success() throws Exception{
+                mockMvc.perform(delete("/accounts/image"))
+                    .andExpect(status().isOk())
+                    .andExpect(content().string(objectMapper.writeValueAsString(
+                        ResultResponse.of(ResultCode.DELETE_MEMBER_IMAGE_SUCCESS, null))));
+            }
+        }
+    }
+    
+
+    @Nested
+    @DisplayName("회원 수정정보 조회는")
+    class Describe_getEditProfile{
+        @Nested
+        @DisplayName("로그인한 상태라면")
+        class Context_logined{
+            @Test
+            @DisplayName("성공 ResultCode를 반환한다")
+            void it_return_success() throws Exception{
+                mockMvc.perform(get("/accounts/edit"))
+                    .andExpect(status().isOk())
+                    .andExpect(content().string(objectMapper.writeValueAsString(
+                        ResultResponse.of(ResultCode.GET_EDIT_PROFILE_SUCCESS, null))));
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("회원 수정은")
+    class Describe_editProfile{
+        @Nested
+        @DisplayName("올바른 parameters가 주어지면")
+        class Context_correct_params{
+            @Test
+            @DisplayName("성공 ResultCode를 반환한다")
+            void it_return_success() throws Exception{
+                EditProfileRequest editProfileRequest = new EditProfileRequest("dlwlrma", "이지금", null, null, "aaa@gmail.com", null, "PRIVATE");
+                mockMvc.perform(put("/accounts/edit")
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(editProfileRequest))
+                    )
+                    .andExpect(status().isOk())
+                    .andExpect(content().string(objectMapper.writeValueAsString(
+                        ResultResponse.of(ResultCode.EDIT_PROFILE_SUCCESS, null))));
+            }
+        }
+
+        @Nested
+        @DisplayName("잘못된 parameters가 주어지면")
+        class Context_wrong_params{
+            @Test
+            @DisplayName("400 에러가 발생한다")
+            void it_return_error() throws Exception{
+                EditProfileRequest editProfileRequest = new EditProfileRequest("dlw", "이지금", null, null, "aaa@gmail.com", null, "PRIVATE");
+                mockMvc.perform(put("/accounts/edit")
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(editProfileRequest))
+                    )
+                    .andExpect(status().isBadRequest());
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("회원 검색은")
+    class Describe_searchMember{
+        @Nested
+        @DisplayName("parameter가 주어지면")
+        class Context_given_param{
+            @Test
+            @DisplayName("성공 ResultCode를 반환한다")
+            void it_return_success() throws Exception{
+                mockMvc.perform(get("/search").param("text", "dlwl"))
+                    .andExpect(status().isOk())
+                    .andExpect(content().string(objectMapper.writeValueAsString(
+                        ResultResponse.of(ResultCode.SEARCH_MEMBER_SUCCESS, Collections.emptyList()))));
+            }
+        }
+
+        @Nested
+        @DisplayName("parameter가 주어지지 않으면")
+        class Context_not_given_param{
+            @Test
+            @DisplayName("400 에러를 반환한다")
+            void it_return_error() throws Exception{
+                mockMvc.perform(get("/search"))
+                    .andExpect(status().isBadRequest());
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
## 정규성 검증 관련 문제 수정
### 에러처리가 제대로 되지 않던 문제
- DTO 관련된 정규성 검증은 `MethodArgumentNotValidException`에러를 발생시키기 때문에 기존에 정상적으로 처리됨
- `@RequestParam`의 정규성 검증은 `MissingServletRequestParameterException`와 `ConstraintViolationException`가 발생하기 때문에 처리되지 않고 500 에러가 발생하고 있었음.

> `MissingServletRequestParameterException`은 parameter가 비어 있을경우,  `ConstraintViolationException`는 parameter가 올바르지 않은 경우 각각 발생함. `@NotBlank`, `@NotNull`은 `MissingServletRequestParameterException`로 먼저 처리 되기 때문에 동작하지 않아 삭제하였음

- `GlobalExceptionHandler`에 해당 예외 `handler`를 추가하여 현재는 DTO와 같이 에러 발생
### `EditProfileRequest` 정규성 수정
- `EditProfileRequest`내 phone과 email의 정규성 설정이 잘못되어 있어 올바르게 수정
### 유저 관련 API 정규성 수정
- 유저 프로필 조회, 미니 프로필 조회는 정규성 검증이 필요하다고 생각되어 추가
-> 지금 생각해보니 없어도 될거같은데 의견 부탁드립니다. @seonpilKim 
## 테스트 작성
- `MemberController` 테스트 작성
- `MemberAuthController` 테스트 작성
## 검색, 유저이름 중복 조회 HTTP Method 변경
- 둘다 `Post`로 되어있었으나 `Get`이 올바르다 생각하여 변경