### PR TITLE
비밀번호 재설정 API 구현

### DIFF
--- a/src/main/java/cloneproject/Instagram/dto/error/ErrorCode.java
+++ b/src/main/java/cloneproject/Instagram/dto/error/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
     ACCOUNT_DOES_NOT_MATCH(401, "M005", "계정정보가 일치하지 않습니다."),
     UPLOAD_PROFILE_IMAGE_FAIL(400, "M006", "회원 이미지를 업로드 하는 중 실패했습니다."),
     NO_CONFIRM_EMAIL(400, "M007", "인증 이메일 전송을 먼저 해야합니다."),
+    CANT_RESET_PASSWORD(400, "M008", "잘못되거나 만료된 코드입니다"),
     
     // FOLLOW
     ALREADY_FOLLOW(400, "F001", "이미 팔로우한 유저입니다."),

--- a/src/main/java/cloneproject/Instagram/dto/member/ResetPasswordRequest.java
+++ b/src/main/java/cloneproject/Instagram/dto/member/ResetPasswordRequest.java
@@ -1,0 +1,38 @@
+package cloneproject.Instagram.dto.member;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+
+import org.hibernate.validator.constraints.Length;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResetPasswordRequest {
+    
+    @ApiModelProperty(value = "유저네임", example = "dlwlrma", required = true)
+    @NotBlank(message = "username을 입력해주세요")
+    @Length(min = 4, max = 12, message = "사용자 이름은 4문자 이상 12문자 이하여야 합니다")
+    @Pattern(regexp = "^[0-9a-zA-Z]+$", message = "username엔 대소문자, 숫자만 사용할 수 있습니다.")
+    private String username;
+    
+    @ApiModelProperty(value = "인증코드", example = "ABC123AAAAAAAA1231313123..", required = true)
+    @NotBlank(message = "인증코드를 입력해주세요")
+    @Length(max = 30, min = 30, message = "인증코드는 30자리 입니다.")
+    private String code;
+
+    @ApiModelProperty(value = "새비밀번호", example = "a12341234", required = true)
+    @NotBlank(message = "새비밀번호를 입력해주세요")
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,}$", 
+                message = "비밀번호는 8자 이상, 최소 하나의 문자와 숫자가 필요합니다")
+    @Length(max = 20, message = "비밀번호는 20문자 이하여야 합니다")
+    private String newPassword;
+    
+}

--- a/src/main/java/cloneproject/Instagram/dto/member/SendConfirmationEmailRequest.java
+++ b/src/main/java/cloneproject/Instagram/dto/member/SendConfirmationEmailRequest.java
@@ -6,6 +6,7 @@ import javax.validation.constraints.Pattern;
 
 import org.hibernate.validator.constraints.Length;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,11 +18,13 @@ import lombok.NoArgsConstructor;
 @Builder
 public class SendConfirmationEmailRequest {
 
+    @ApiModelProperty(value = "유저네임", example = "dlwlrma", required = true)
     @NotBlank(message = "username을 입력해주세요")
     @Length(min = 4, max = 12, message = "사용자 이름은 4문자 이상 12문자 이하여야 합니다")
     @Pattern(regexp = "^[0-9a-zA-Z]+$", message = "username엔 대소문자, 숫자만 사용할 수 있습니다.")
     String username;
     
+    @ApiModelProperty(value = "이메일", example = "aaa@gmail.com", required = true)
     @NotBlank(message = "이메일을 입력해주세요")
     @Email(message = "이메일의 형식이 맞지 않습니다")
     String email;

--- a/src/main/java/cloneproject/Instagram/dto/result/ResultCode.java
+++ b/src/main/java/cloneproject/Instagram/dto/result/ResultCode.java
@@ -24,6 +24,10 @@ public enum ResultCode {
     SEND_CONFIRM_EMAIL_SUCCESS(200, "M014", "인증코드 이메일 전송 완료"),
     SEARCH_MEMBER_SUCCESS(200, "M015", "회원 검색 완료"),
     GET_MENU_MEMBER_SUCCESS(200, "M016", "상단 메뉴 프로필 조회 완료"),
+    SEND_RESET_PASSWORD_EMAIL_SUCCESS(200, "M017", "비밀번호 재설정 메일 전송 완료"),
+    RESET_PASSWORD_SUCCESS(200, "M018", "비밀번호 재설정 완료"),
+    LOGIN_WITH_CODE_SUCCESS(200, "M019", "비밀번호 재설정 코드로 로그인 성공"),
+    EXPIRE_RESET_PASSWORD_CODE_SUCCESS(200, "M020", "비밀번호 재설정 코드 만료 성공"),
     
     // Alarm
     GET_ALARMS_SUCCESS(200, "A001", "알림 조회 완료"),

--- a/src/main/java/cloneproject/Instagram/entity/redis/EmailCode.java
+++ b/src/main/java/cloneproject/Instagram/entity/redis/EmailCode.java
@@ -3,8 +3,6 @@ package cloneproject.Instagram.entity.redis;
 import java.io.Serializable;
 import java.util.concurrent.TimeUnit;
 
-
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.TimeToLive;

--- a/src/main/java/cloneproject/Instagram/entity/redis/ResetPasswordCode.java
+++ b/src/main/java/cloneproject/Instagram/entity/redis/ResetPasswordCode.java
@@ -1,0 +1,32 @@
+package cloneproject.Instagram.entity.redis;
+
+import java.io.Serializable;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+import org.springframework.data.redis.core.index.Indexed;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@RedisHash("ResetPasswordCode")
+public class ResetPasswordCode implements Serializable{
+    
+    @Id
+    @Indexed // Redis 에선 Indexed 어노테이션이 있어야 find 가능
+    private String username;
+
+    private String code;
+
+    @TimeToLive(unit = TimeUnit.SECONDS)
+    private Long timeout = 1800L; // 30분
+
+    @Builder
+    public ResetPasswordCode(String username, String code) {
+        this.username = username;
+        this.code = code;
+    }
+}

--- a/src/main/java/cloneproject/Instagram/exception/CantResetPasswordException.java
+++ b/src/main/java/cloneproject/Instagram/exception/CantResetPasswordException.java
@@ -1,0 +1,9 @@
+package cloneproject.Instagram.exception;
+
+import cloneproject.Instagram.dto.error.ErrorCode;
+
+public class CantResetPasswordException extends BusinessException{
+    public CantResetPasswordException(){
+        super(ErrorCode.CANT_RESET_PASSWORD);
+    }
+}

--- a/src/main/java/cloneproject/Instagram/repository/ResetPasswordCodeRedisRepository.java
+++ b/src/main/java/cloneproject/Instagram/repository/ResetPasswordCodeRedisRepository.java
@@ -1,0 +1,13 @@
+package cloneproject.Instagram.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.repository.CrudRepository;
+
+import cloneproject.Instagram.entity.redis.ResetPasswordCode;
+
+public interface ResetPasswordCodeRedisRepository extends CrudRepository<ResetPasswordCode, String>{
+    
+    public Optional<ResetPasswordCode> findByUsername(String username);
+
+}

--- a/src/main/java/cloneproject/Instagram/util/JwtUtil.java
+++ b/src/main/java/cloneproject/Instagram/util/JwtUtil.java
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -105,6 +106,11 @@ public class JwtUtil {
         UserDetails principal = new User(claims.getSubject(), "", authorities);
 
         return new UsernamePasswordAuthenticationToken(principal, "", authorities);
+    }
+
+    public Authentication getAuthenticationWithMember(String id){
+        Authentication authentication = new UsernamePasswordAuthenticationToken(id, null,AuthorityUtils.createAuthorityList("ROLE_USER"));
+        return authentication;
     }
 
     public boolean validateAccessJwt(String token){


### PR DESCRIPTION
## 비밀번호 재설정
- 현재는 단순히 인증코드만 이메일로 전송하는데 프론트 개발 완료 후 링크로 변경할 예정
- 실제 인스타그램은 만료 기간이 매우 길게(1~2일 정도로) 설정되어 있는데 30분으로 제한시킴\
- `비밀번호 재설정` API 호출 성공시엔 자동으로 로그인되어 JWT 토큰이 반환됨
- 인스타그램과 똑같이 두 종류의 상황 구현
### 바로 로그인 하기 링크를 누른 경우
-  `코드를 통한 로그인` API를 호출하여 JWT 토큰을 받음
- 이후 아래의 비밀번호 재설정 화면을 띄움

![image](https://user-images.githubusercontent.com/58378676/156338909-e4ae21c2-a144-430e-af02-6f3a21ab9f6a.png)

- 비밀번호 재설정을 하는 경우 비밀번호 재설정 API를 호출하면 됨
- `비밀번호 재설정` API를 호출하는 경우 자동으로 코드가 만료됨
- 건너띄기를 하는 경우 인증코드를 만료시키기 위해 `비밀번호 재설정 코드 만료시키기` API를 호출 해주어야함

### 비밀번호 재설정 링크를 누른 경우
- 바로 비밀번호 재설정 API를 호출하면 됨
- `비밀번호 재설정` API를 호출하는 경우 자동으로 코드가 만료됨
- 이때 실제 인스타그램은 아래와 같은 형태인데 아마 옛날의 코드를 그대로 방치해 놓은 듯함
-> 프론트분들과 상의해 임의로 만드는 것이 괜찮아보임 
![image](https://user-images.githubusercontent.com/58378676/156340246-c11ed1cf-c26f-486f-85bb-f538cb133314.png)

## 기존 API 수정
- `swagger docs` 상에 정상적으로 표시되지 않던 parameter 수정
- 회원가입 이메일 인증 관련 로직 일부 수정
  - `MemberAuthService`에서 점검하고 있었는데 `EmailCodeService`에서 점검하도록 옮김
- `JwtUtil`에 `Member` 엔티티를 `Authentication`으로 변환해주는 메서드 추가

resolves: #117 