### PR TITLE
게시물 이미지 태그 -> 알림이 아닌 DM으로 게시물 공유하는 방식으로 변경 등

### DIFF
--- a/src/main/java/cloneproject/Instagram/dto/chat/JoinRoomDTO.java
+++ b/src/main/java/cloneproject/Instagram/dto/chat/JoinRoomDTO.java
@@ -1,6 +1,5 @@
 package cloneproject.Instagram.dto.chat;
 
-import cloneproject.Instagram.entity.chat.Message;
 import cloneproject.Instagram.entity.member.Member;
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.Getter;
@@ -22,9 +21,8 @@ public class JoinRoomDTO {
     private List<MemberSimpleInfo> members = new ArrayList<>();
 
     @QueryProjection
-    public JoinRoomDTO(Long roomId, Message message, boolean unreadFlag, Member member) {
+    public JoinRoomDTO(Long roomId, boolean unreadFlag, Member member) {
         this.roomId = roomId;
-        this.lastMessage = new MessageDTO(message);
         this.unreadFlag = unreadFlag;
         this.inviter = new MemberSimpleInfo(member);
     }

--- a/src/main/java/cloneproject/Instagram/dto/chat/MessageDTO.java
+++ b/src/main/java/cloneproject/Instagram/dto/chat/MessageDTO.java
@@ -29,13 +29,19 @@ public class MessageDTO {
         this.senderImage = message.getMember().getImage();
         this.messageDate = message.getCreatedDate();
         this.messageType = message.getDtype();
-        this.content = MessagePostDTO.builder()
-                .status(message.getPost() == null ? "DELETED" : "UPLOADED")
-                .postId(message.getPost().getId())
-                .postImage(message.getPost().getPostImages().get(0).getImage())
-                .postImageCount(message.getPost().getPostImages().size())
-                .uploader(new MenuMemberDTO(message.getMember()))
-                .build();
+        try {
+            this.content = MessagePostDTO.builder()
+                    .status("UPLOADED")
+                    .postId(message.getPost().getId())
+                    .postImage(message.getPost().getPostImages().get(0).getImage())
+                    .postImageCount(message.getPost().getPostImages().size())
+                    .uploader(new MenuMemberDTO(message.getMember()))
+                    .build();
+        } catch (Exception e) {
+            this.content = MessagePostDTO.builder()
+                    .status("DELETED")
+                    .build();
+        }
     }
 
     public MessageDTO(MessageText message) {

--- a/src/main/java/cloneproject/Instagram/dto/chat/MessageDTO.java
+++ b/src/main/java/cloneproject/Instagram/dto/chat/MessageDTO.java
@@ -1,11 +1,11 @@
 package cloneproject.Instagram.dto.chat;
 
-import cloneproject.Instagram.entity.chat.Message;
-import cloneproject.Instagram.entity.chat.MessageType;
-import com.querydsl.core.annotations.QueryProjection;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import cloneproject.Instagram.dto.member.MenuMemberDTO;
+import cloneproject.Instagram.entity.chat.MessageImage;
+import cloneproject.Instagram.entity.chat.MessagePost;
+import cloneproject.Instagram.entity.chat.MessageText;
+import cloneproject.Instagram.vo.Image;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
@@ -17,17 +17,58 @@ public class MessageDTO {
     private Long roomId;
     private Long messageId;
     private Long senderId;
-    private String content;
-    private MessageType messageType;
+    private Image senderImage;
+    private Object content;
+    private String messageType;
     private LocalDateTime messageDate;
 
-    @QueryProjection
-    public MessageDTO(Message message) {
+    public MessageDTO(MessagePost message) {
         this.roomId = message.getRoom().getId();
         this.messageId = message.getId();
-        this.messageType = message.getType();
-        this.content = message.getContent();
         this.senderId = message.getMember().getId();
+        this.senderImage = message.getMember().getImage();
         this.messageDate = message.getCreatedDate();
+        this.messageType = message.getDtype();
+        this.content = MessagePostDTO.builder()
+                .status(message.getPost() == null ? "DELETED" : "UPLOADED")
+                .postId(message.getPost().getId())
+                .postImage(message.getPost().getPostImages().get(0).getImage())
+                .postImageCount(message.getPost().getPostImages().size())
+                .uploader(new MenuMemberDTO(message.getMember()))
+                .build();
+    }
+
+    public MessageDTO(MessageText message) {
+        this.roomId = message.getRoom().getId();
+        this.messageId = message.getId();
+        this.senderId = message.getMember().getId();
+        this.senderImage = message.getMember().getImage();
+        this.messageDate = message.getCreatedDate();
+        this.messageType = message.getDtype();
+        this.content = message.getContent();
+    }
+
+    public MessageDTO(MessageImage message) {
+        this.roomId = message.getRoom().getId();
+        this.messageId = message.getId();
+        this.senderId = message.getMember().getId();
+        this.senderImage = message.getMember().getImage();
+        this.messageDate = message.getCreatedDate();
+        this.messageType = message.getDtype();
+        this.content = message.getImage();
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class MessagePostDTO {
+
+        private String status;
+        private Long postId;
+        private Image postImage;
+        private Integer postImageCount;
+        private MenuMemberDTO uploader;
     }
 }

--- a/src/main/java/cloneproject/Instagram/dto/chat/MessageRequest.java
+++ b/src/main/java/cloneproject/Instagram/dto/chat/MessageRequest.java
@@ -1,6 +1,5 @@
 package cloneproject.Instagram.dto.chat;
 
-import cloneproject.Instagram.entity.chat.MessageType;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -19,7 +18,4 @@ public class MessageRequest {
 
     @NotEmpty(message = "채팅 메시지는 필수입니다.")
     private String content;
-
-    @NotNull(message = "채팅 메시지 타입은 필수입니다.")
-    private MessageType messageType;
 }

--- a/src/main/java/cloneproject/Instagram/entity/chat/Message.java
+++ b/src/main/java/cloneproject/Instagram/entity/chat/Message.java
@@ -15,6 +15,8 @@ import java.time.LocalDateTime;
 @Entity
 @EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Inheritance(strategy = InheritanceType.JOINED)
+@DiscriminatorColumn
 @Table(name = "messages")
 public class Message {
 
@@ -28,26 +30,19 @@ public class Message {
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "join_room_id")
+    @JoinColumn(name = "room_id")
     private Room room;
-
-    @Lob
-    @Column(name = "message_content")
-    private String content;
 
     @CreatedDate
     @Column(name = "message_created_date")
     private LocalDateTime createdDate;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "message_type")
-    private MessageType type;
+    @Column(insertable=false, updatable=false)
+    private String dtype;
 
     @Builder
-    public Message(Member member, Room room, String content, MessageType type) {
+    public Message(Member member, Room room) {
         this.member = member;
         this.room = room;
-        this.content = content;
-        this.type = type;
     }
 }

--- a/src/main/java/cloneproject/Instagram/entity/chat/MessageImage.java
+++ b/src/main/java/cloneproject/Instagram/entity/chat/MessageImage.java
@@ -1,8 +1,8 @@
 package cloneproject.Instagram.entity.chat;
 
+import cloneproject.Instagram.entity.member.Member;
 import cloneproject.Instagram.vo.Image;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -11,30 +11,21 @@ import javax.persistence.*;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DiscriminatorValue("IMAGE")
 @Table(name = "message_images")
-public class MessageImage {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "message_image_id")
-    private Long id;
-
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "message_id")
-    private Message message;
+public class MessageImage extends Message {
 
     @Embedded
     @AttributeOverrides({
-            @AttributeOverride(name = "imageUrl", column = @Column(name = "post_image_url")),
-            @AttributeOverride(name = "imageType", column = @Column(name = "post_image_type")),
-            @AttributeOverride(name = "imageName", column = @Column(name = "post_image_name")),
-            @AttributeOverride(name = "imageUUID", column = @Column(name = "post_image_uuid"))
+            @AttributeOverride(name = "imageUrl", column = @Column(name = "message_image_url")),
+            @AttributeOverride(name = "imageType", column = @Column(name = "message_image_type")),
+            @AttributeOverride(name = "imageName", column = @Column(name = "message_image_name")),
+            @AttributeOverride(name = "imageUUID", column = @Column(name = "message_image_uuid"))
     })
     private Image image;
 
-    @Builder
-    public MessageImage(Message message, Image image) {
-        this.message = message;
+    public MessageImage(Image image, Member member, Room room) {
+        super(member, room);
         this.image = image;
     }
 }

--- a/src/main/java/cloneproject/Instagram/entity/chat/MessagePost.java
+++ b/src/main/java/cloneproject/Instagram/entity/chat/MessagePost.java
@@ -1,0 +1,26 @@
+package cloneproject.Instagram.entity.chat;
+
+import cloneproject.Instagram.entity.member.Member;
+import cloneproject.Instagram.entity.post.Post;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DiscriminatorValue("POST")
+@Table(name = "message_posts")
+public class MessagePost extends Message {
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    public MessagePost(Post post, Member member, Room room) {
+        super(member, room);
+        this.post = post;
+    }
+}

--- a/src/main/java/cloneproject/Instagram/entity/chat/MessageText.java
+++ b/src/main/java/cloneproject/Instagram/entity/chat/MessageText.java
@@ -1,0 +1,25 @@
+package cloneproject.Instagram.entity.chat;
+
+import cloneproject.Instagram.entity.member.Member;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DiscriminatorValue("TEXT")
+@Table(name = "message_texts")
+public class MessageText extends Message {
+
+    @Lob
+    @Column(name = "message_text_content")
+    private String content;
+
+    public MessageText(String content, Member member, Room room) {
+        super(member, room);
+        this.content = content;
+    }
+}

--- a/src/main/java/cloneproject/Instagram/entity/chat/MessageType.java
+++ b/src/main/java/cloneproject/Instagram/entity/chat/MessageType.java
@@ -1,5 +1,0 @@
-package cloneproject.Instagram.entity.chat;
-
-public enum MessageType {
-    TEXT, IMAGE
-}

--- a/src/main/java/cloneproject/Instagram/entity/chat/Room.java
+++ b/src/main/java/cloneproject/Instagram/entity/chat/Room.java
@@ -38,7 +38,7 @@ public class Room {
         this.member = member;
     }
 
-    public void updateLastMessage(Message message){
+    public void updateLastMessage(Message message) {
         this.message = message;
     }
 }

--- a/src/main/java/cloneproject/Instagram/entity/member/Block.java
+++ b/src/main/java/cloneproject/Instagram/entity/member/Block.java
@@ -17,19 +17,18 @@ public class Block {
     @Column(name = "block_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    
-    @ManyToOne
-    @JoinColumn(name="member_id")
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
     private Member member;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "block_member_id")
     private Member blockMember;
 
     @Builder
-    public Block(Member member, Member blockMember){
+    public Block(Member member, Member blockMember) {
         this.member = member;
         this.blockMember = blockMember;
     }
-    
 }

--- a/src/main/java/cloneproject/Instagram/entity/member/Follow.java
+++ b/src/main/java/cloneproject/Instagram/entity/member/Follow.java
@@ -17,19 +17,18 @@ public class Follow {
     @Column(name = "follow_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    
-    @ManyToOne
-    @JoinColumn(name="member_id")
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
     private Member member;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "follow_member_id")
     private Member followMember;
 
     @Builder
-    public Follow(Member member, Member followMember){
+    public Follow(Member member, Member followMember) {
         this.member = member;
         this.followMember = followMember;
     }
-    
 }

--- a/src/main/java/cloneproject/Instagram/entity/member/Member.java
+++ b/src/main/java/cloneproject/Instagram/entity/member/Member.java
@@ -29,14 +29,14 @@ public class Member {
 
     @Column(name = "member_username", nullable = false, length = 20, unique = true)
     private String username;
-    
+
     @Column(name = "member_role")
     @Enumerated(EnumType.STRING)
     private MemberRole role;
 
     @Column(name = "member_password", nullable = false)
     private String password;
-    
+
     @Column(name = "member_name", nullable = false, length = 20)
     private String name;
 
@@ -59,7 +59,7 @@ public class Member {
 
     @OneToMany(mappedBy = "member")
     private List<Follow> followings = new ArrayList<>();
-    
+
     @Embedded
     @AttributeOverrides({
             @AttributeOverride(name = "value", column = @Column(name = "member_refresh_token_value")),
@@ -76,49 +76,49 @@ public class Member {
     })
     private Image image;
 
-    public void updateUsername(String username){
+    public void updateUsername(String username) {
         this.username = username;
     }
 
-    public void updateName(String name){
+    public void updateName(String name) {
         this.name = name;
     }
 
-    public void updateWebsite(String website){
+    public void updateWebsite(String website) {
         this.website = website;
     }
 
-    public void updateIntroduce(String introduce){
+    public void updateIntroduce(String introduce) {
         this.introduce = introduce;
     }
 
-    public void updatePhone(String phone){
+    public void updatePhone(String phone) {
         this.phone = phone;
     }
 
-    public void updateEmail(String email){
+    public void updateEmail(String email) {
         this.email = email;
     }
 
-    public void updateGender(Gender gender){
+    public void updateGender(Gender gender) {
         this.gender = gender;
     }
 
-    public void setRefreshToken(RefreshToken refreshToken){
+    public void setRefreshToken(RefreshToken refreshToken) {
         this.refreshToken = refreshToken;
     }
 
-    public void setEncryptedPassword(String encryptedPassword){
+    public void setEncryptedPassword(String encryptedPassword) {
         this.password = encryptedPassword;
     }
 
-    public void uploadImage(Image image){
+    public void uploadImage(Image image) {
         deleteImage();
         this.image = image;
     }
 
-    public void deleteImage(){
-        if(this.image.getImageUUID().equals("base-UUID"))
+    public void deleteImage() {
+        if (this.image.getImageUUID().equals("base-UUID"))
             return;
 
         this.image = Image.builder()
@@ -130,12 +130,12 @@ public class Member {
     }
 
     @Builder
-    public Member(String username, String name, String password, String email){
+    public Member(String username, String name, String password, String email) {
         this.username = username;
         this.name = name;
         this.password = password;
         this.email = email;
-        
+
         // 자동 초기화
         this.role = MemberRole.ROLE_USER;
         this.gender = Gender.PRIVATE;
@@ -146,5 +146,5 @@ public class Member {
                 .imageUUID("base-UUID")
                 .build();
     }
-    
+
 }

--- a/src/main/java/cloneproject/Instagram/repository/MemberRepository.java
+++ b/src/main/java/cloneproject/Instagram/repository/MemberRepository.java
@@ -1,5 +1,6 @@
 package cloneproject.Instagram.repository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -19,5 +20,5 @@ public interface MemberRepository extends JpaRepository<Member, Long>, JpaSpecif
 
     boolean existsByUsername(String username);
 
-    List<Member> findAllByUsernameIn(List<String> usernames);
+    List<Member> findAllByUsernameIn(Collection<String> usernames);
 }

--- a/src/main/java/cloneproject/Instagram/repository/chat/JoinRomRepositoryJdbc.java
+++ b/src/main/java/cloneproject/Instagram/repository/chat/JoinRomRepositoryJdbc.java
@@ -1,0 +1,12 @@
+package cloneproject.Instagram.repository.chat;
+
+import cloneproject.Instagram.entity.chat.JoinRoom;
+
+import java.util.List;
+
+public interface JoinRomRepositoryJdbc {
+
+    void saveAllBatch(List<JoinRoom> joinRooms);
+
+    void updateAllBatch(List<JoinRoom> updateJoinRooms);
+}

--- a/src/main/java/cloneproject/Instagram/repository/chat/JoinRomRepositoryJdbcImpl.java
+++ b/src/main/java/cloneproject/Instagram/repository/chat/JoinRomRepositoryJdbcImpl.java
@@ -1,0 +1,64 @@
+package cloneproject.Instagram.repository.chat;
+
+import cloneproject.Instagram.entity.chat.JoinRoom;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@RequiredArgsConstructor
+public class JoinRomRepositoryJdbcImpl implements JoinRomRepositoryJdbc {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Override
+    public void saveAllBatch(List<JoinRoom> joinRooms) {
+        final String now = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+        final String sql =
+                "INSERT INTO join_rooms (`join_room_created_date`, `join_room_last_message_date`, `member_id`, `room_id`) " +
+                        "VALUES(?, ?, ?, ?)";
+
+        jdbcTemplate.batchUpdate(
+                sql,
+                new BatchPreparedStatementSetter() {
+                    @Override
+                    public void setValues(PreparedStatement ps, int i) throws SQLException {
+                        ps.setString(1, now);
+                        ps.setString(2, now);
+                        ps.setString(3, joinRooms.get(i).getMember().getId().toString());
+                        ps.setString(4, joinRooms.get(i).getRoom().getId().toString());
+                    }
+
+                    @Override
+                    public int getBatchSize() {
+                        return joinRooms.size();
+                    }
+                });
+    }
+
+    @Override
+    public void updateAllBatch(List<JoinRoom> updateJoinRooms) {
+        final String now = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+        final String sql = "UPDATE join_rooms SET join_room_last_message_date = ? where join_room_id = ?";
+
+        jdbcTemplate.batchUpdate(
+                sql,
+                new BatchPreparedStatementSetter() {
+                    @Override
+                    public void setValues(PreparedStatement ps, int i) throws SQLException {
+                        ps.setString(1, now);
+                        ps.setString(2, updateJoinRooms.get(i).getId().toString());
+                    }
+
+                    @Override
+                    public int getBatchSize() {
+                        return updateJoinRooms.size();
+                    }
+                });
+    }
+}

--- a/src/main/java/cloneproject/Instagram/repository/chat/JoinRoomRepository.java
+++ b/src/main/java/cloneproject/Instagram/repository/chat/JoinRoomRepository.java
@@ -1,6 +1,8 @@
 package cloneproject.Instagram.repository.chat;
 
 import cloneproject.Instagram.entity.chat.JoinRoom;
+import cloneproject.Instagram.entity.chat.Room;
+import cloneproject.Instagram.entity.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -8,9 +10,16 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 import java.util.Optional;
 
-public interface JoinRoomRepository extends JpaRepository<JoinRoom, Long>, JoinRoomRepositoryQuerydsl {
+public interface JoinRoomRepository extends JpaRepository<JoinRoom, Long>, JoinRoomRepositoryQuerydsl, JoinRomRepositoryJdbc {
+
     Optional<JoinRoom> findByMemberIdAndRoomId(Long memberId, Long roomId);
+
     void deleteByMemberIdAndRoomId(Long memberId, Long roomId);
+
     @Query(value = "select j from JoinRoom j join fetch j.member where j.room.id = :id")
     List<JoinRoom> findAllByRoomId(@Param("id") Long id);
+
+    Optional<JoinRoom> findByMemberAndRoom(Member member, Room room);
+
+    List<JoinRoom> findByRoomAndMemberIn(Room room, List<Member> members);
 }

--- a/src/main/java/cloneproject/Instagram/repository/chat/JoinRoomRepositoryQuerydslImpl.java
+++ b/src/main/java/cloneproject/Instagram/repository/chat/JoinRoomRepositoryQuerydslImpl.java
@@ -2,6 +2,7 @@ package cloneproject.Instagram.repository.chat;
 
 import cloneproject.Instagram.dto.chat.JoinRoomDTO;
 import cloneproject.Instagram.dto.chat.MemberSimpleInfo;
+import cloneproject.Instagram.dto.chat.MessageDTO;
 import cloneproject.Instagram.dto.chat.QJoinRoomDTO;
 import cloneproject.Instagram.entity.chat.*;
 import com.querydsl.jpa.JPAExpressions;
@@ -17,10 +18,15 @@ import java.util.stream.Collectors;
 
 import static cloneproject.Instagram.entity.chat.QJoinRoom.joinRoom;
 import static cloneproject.Instagram.entity.chat.QMessage.message;
+import static cloneproject.Instagram.entity.chat.QMessageImage.messageImage;
+import static cloneproject.Instagram.entity.chat.QMessagePost.messagePost;
+import static cloneproject.Instagram.entity.chat.QMessageText.messageText;
 import static cloneproject.Instagram.entity.chat.QRoom.room;
 import static cloneproject.Instagram.entity.chat.QRoomMember.roomMember;
 import static cloneproject.Instagram.entity.chat.QRoomUnreadMember.roomUnreadMember;
 import static cloneproject.Instagram.entity.member.QMember.member;
+import static cloneproject.Instagram.entity.post.QPost.post;
+import static com.querydsl.core.group.GroupBy.groupBy;
 
 @RequiredArgsConstructor
 public class JoinRoomRepositoryQuerydslImpl implements JoinRoomRepositoryQuerydsl {
@@ -32,7 +38,6 @@ public class JoinRoomRepositoryQuerydslImpl implements JoinRoomRepositoryQueryds
         final List<JoinRoomDTO> joinRoomDTOs = queryFactory
                 .select(new QJoinRoomDTO(
                         joinRoom.room.id,
-                        joinRoom.room.message,
                         JPAExpressions
                                 .selectFrom(roomUnreadMember)
                                 .where(
@@ -53,14 +58,39 @@ public class JoinRoomRepositoryQuerydslImpl implements JoinRoomRepositoryQueryds
                 .orderBy(joinRoom.lastMessageDate.desc())
                 .fetch();
 
+        final List<Long> roomIds = joinRoomDTOs.stream()
+                .map(JoinRoomDTO::getRoomId)
+                .collect(Collectors.toList());
+        final List<Message> messages = queryFactory
+                .select(room.message)
+                .from(room)
+                .innerJoin(room.message, message)
+                .where(room.id.in(roomIds))
+                .fetch();
+        final List<Long> messageIds = messages.stream()
+                .map(Message::getId)
+                .collect(Collectors.toList());
+
+        final Map<Long, MessagePost> messagePostMap = queryFactory
+                .from(messagePost)
+                .innerJoin(messagePost.post, post).fetchJoin()
+                .where(messagePost.id.in(messageIds))
+                .transform(groupBy(messagePost.room.id).as(messagePost));
+
+        final Map<Long, MessageImage> messageImageMap = queryFactory
+                .from(messageImage)
+                .where(messageImage.id.in(messageIds))
+                .transform(groupBy(messageImage.room.id).as(messageImage));
+
+        final Map<Long, MessageText> messageTextMap = queryFactory
+                .from(messageText)
+                .where(messageText.id.in(messageIds))
+                .transform(groupBy(messageText.room.id).as(messageText));
+
         final long total = queryFactory
                 .selectFrom(joinRoom)
                 .where(joinRoom.member.id.eq(memberId))
                 .fetchCount();
-
-        final List<Long> roomIds = joinRoomDTOs.stream()
-                .map(JoinRoomDTO::getRoomId)
-                .collect(Collectors.toList());
 
         final List<RoomMember> roomMembers = queryFactory
                 .selectFrom(roomMember)
@@ -70,11 +100,19 @@ public class JoinRoomRepositoryQuerydslImpl implements JoinRoomRepositoryQueryds
         final Map<Long, List<RoomMember>> roomMemberMap = roomMembers.stream()
                 .collect(Collectors.groupingBy(r -> r.getRoom().getId()));
 
-        joinRoomDTOs.forEach(j -> j.setMembers(
-                roomMemberMap.get(j.getRoomId()).stream()
-                        .map(r -> new MemberSimpleInfo(r.getMember()))
-                        .collect(Collectors.toList()))
-        );
+        joinRoomDTOs.forEach(j -> {
+            j.setMembers(
+                    roomMemberMap.get(j.getRoomId()).stream()
+                            .map(r -> new MemberSimpleInfo(r.getMember()))
+                            .collect(Collectors.toList())
+            );
+            if (messagePostMap.containsKey(j.getRoomId()))
+                j.setLastMessage(new MessageDTO(messagePostMap.get(j.getRoomId())));
+            else if (messageImageMap.containsKey(j.getRoomId()))
+                j.setLastMessage(new MessageDTO(messageImageMap.get(j.getRoomId())));
+            else if (messageTextMap.containsKey(j.getRoomId()))
+                j.setLastMessage(new MessageDTO(messageTextMap.get(j.getRoomId())));
+        });
 
         return new PageImpl<>(joinRoomDTOs, pageable, total);
     }

--- a/src/main/java/cloneproject/Instagram/repository/chat/MessagePostRepository.java
+++ b/src/main/java/cloneproject/Instagram/repository/chat/MessagePostRepository.java
@@ -1,0 +1,7 @@
+package cloneproject.Instagram.repository.chat;
+
+import cloneproject.Instagram.entity.chat.MessagePost;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MessagePostRepository extends JpaRepository<MessagePost, Long> {
+}

--- a/src/main/java/cloneproject/Instagram/repository/chat/MessageRepositoryQuerydslImpl.java
+++ b/src/main/java/cloneproject/Instagram/repository/chat/MessageRepositoryQuerydslImpl.java
@@ -57,7 +57,7 @@ public class MessageRepositoryQuerydslImpl implements MessageRepositoryQuerydsl 
 
         final Map<Long, MessagePost> messagePostMap = queryFactory
                 .from(messagePost)
-                .innerJoin(messagePost.post, post).fetchJoin()
+                .leftJoin(messagePost.post, post).fetchJoin()
                 .where(messagePost.id.in(messageIds))
                 .transform(groupBy(messagePost.id).as(messagePost));
 

--- a/src/main/java/cloneproject/Instagram/repository/chat/MessageRepositoryQuerydslImpl.java
+++ b/src/main/java/cloneproject/Instagram/repository/chat/MessageRepositoryQuerydslImpl.java
@@ -1,8 +1,7 @@
 package cloneproject.Instagram.repository.chat;
 
 import cloneproject.Instagram.dto.chat.MessageDTO;
-import cloneproject.Instagram.dto.chat.QMessageDTO;
-import cloneproject.Instagram.entity.chat.JoinRoom;
+import cloneproject.Instagram.entity.chat.*;
 import cloneproject.Instagram.exception.JoinRoomNotFoundException;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -11,11 +10,18 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import static cloneproject.Instagram.entity.chat.QJoinRoom.joinRoom;
 import static cloneproject.Instagram.entity.chat.QMessage.message;
+import static cloneproject.Instagram.entity.chat.QMessageImage.messageImage;
+import static cloneproject.Instagram.entity.chat.QMessagePost.messagePost;
+import static cloneproject.Instagram.entity.chat.QMessageText.messageText;
 import static cloneproject.Instagram.entity.chat.QRoom.room;
 import static cloneproject.Instagram.entity.member.QMember.member;
+import static cloneproject.Instagram.entity.post.QPost.post;
+import static com.querydsl.core.group.GroupBy.groupBy;
 
 @RequiredArgsConstructor
 public class MessageRepositoryQuerydslImpl implements MessageRepositoryQuerydsl {
@@ -34,24 +40,56 @@ public class MessageRepositoryQuerydslImpl implements MessageRepositoryQuerydsl 
         if (findJoinRoom == null)
             throw new JoinRoomNotFoundException();
 
-        final List<MessageDTO> messageDTOs = queryFactory
-                .select(new QMessageDTO(message))
-                .from(message)
+        final List<Message> messages = queryFactory
+                .selectFrom(message)
                 .where(
                         message.room.id.eq(findJoinRoom.getRoom().getId()).and(
-                                message.createdDate.after(findJoinRoom.getCreatedDate())
+                                message.createdDate.goe(findJoinRoom.getCreatedDate())
                         )
                 )
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .orderBy(message.id.desc())
                 .fetch();
+        final List<Long> messageIds = messages.stream()
+                .map(Message::getId)
+                .collect(Collectors.toList());
+
+        final Map<Long, MessagePost> messagePostMap = queryFactory
+                .from(messagePost)
+                .innerJoin(messagePost.post, post).fetchJoin()
+                .where(messagePost.id.in(messageIds))
+                .transform(groupBy(messagePost.id).as(messagePost));
+
+        final Map<Long, MessageImage> messageImageMap = queryFactory
+                .from(messageImage)
+                .where(messageImage.id.in(messageIds))
+                .transform(groupBy(messageImage.id).as(messageImage));
+
+        final Map<Long, MessageText> messageTextMap = queryFactory
+                .from(messageText)
+                .where(messageText.id.in(messageIds))
+                .transform(groupBy(messageText.id).as(messageText));
+
+        final List<MessageDTO> messageDTOs = messages.stream()
+                .map(m -> {
+                    switch (m.getDtype()) {
+                        case "POST":
+                            return new MessageDTO(messagePostMap.get(m.getId()));
+                        case "IMAGE":
+                            return new MessageDTO(messageImageMap.get(m.getId()));
+                        case "TEXT":
+                            return new MessageDTO(messageTextMap.get(m.getId()));
+                    }
+                    return null;
+                })
+                .collect(Collectors.toList());
 
         final long total = queryFactory
                 .selectFrom(message)
                 .where(
                         message.room.id.eq(findJoinRoom.getRoom().getId()).and(
-                                message.createdDate.after(findJoinRoom.getCreatedDate())
+                                message.createdDate.goe(findJoinRoom.getCreatedDate())
                         )
                 )
                 .fetchCount();

--- a/src/main/java/cloneproject/Instagram/repository/chat/MessageTextRepository.java
+++ b/src/main/java/cloneproject/Instagram/repository/chat/MessageTextRepository.java
@@ -1,0 +1,7 @@
+package cloneproject.Instagram.repository.chat;
+
+import cloneproject.Instagram.entity.chat.MessageText;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MessageTextRepository extends JpaRepository<MessageText, Long> {
+}

--- a/src/main/java/cloneproject/Instagram/repository/chat/RoomMemberRepository.java
+++ b/src/main/java/cloneproject/Instagram/repository/chat/RoomMemberRepository.java
@@ -3,14 +3,17 @@ package cloneproject.Instagram.repository.chat;
 import cloneproject.Instagram.entity.chat.RoomMember;
 import cloneproject.Instagram.entity.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface RoomMemberRepository extends JpaRepository<RoomMember, Long>, RoomMemberRepositoryJdbc {
 
-    List<RoomMember> findAllByRoomId(Long roomId);
-
     List<RoomMember> findAllByMemberIn(List<Member> members);
 
     List<RoomMember> findAllByRoomIdIn(List<Long> roomIds);
+
+    @Query("select r from RoomMember r join fetch r.member where r.room.id = :roomId")
+    List<RoomMember> findAllWithMemberByRoomId(@Param("roomId") Long roomId);
 }

--- a/src/main/java/cloneproject/Instagram/repository/chat/RoomMemberRepository.java
+++ b/src/main/java/cloneproject/Instagram/repository/chat/RoomMemberRepository.java
@@ -1,11 +1,16 @@
 package cloneproject.Instagram.repository.chat;
 
 import cloneproject.Instagram.entity.chat.RoomMember;
+import cloneproject.Instagram.entity.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
-public interface RoomMemberRepository extends JpaRepository<RoomMember, Long> {
-    List<RoomMember> findAllByMemberId(Long memberId);
+public interface RoomMemberRepository extends JpaRepository<RoomMember, Long>, RoomMemberRepositoryJdbc {
+
     List<RoomMember> findAllByRoomId(Long roomId);
+
+    List<RoomMember> findAllByMemberIn(List<Member> members);
+
+    List<RoomMember> findAllByRoomIdIn(List<Long> roomIds);
 }

--- a/src/main/java/cloneproject/Instagram/repository/chat/RoomMemberRepositoryJdbc.java
+++ b/src/main/java/cloneproject/Instagram/repository/chat/RoomMemberRepositoryJdbc.java
@@ -1,0 +1,11 @@
+package cloneproject.Instagram.repository.chat;
+
+import cloneproject.Instagram.entity.chat.Room;
+import cloneproject.Instagram.entity.member.Member;
+
+import java.util.List;
+
+public interface RoomMemberRepositoryJdbc {
+
+    void saveAllBatch(Room room, List<Member> members);
+}

--- a/src/main/java/cloneproject/Instagram/repository/chat/RoomMemberRepositoryJdbcImpl.java
+++ b/src/main/java/cloneproject/Instagram/repository/chat/RoomMemberRepositoryJdbcImpl.java
@@ -1,0 +1,37 @@
+package cloneproject.Instagram.repository.chat;
+
+import cloneproject.Instagram.entity.chat.Room;
+import cloneproject.Instagram.entity.member.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.List;
+
+@RequiredArgsConstructor
+public class RoomMemberRepositoryJdbcImpl implements RoomMemberRepositoryJdbc {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Override
+    public void saveAllBatch(Room room, List<Member> members) {
+        final String sql = "INSERT INTO room_members (`member_id`, `room_id`) VALUES(?, ?)";
+
+        jdbcTemplate.batchUpdate(
+                sql,
+                new BatchPreparedStatementSetter() {
+                    @Override
+                    public void setValues(PreparedStatement ps, int i) throws SQLException {
+                        ps.setString(1, members.get(i).getId().toString());
+                        ps.setString(2, room.getId().toString());
+                    }
+
+                    @Override
+                    public int getBatchSize() {
+                        return members.size();
+                    }
+                });
+    }
+}

--- a/src/main/java/cloneproject/Instagram/repository/chat/RoomUnreadMemberRepository.java
+++ b/src/main/java/cloneproject/Instagram/repository/chat/RoomUnreadMemberRepository.java
@@ -5,9 +5,10 @@ import cloneproject.Instagram.entity.chat.RoomUnreadMember;
 import cloneproject.Instagram.entity.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
-public interface RoomUnreadMemberRepository extends JpaRepository<RoomUnreadMember, Long> {
+public interface RoomUnreadMemberRepository extends JpaRepository<RoomUnreadMember, Long>, RoomUnreadMemberRepositoryJdbc {
 
     void deleteByRoomIdAndMemberId(Long roomId, Long memberId);
 
@@ -16,4 +17,6 @@ public interface RoomUnreadMemberRepository extends JpaRepository<RoomUnreadMemb
     long countByRoomId(Long roomId);
 
     Optional<RoomUnreadMember> findByRoomAndMember(Room room, Member member);
+
+    List<RoomUnreadMember> findByRoomAndMemberIn(Room room, List<Member> members);
 }

--- a/src/main/java/cloneproject/Instagram/repository/chat/RoomUnreadMemberRepository.java
+++ b/src/main/java/cloneproject/Instagram/repository/chat/RoomUnreadMemberRepository.java
@@ -1,12 +1,19 @@
 package cloneproject.Instagram.repository.chat;
 
+import cloneproject.Instagram.entity.chat.Room;
 import cloneproject.Instagram.entity.chat.RoomUnreadMember;
+import cloneproject.Instagram.entity.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface RoomUnreadMemberRepository extends JpaRepository<RoomUnreadMember, Long> {
+
     void deleteByRoomIdAndMemberId(Long roomId, Long memberId);
+
     Optional<RoomUnreadMember> findByRoomIdAndMemberId(Long roomId, Long memberId);
+
     long countByRoomId(Long roomId);
+
+    Optional<RoomUnreadMember> findByRoomAndMember(Room room, Member member);
 }

--- a/src/main/java/cloneproject/Instagram/repository/chat/RoomUnreadMemberRepositoryJdbc.java
+++ b/src/main/java/cloneproject/Instagram/repository/chat/RoomUnreadMemberRepositoryJdbc.java
@@ -1,0 +1,10 @@
+package cloneproject.Instagram.repository.chat;
+
+import cloneproject.Instagram.entity.chat.RoomUnreadMember;
+
+import java.util.List;
+
+public interface RoomUnreadMemberRepositoryJdbc {
+
+    void saveAllBatch(List<RoomUnreadMember> roomUnreadMembers);
+}

--- a/src/main/java/cloneproject/Instagram/repository/chat/RoomUnreadMemberRepositoryJdbcImpl.java
+++ b/src/main/java/cloneproject/Instagram/repository/chat/RoomUnreadMemberRepositoryJdbcImpl.java
@@ -1,0 +1,36 @@
+package cloneproject.Instagram.repository.chat;
+
+import cloneproject.Instagram.entity.chat.RoomUnreadMember;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.List;
+
+@RequiredArgsConstructor
+public class RoomUnreadMemberRepositoryJdbcImpl implements RoomUnreadMemberRepositoryJdbc {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Override
+    public void saveAllBatch(List<RoomUnreadMember> roomUnreadMembers) {
+        final String sql = "INSERT INTO room_unread_members (`member_id`, `room_id`) VALUES(?, ?)";
+
+        jdbcTemplate.batchUpdate(
+                sql,
+                new BatchPreparedStatementSetter() {
+                    @Override
+                    public void setValues(PreparedStatement ps, int i) throws SQLException {
+                        ps.setString(1, roomUnreadMembers.get(i).getMember().getId().toString());
+                        ps.setString(2, roomUnreadMembers.get(i).getRoom().getId().toString());
+                    }
+
+                    @Override
+                    public int getBatchSize() {
+                        return roomUnreadMembers.size();
+                    }
+                });
+    }
+}


### PR DESCRIPTION
## 변경 사항
### 게시물 이미지 태그 -> 알림이 아닌 DM으로 게시물 공유하는 방식으로 변경
- 게시물 공유 메시지 응답 DTO
    - ![image](https://user-images.githubusercontent.com/68049320/155850014-76735d68-8bf4-43b4-b176-8b94c3d778a6.png)
- 해당 메시지에 마우스 오버 시, 미니 프로필 조회는 x
- 해당 메시지를 클릭하면 해당 게시물로 이동하는 방식
- 메시지 목록 조회 시, 공유한 게시물이 삭제된 경우 다음과 같이 표현
    - ![image](https://user-images.githubusercontent.com/68049320/155849902-2b5461de-f3c3-4a5f-8bcc-c948c4179d21.png)
        - 본인이 메시지 삭제만 가능. 메시지 좋아요, 복사 등 불가능
    - 응답 메시지는 다음과 같음
        - ![image](https://user-images.githubusercontent.com/68049320/155849926-1e659e6f-509b-4ba7-9f6e-6d725742c1e8.png)

### 메시지 엔티티 테이블 구조 변경
- 슈퍼타입-서브타입 관계 모델링 기법 적용
- Message를 상속받는 MessageText, MessagePost, MessageImage
- 각각 서브타입 테이블의 PK겸 FK는 message_id
- 기존의 MessageType Enum 제거

### 메시지 전송 API 쿼리 최적화 등
- roomUnreadMember, joinRoom bulk update
- left outer join -> inner join
- 모든 메시지 전송 로직이 있는 API에서 room_unread_members 테이블에 본인을 추가하지 않도록 수정

## 해결 이슈
- Resolve: #104 
- Resolve: #111 
- Resolve: #112 