### PR TITLE
DM 단톡 기능 추가 및 알람 목록 페이징 조회 API 쿼리 수정

### DIFF
--- a/src/main/java/cloneproject/Instagram/controller/ChatController.java
+++ b/src/main/java/cloneproject/Instagram/controller/ChatController.java
@@ -14,8 +14,10 @@ import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
-import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
+
+import java.util.List;
 
 import static cloneproject.Instagram.dto.result.ResultCode.*;
 
@@ -28,10 +30,9 @@ public class ChatController {
     private final ChatService chatService;
 
     @ApiOperation(value = "채팅방 생성")
-    @ApiImplicitParam(name = "username", value = "상대방 username", example = "dlwlrma1", required = true)
     @PostMapping("/chat/rooms")
-    public ResponseEntity<ResultResponse> createChatRoom(@NotBlank(message = "상대방 username은 필수입니다.") @RequestParam String username) {
-        final ChatRoomCreateResponse response = chatService.createRoom(username);
+    public ResponseEntity<ResultResponse> createChatRoom(@NotEmpty(message = "상대방 username은 필수입니다.") @RequestParam List<String> usernames) {
+        final ChatRoomCreateResponse response = chatService.createRoom(usernames);
 
         return ResponseEntity.ok(ResultResponse.of(CREATE_CHAT_ROOM_SUCCESS, response));
     }

--- a/src/main/java/cloneproject/Instagram/dto/result/ResultCode.java
+++ b/src/main/java/cloneproject/Instagram/dto/result/ResultCode.java
@@ -69,7 +69,7 @@ public enum ResultCode {
     GET_COMMENT_LIKES_SUCCESS(200, "P018", "댓글 좋아요한 사람 목록 페이지 조회 성공"),
 
     // CHAT
-    CREATE_CHAT_ROOM_SUCCESS(200, "C001", "채팅방 생성 성공"),
+    CREATE_CHAT_ROOM_SUCCESS(200, "C001", "채팅방 생성 요청 성공"),
     INQUIRE_CHAT_ROOM_SUCCESS(200, "C002", "채팅방 조회 성공"),
     DELETE_JOIN_ROOM_SUCCESS(200, "C003", "참여 중인 채팅방 삭제 성공"),
     GET_JOIN_ROOMS_SUCCESS(200, "C004", "채팅방 목록 조회 성공"),

--- a/src/main/java/cloneproject/Instagram/repository/AlarmRepositoryQuerydslImpl.java
+++ b/src/main/java/cloneproject/Instagram/repository/AlarmRepositoryQuerydslImpl.java
@@ -21,7 +21,6 @@ import static cloneproject.Instagram.entity.alarms.QAlarm.alarm;
 import static cloneproject.Instagram.entity.member.QFollow.follow;
 import static cloneproject.Instagram.entity.member.QMember.member;
 import static cloneproject.Instagram.entity.post.QPost.post;
-import static cloneproject.Instagram.entity.post.QPostImage.postImage;
 import static com.querydsl.core.group.GroupBy.groupBy;
 
 @RequiredArgsConstructor
@@ -35,7 +34,6 @@ public class AlarmRepositoryQuerydslImpl implements AlarmRepositoryQuerydsl {
                 .selectFrom(alarm)
                 .innerJoin(alarm.agent, member).fetchJoin()
                 .leftJoin(alarm.post, post).fetchJoin()
-                .leftJoin(post.postImages, postImage).fetchJoin()
                 .where(alarm.target.id.eq(memberId))
                 .orderBy(alarm.id.desc())
                 .offset(pageable.getOffset())
@@ -53,6 +51,8 @@ public class AlarmRepositoryQuerydslImpl implements AlarmRepositoryQuerydsl {
                                 follow.followMember.id.in(agentIds)
                         )
                 )
+                .innerJoin(follow.member, member).fetchJoin()
+                .innerJoin(follow.followMember, member).fetchJoin()
                 .transform(groupBy(follow.followMember.id).as(follow));
 
         final List<AlarmDTO> content = alarms.stream()


### PR DESCRIPTION
## 변경 사항
### DM 단톡 기능 추가
- 이미 존재하는 채팅방 여부 찾는 로직 설명
    1. usernames으로 members 조회
    2. members으로 roomMembers 조회
    3. roomMembers를 roomId로 그룹핑 -> List(roomMembers) 개수가 members 개수와 동일한 경우 따로 roomId 저장
        - 현재 members와의 채팅방이거나, 현재 members + 다른 회원이 포함된 채팅방인 경우에 해당
    4. 위에서 저장한 roomId로 다시 roomMembers 조회
    5. List(roomMembers) 개수가 members 개수와 동일한 경우, 이미 존재하는 채팅방
- 이미 존재하는 채팅방인 경우 false, 새로 개설하는 채팅방인 경우 true를 status에 저장하여 응답

### 알람 목록 페이징 조회 API 쿼리 수정
- 기존 페이징 조회 시 컬렉션도 fetch join -> 삭제 + 지연 로딩 이용
    - 페이징 조회 시 컬렉션을 fetch join하면 데이터가 뻥튀기되어 조회되므로, 페이징 처리가 이상하게 됨
    - 따라서 컬렉션은 지연 로딩 이용, spring.jpa.properties.hibernate.default_atch_fetch_size 만큼 끊어서 한 번에 조회
- where절 innerJoin 명시

## 해결 이슈
- Resolve: #109 