### PR TITLE
채팅 API 추가 및 변경

### DIFF
--- a/src/main/java/cloneproject/Instagram/controller/ChatController.java
+++ b/src/main/java/cloneproject/Instagram/controller/ChatController.java
@@ -13,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
@@ -78,8 +79,37 @@ public class ChatController {
         return ResponseEntity.ok(ResultResponse.of(GET_CHAT_MESSAGES_SUCCESS, response));
     }
 
+    @MessageMapping("/messages/like")
+    public void likeMessage(
+            @NotNull(message = "좋아요할 메시지 PK는 필수입니다.") @RequestParam Long messageId,
+            @NotNull(message = "회원 PK는 필수입니다.") @RequestParam Long memberId) {
+        chatService.likeMessage(messageId, memberId);
+    }
+
+    @MessageMapping("/messages/unlike")
+    public void unlikeMessage(
+            @NotNull(message = "좋아요 취소할 메시지 PK는 필수입니다.") @RequestParam Long messageId,
+            @NotNull(message = "회원 PK는 필수입니다.") @RequestParam Long memberId) {
+        chatService.unlikeMessage(messageId, memberId);
+    }
+
+    @MessageMapping("/messages/delete")
+    public void deleteMessage(
+            @NotNull(message = "삭제할 메시지 PK는 필수입니다.") @RequestParam Long messageId,
+            @NotNull(message = "회원 PK는 필수입니다.") @RequestParam Long memberId) {
+        chatService.deleteMessage(messageId, memberId);
+    }
+
+    @MessageMapping("/messages/images")
+    public void sendImageMessage(
+            @NotNull(message = "채팅방 PK는 필수입니다.") @RequestParam Long roomId,
+            @NotNull(message = "메시지를 전송하는 회원 PK는 필수입니다.") @RequestParam Long senderId,
+            @RequestParam MultipartFile image) {
+        chatService.sendImage(roomId, senderId, image);
+    }
+
     @MessageMapping("/messages")
-    public void sendChatMessage(@RequestBody MessageRequest request) {
+    public void sendTextMessage(@RequestBody MessageRequest request) {
         chatService.sendMessage(request);
     }
 

--- a/src/main/java/cloneproject/Instagram/dto/chat/MessageAction.java
+++ b/src/main/java/cloneproject/Instagram/dto/chat/MessageAction.java
@@ -1,5 +1,5 @@
 package cloneproject.Instagram.dto.chat;
 
 public enum MessageAction {
-    MESSAGE_GET, MESSAGE_ACK, MESSAGE_SEEN
+    MESSAGE_GET, MESSAGE_ACK, MESSAGE_SEEN, MESSAGE_DELETE, MESSAGE_LIKE, MESSAGE_UNLIKE
 }

--- a/src/main/java/cloneproject/Instagram/dto/chat/MessageDTO.java
+++ b/src/main/java/cloneproject/Instagram/dto/chat/MessageDTO.java
@@ -8,8 +8,11 @@ import cloneproject.Instagram.vo.Image;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
+@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 public class MessageDTO {
@@ -21,6 +24,7 @@ public class MessageDTO {
     private Object content;
     private String messageType;
     private LocalDateTime messageDate;
+    private List<MenuMemberDTO> likeMembers = new ArrayList<>();
 
     public MessageDTO(MessagePost message) {
         this.roomId = message.getRoom().getId();

--- a/src/main/java/cloneproject/Instagram/dto/chat/MessageSimpleDTO.java
+++ b/src/main/java/cloneproject/Instagram/dto/chat/MessageSimpleDTO.java
@@ -1,0 +1,23 @@
+package cloneproject.Instagram.dto.chat;
+
+import cloneproject.Instagram.entity.chat.Message;
+import cloneproject.Instagram.entity.member.Member;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MessageSimpleDTO {
+
+    private Long roomId;
+    private Long messageId;
+    private Long memberId;
+
+    public MessageSimpleDTO(Message message, Member member) {
+        this.roomId = message.getRoom().getId();
+        this.messageId = message.getId();
+        this.memberId = member.getId();
+    }
+}

--- a/src/main/java/cloneproject/Instagram/dto/error/ErrorCode.java
+++ b/src/main/java/cloneproject/Instagram/dto/error/ErrorCode.java
@@ -61,6 +61,11 @@ public enum ErrorCode {
     // Chat
     CHAT_ROOM_NOT_FOUND(400, "C001", "존재하지 않는 채팅방입니다."),
     JOIN_ROOM_NOT_FOUND(400, "C002", "해당 채팅방에 참여하지 않은 회원입니다."),
+    MESSAGE_IMAGE_INVALID(400, "C003", "메시지로 전송할 이미지는 필수입니다."),
+    MESSAGE_NOT_FOUND(400, "C004", "존재하지 않는 메시지입니다."),
+    MESSAGE_SENDER_MISMATCH(400, "C005", "해당 메시지를 전송한 회원이 아닙니다."),
+    MESSAGE_LIKE_ALREADY_EXIST(400, "C006", "해당 메시지를 이미 좋아요한 회원입니다."),
+    MESSAGE_LIKE_NOT_FOUND(400, "C007", "해당 메시지를 좋아요하지 않은 회원입니다."),
 
     // FILE
     CANT_CONVERT_FILE(500, "FI001", "파일을 변환할수 없습니다"),

--- a/src/main/java/cloneproject/Instagram/entity/chat/JoinRoom.java
+++ b/src/main/java/cloneproject/Instagram/entity/chat/JoinRoom.java
@@ -6,7 +6,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
@@ -36,17 +35,18 @@ public class JoinRoom {
     @Column(name = "join_room_created_date")
     private LocalDateTime createdDate;
 
-    @LastModifiedDate
-    @Column(name = "join_room_last_message_date")
-    private LocalDateTime lastMessageDate;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "message_id")
+    private Message message;
 
     @Builder
-    public JoinRoom(Room room, Member member) {
+    public JoinRoom(Room room, Member member, Message message) {
         this.room = room;
         this.member = member;
+        this.message = message;
     }
 
-    public void update() {
-        this.lastMessageDate = LocalDateTime.now();
+    public void updateMessage(Message message){
+        this.message = message;
     }
 }

--- a/src/main/java/cloneproject/Instagram/entity/chat/Message.java
+++ b/src/main/java/cloneproject/Instagram/entity/chat/Message.java
@@ -37,7 +37,7 @@ public class Message {
     @Column(name = "message_created_date")
     private LocalDateTime createdDate;
 
-    @Column(insertable=false, updatable=false)
+    @Column(insertable = false, updatable = false)
     private String dtype;
 
     @Builder

--- a/src/main/java/cloneproject/Instagram/entity/chat/Room.java
+++ b/src/main/java/cloneproject/Instagram/entity/chat/Room.java
@@ -24,10 +24,6 @@ public class Room {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "message_id")
-    private Message message;
-
     @OneToMany(mappedBy = "room")
     private List<RoomUnreadMember> roomUnreadMembers = new ArrayList<>();
 
@@ -36,9 +32,5 @@ public class Room {
 
     public Room(Member member) {
         this.member = member;
-    }
-
-    public void updateLastMessage(Message message) {
-        this.message = message;
     }
 }

--- a/src/main/java/cloneproject/Instagram/entity/chat/RoomUnreadMember.java
+++ b/src/main/java/cloneproject/Instagram/entity/chat/RoomUnreadMember.java
@@ -24,12 +24,17 @@ public class RoomUnreadMember {
     private Room room;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "message_id")
+    private Message message;
+
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
     @Builder
-    public RoomUnreadMember(Room room, Member member) {
+    public RoomUnreadMember(Room room, Message message, Member member) {
         this.room = room;
+        this.message = message;
         this.member = member;
     }
 }

--- a/src/main/java/cloneproject/Instagram/exception/InvalidInputException.java
+++ b/src/main/java/cloneproject/Instagram/exception/InvalidInputException.java
@@ -1,0 +1,13 @@
+package cloneproject.Instagram.exception;
+
+import cloneproject.Instagram.dto.error.ErrorCode;
+import cloneproject.Instagram.dto.error.ErrorResponse;
+
+import java.util.List;
+
+public class InvalidInputException extends BusinessException {
+
+    public InvalidInputException(List<ErrorResponse.FieldError> errors) {
+        super(ErrorCode.INVALID_INPUT_VALUE, errors);
+    }
+}

--- a/src/main/java/cloneproject/Instagram/exception/MessageLikeAlreadyExistException.java
+++ b/src/main/java/cloneproject/Instagram/exception/MessageLikeAlreadyExistException.java
@@ -1,0 +1,10 @@
+package cloneproject.Instagram.exception;
+
+import cloneproject.Instagram.dto.error.ErrorCode;
+
+public class MessageLikeAlreadyExistException extends BusinessException {
+
+    public MessageLikeAlreadyExistException() {
+        super(ErrorCode.MESSAGE_LIKE_ALREADY_EXIST);
+    }
+}

--- a/src/main/java/cloneproject/Instagram/exception/MessageLikeNotFoundException.java
+++ b/src/main/java/cloneproject/Instagram/exception/MessageLikeNotFoundException.java
@@ -1,0 +1,10 @@
+package cloneproject.Instagram.exception;
+
+import cloneproject.Instagram.dto.error.ErrorCode;
+
+public class MessageLikeNotFoundException extends BusinessException {
+
+    public MessageLikeNotFoundException() {
+        super(ErrorCode.MESSAGE_LIKE_NOT_FOUND);
+    }
+}

--- a/src/main/java/cloneproject/Instagram/exception/MessageNotFoundException.java
+++ b/src/main/java/cloneproject/Instagram/exception/MessageNotFoundException.java
@@ -1,0 +1,10 @@
+package cloneproject.Instagram.exception;
+
+import cloneproject.Instagram.dto.error.ErrorCode;
+
+public class MessageNotFoundException extends BusinessException {
+
+    public MessageNotFoundException() {
+        super(ErrorCode.MESSAGE_NOT_FOUND);
+    }
+}

--- a/src/main/java/cloneproject/Instagram/repository/chat/JoinRomRepositoryJdbc.java
+++ b/src/main/java/cloneproject/Instagram/repository/chat/JoinRomRepositoryJdbc.java
@@ -1,12 +1,13 @@
 package cloneproject.Instagram.repository.chat;
 
 import cloneproject.Instagram.entity.chat.JoinRoom;
+import cloneproject.Instagram.entity.chat.Message;
 
 import java.util.List;
 
 public interface JoinRomRepositoryJdbc {
 
-    void saveAllBatch(List<JoinRoom> joinRooms);
+    void saveAllBatch(List<JoinRoom> joinRooms, Message message);
 
-    void updateAllBatch(List<JoinRoom> updateJoinRooms);
+    void updateAllBatch(List<JoinRoom> updateJoinRooms, Message message);
 }

--- a/src/main/java/cloneproject/Instagram/repository/chat/JoinRomRepositoryJdbcImpl.java
+++ b/src/main/java/cloneproject/Instagram/repository/chat/JoinRomRepositoryJdbcImpl.java
@@ -1,6 +1,7 @@
 package cloneproject.Instagram.repository.chat;
 
 import cloneproject.Instagram.entity.chat.JoinRoom;
+import cloneproject.Instagram.entity.chat.Message;
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.BatchPreparedStatementSetter;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -17,10 +18,10 @@ public class JoinRomRepositoryJdbcImpl implements JoinRomRepositoryJdbc {
     private final JdbcTemplate jdbcTemplate;
 
     @Override
-    public void saveAllBatch(List<JoinRoom> joinRooms) {
+    public void saveAllBatch(List<JoinRoom> joinRooms, Message message) {
         final String now = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
         final String sql =
-                "INSERT INTO join_rooms (`join_room_created_date`, `join_room_last_message_date`, `member_id`, `room_id`) " +
+                "INSERT INTO join_rooms (`join_room_created_date`, `member_id`, `message_id`, `room_id`) " +
                         "VALUES(?, ?, ?, ?)";
 
         jdbcTemplate.batchUpdate(
@@ -29,8 +30,8 @@ public class JoinRomRepositoryJdbcImpl implements JoinRomRepositoryJdbc {
                     @Override
                     public void setValues(PreparedStatement ps, int i) throws SQLException {
                         ps.setString(1, now);
-                        ps.setString(2, now);
-                        ps.setString(3, joinRooms.get(i).getMember().getId().toString());
+                        ps.setString(2, joinRooms.get(i).getMember().getId().toString());
+                        ps.setString(3, message.getId().toString());
                         ps.setString(4, joinRooms.get(i).getRoom().getId().toString());
                     }
 
@@ -42,16 +43,15 @@ public class JoinRomRepositoryJdbcImpl implements JoinRomRepositoryJdbc {
     }
 
     @Override
-    public void updateAllBatch(List<JoinRoom> updateJoinRooms) {
-        final String now = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
-        final String sql = "UPDATE join_rooms SET join_room_last_message_date = ? where join_room_id = ?";
+    public void updateAllBatch(List<JoinRoom> updateJoinRooms, Message message) {
+        final String sql = "UPDATE join_rooms SET message_id = ? where join_room_id = ?";
 
         jdbcTemplate.batchUpdate(
                 sql,
                 new BatchPreparedStatementSetter() {
                     @Override
                     public void setValues(PreparedStatement ps, int i) throws SQLException {
-                        ps.setString(1, now);
+                        ps.setString(1, message.getId().toString());
                         ps.setString(2, updateJoinRooms.get(i).getId().toString());
                     }
 

--- a/src/main/java/cloneproject/Instagram/repository/chat/JoinRoomRepository.java
+++ b/src/main/java/cloneproject/Instagram/repository/chat/JoinRoomRepository.java
@@ -12,14 +12,14 @@ import java.util.Optional;
 
 public interface JoinRoomRepository extends JpaRepository<JoinRoom, Long>, JoinRoomRepositoryQuerydsl, JoinRomRepositoryJdbc {
 
-    Optional<JoinRoom> findByMemberIdAndRoomId(Long memberId, Long roomId);
-
-    void deleteByMemberIdAndRoomId(Long memberId, Long roomId);
-
     @Query(value = "select j from JoinRoom j join fetch j.member where j.room.id = :id")
     List<JoinRoom> findAllByRoomId(@Param("id") Long id);
 
     Optional<JoinRoom> findByMemberAndRoom(Member member, Room room);
 
     List<JoinRoom> findByRoomAndMemberIn(Room room, List<Member> members);
+
+    List<JoinRoom> findAllByRoom(Room room);
+
+    void deleteByMemberAndRoom(Member member, Room room);
 }

--- a/src/main/java/cloneproject/Instagram/repository/chat/JoinRoomRepositoryQuerydslImpl.java
+++ b/src/main/java/cloneproject/Instagram/repository/chat/JoinRoomRepositoryQuerydslImpl.java
@@ -50,22 +50,21 @@ public class JoinRoomRepositoryQuerydslImpl implements JoinRoomRepositoryQueryds
                 ))
                 .from(joinRoom)
                 .innerJoin(joinRoom.room, room)
-                .innerJoin(joinRoom.room.message, message)
+                .innerJoin(joinRoom.message, message)
                 .innerJoin(joinRoom.room.member, member)
                 .where(joinRoom.member.id.eq(memberId))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
-                .orderBy(joinRoom.lastMessageDate.desc())
+                .orderBy(joinRoom.message.createdDate.desc())
                 .fetch();
-
         final List<Long> roomIds = joinRoomDTOs.stream()
                 .map(JoinRoomDTO::getRoomId)
                 .collect(Collectors.toList());
         final List<Message> messages = queryFactory
-                .select(room.message)
-                .from(room)
-                .innerJoin(room.message, message)
-                .where(room.id.in(roomIds))
+                .select(joinRoom.message)
+                .from(joinRoom)
+                .innerJoin(joinRoom.message, message)
+                .where(joinRoom.member.id.eq(memberId))
                 .fetch();
         final List<Long> messageIds = messages.stream()
                 .map(Message::getId)

--- a/src/main/java/cloneproject/Instagram/repository/chat/MessageLikeRepository.java
+++ b/src/main/java/cloneproject/Instagram/repository/chat/MessageLikeRepository.java
@@ -1,7 +1,13 @@
 package cloneproject.Instagram.repository.chat;
 
+import cloneproject.Instagram.entity.chat.Message;
 import cloneproject.Instagram.entity.chat.MessageLike;
+import cloneproject.Instagram.entity.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MessageLikeRepository extends JpaRepository<MessageLike, Long> {
+
+    Optional<MessageLike> findByMemberAndMessage(Member member, Message message);
 }

--- a/src/main/java/cloneproject/Instagram/repository/chat/MessageRepository.java
+++ b/src/main/java/cloneproject/Instagram/repository/chat/MessageRepository.java
@@ -1,7 +1,19 @@
 package cloneproject.Instagram.repository.chat;
 
 import cloneproject.Instagram.entity.chat.Message;
+import cloneproject.Instagram.entity.chat.Room;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface MessageRepository extends JpaRepository<Message, Long>, MessageRepositoryQuerydsl {
+
+    @Query("select m from Message m join fetch m.room where m.id = :id")
+    Optional<Message> findWithRoomById(@Param("id") Long id);
+
+    Page<Message> findAllByRoom(Room room, Pageable pageable);
 }

--- a/src/main/java/cloneproject/Instagram/repository/chat/MessageRepositoryQuerydslImpl.java
+++ b/src/main/java/cloneproject/Instagram/repository/chat/MessageRepositoryQuerydslImpl.java
@@ -1,6 +1,7 @@
 package cloneproject.Instagram.repository.chat;
 
 import cloneproject.Instagram.dto.chat.MessageDTO;
+import cloneproject.Instagram.dto.member.MenuMemberDTO;
 import cloneproject.Instagram.entity.chat.*;
 import cloneproject.Instagram.exception.JoinRoomNotFoundException;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -16,12 +17,13 @@ import java.util.stream.Collectors;
 import static cloneproject.Instagram.entity.chat.QJoinRoom.joinRoom;
 import static cloneproject.Instagram.entity.chat.QMessage.message;
 import static cloneproject.Instagram.entity.chat.QMessageImage.messageImage;
+import static cloneproject.Instagram.entity.chat.QMessageLike.messageLike;
 import static cloneproject.Instagram.entity.chat.QMessagePost.messagePost;
 import static cloneproject.Instagram.entity.chat.QMessageText.messageText;
 import static cloneproject.Instagram.entity.chat.QRoom.room;
 import static cloneproject.Instagram.entity.member.QMember.member;
 import static cloneproject.Instagram.entity.post.QPost.post;
-import static com.querydsl.core.group.GroupBy.groupBy;
+import static com.querydsl.core.group.GroupBy.*;
 
 @RequiredArgsConstructor
 public class MessageRepositoryQuerydslImpl implements MessageRepositoryQuerydsl {
@@ -55,6 +57,7 @@ public class MessageRepositoryQuerydslImpl implements MessageRepositoryQuerydsl 
                 .map(Message::getId)
                 .collect(Collectors.toList());
 
+
         final Map<Long, MessagePost> messagePostMap = queryFactory
                 .from(messagePost)
                 .leftJoin(messagePost.post, post).fetchJoin()
@@ -84,6 +87,21 @@ public class MessageRepositoryQuerydslImpl implements MessageRepositoryQuerydsl 
                     return null;
                 })
                 .collect(Collectors.toList());
+
+        final Map<Long, List<MessageLike>> messageLikeMap = queryFactory
+                .from(messageLike)
+                .where(messageLike.message.id.in(messageIds))
+                .innerJoin(messageLike.member, member).fetchJoin()
+                .transform(groupBy(messageLike.message.id).as(list(messageLike)));
+
+        messageDTOs.forEach(m -> {
+            if (messageLikeMap.containsKey(m.getMessageId())) {
+                final List<MenuMemberDTO> likeMembers = messageLikeMap.get(m.getMessageId()).stream()
+                        .map(ml -> new MenuMemberDTO(ml.getMember()))
+                        .collect(Collectors.toList());
+                m.setLikeMembers(likeMembers);
+            }
+        });
 
         final long total = queryFactory
                 .selectFrom(message)

--- a/src/main/java/cloneproject/Instagram/repository/chat/RoomMemberRepository.java
+++ b/src/main/java/cloneproject/Instagram/repository/chat/RoomMemberRepository.java
@@ -1,5 +1,6 @@
 package cloneproject.Instagram.repository.chat;
 
+import cloneproject.Instagram.entity.chat.Room;
 import cloneproject.Instagram.entity.chat.RoomMember;
 import cloneproject.Instagram.entity.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -16,4 +17,6 @@ public interface RoomMemberRepository extends JpaRepository<RoomMember, Long>, R
 
     @Query("select r from RoomMember r join fetch r.member where r.room.id = :roomId")
     List<RoomMember> findAllWithMemberByRoomId(@Param("roomId") Long roomId);
+
+    List<RoomMember> findAllByRoom(Room room);
 }

--- a/src/main/java/cloneproject/Instagram/repository/chat/RoomUnreadMemberRepository.java
+++ b/src/main/java/cloneproject/Instagram/repository/chat/RoomUnreadMemberRepository.java
@@ -1,22 +1,18 @@
 package cloneproject.Instagram.repository.chat;
 
+import cloneproject.Instagram.entity.chat.Message;
 import cloneproject.Instagram.entity.chat.Room;
 import cloneproject.Instagram.entity.chat.RoomUnreadMember;
 import cloneproject.Instagram.entity.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface RoomUnreadMemberRepository extends JpaRepository<RoomUnreadMember, Long>, RoomUnreadMemberRepositoryJdbc {
 
-    void deleteByRoomIdAndMemberId(Long roomId, Long memberId);
+    List<RoomUnreadMember> findAllByRoomAndMember(Room room, Member member);
 
-    Optional<RoomUnreadMember> findByRoomIdAndMemberId(Long roomId, Long memberId);
+    List<RoomUnreadMember> findAllByMessage(Message message);
 
-    long countByRoomId(Long roomId);
-
-    Optional<RoomUnreadMember> findByRoomAndMember(Room room, Member member);
-
-    List<RoomUnreadMember> findByRoomAndMemberIn(Room room, List<Member> members);
+    List<RoomUnreadMember> findAllByRoom(Room room);
 }

--- a/src/main/java/cloneproject/Instagram/repository/chat/RoomUnreadMemberRepositoryJdbc.java
+++ b/src/main/java/cloneproject/Instagram/repository/chat/RoomUnreadMemberRepositoryJdbc.java
@@ -1,10 +1,11 @@
 package cloneproject.Instagram.repository.chat;
 
+import cloneproject.Instagram.entity.chat.Message;
 import cloneproject.Instagram.entity.chat.RoomUnreadMember;
 
 import java.util.List;
 
 public interface RoomUnreadMemberRepositoryJdbc {
 
-    void saveAllBatch(List<RoomUnreadMember> roomUnreadMembers);
+    void saveAllBatch(List<RoomUnreadMember> roomUnreadMembers, Message message);
 }

--- a/src/main/java/cloneproject/Instagram/repository/chat/RoomUnreadMemberRepositoryJdbcImpl.java
+++ b/src/main/java/cloneproject/Instagram/repository/chat/RoomUnreadMemberRepositoryJdbcImpl.java
@@ -1,5 +1,6 @@
 package cloneproject.Instagram.repository.chat;
 
+import cloneproject.Instagram.entity.chat.Message;
 import cloneproject.Instagram.entity.chat.RoomUnreadMember;
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.BatchPreparedStatementSetter;
@@ -15,8 +16,8 @@ public class RoomUnreadMemberRepositoryJdbcImpl implements RoomUnreadMemberRepos
     private final JdbcTemplate jdbcTemplate;
 
     @Override
-    public void saveAllBatch(List<RoomUnreadMember> roomUnreadMembers) {
-        final String sql = "INSERT INTO room_unread_members (`member_id`, `room_id`) VALUES(?, ?)";
+    public void saveAllBatch(List<RoomUnreadMember> roomUnreadMembers, Message message) {
+        final String sql = "INSERT INTO room_unread_members (`member_id`, `room_id`, `message_id`) VALUES(?, ?, ?)";
 
         jdbcTemplate.batchUpdate(
                 sql,
@@ -25,6 +26,7 @@ public class RoomUnreadMemberRepositoryJdbcImpl implements RoomUnreadMemberRepos
                     public void setValues(PreparedStatement ps, int i) throws SQLException {
                         ps.setString(1, roomUnreadMembers.get(i).getMember().getId().toString());
                         ps.setString(2, roomUnreadMembers.get(i).getRoom().getId().toString());
+                        ps.setString(3, message.getId().toString());
                     }
 
                     @Override


### PR DESCRIPTION
## 변경 사항
### 채팅 APIs: 쿼리 최적화
- xxxByEntityId -> `xxxByEntity`
### 게시물 삭제 API 로직 추가
- S3에서 해당 객체 제거
### 엔티티 수정
- `JoinRoom`: Message 연관관계 추가, lastMessageDate 필드 제거
- `Room`: Message 연관관계 삭제
- `RoomUnreadMember`: Message 연관관계 추가
    - 채팅방마다 -> 메시지마다 읽지 않음 여부 저장
___
### 이미지 전송 API 추가
- Endpoint: `/messages/image`
- http method: POST with JWT
```
- roomId 
- image (file)
```
- 응답
```
{
  action: MESSAGE_GET,
  data: 
  {
    roomId: 1,
    messageId: 1,
    senderId: 1,
    senderImage: { ... },
    content: { ... },
    messageType: IMAGE,
    messageDate: ...,
    likeMembers: { ... }
  }
}
```
### 메시지 삭제 API 추가
- Endpoint: `/pub/messages/delete`
```
- messageId
- memberId
```
- 응답
```
{
  action: MESSAGE_DELETE,
  data: 
  {
    roomId: 1,
    messageId: 1,
    memberId: 1
  }
}
```
### 메시지 좋아요/취소 API 추가
- Endpoint: `/pub/messages/like(unlike)`
```
- messageId
- memberId
```
- 응답
```
{
  action: MESSAGE_LIKE(UNLIKE),
  data: 
  {
    roomId: 1,
    messageId: 1,
    memberId: 1
  }
}
```
### 메시지 목록 조회 API 응답 데이터 추가
- 메시지 좋아요한 사람 목록
```
likeMembers:
{
  {
    memberId: 1,
    memberUsername: dlwlrma,
    memberImageUrl: ...,
    memberName: 아이유
  },
  {
    memberId: 2,
    memberUsername: dlwlrma2,
    memberImageUrl: ...,
    memberName: 아이유2
  }
}
```
### 채팅방 조회 API 응답 메시지 수정
- action: message_ack -> `message_seen`으로 수정

## 해결 이슈
- Resolve: #114