### PR TITLE
동일 트랜잭션에서 DiscriminatorValue을 가져오지 못하는 문제 해결

### DIFF
--- a/src/main/java/cloneproject/Instagram/entity/chat/Message.java
+++ b/src/main/java/cloneproject/Instagram/entity/chat/Message.java
@@ -45,4 +45,9 @@ public class Message {
         this.member = member;
         this.room = room;
     }
+
+    @Transient
+    public void setDtype() {
+        this.dtype = getClass().getAnnotation(DiscriminatorValue.class).value();
+    }
 }

--- a/src/main/java/cloneproject/Instagram/service/ChatService.java
+++ b/src/main/java/cloneproject/Instagram/service/ChatService.java
@@ -148,6 +148,7 @@ public class ChatService {
             throw new JoinRoomNotFoundException();
 
         final MessageText message = messageTextRepository.save(new MessageText(request.getContent(), sender, room));
+        message.setDtype();
         updateRoom(request.getSenderId(), room, roomMembers, message);
 
         final MessageResponse response = new MessageResponse(MessageAction.MESSAGE_GET, new MessageDTO(message));
@@ -190,6 +191,7 @@ public class ChatService {
 
         final Image image = uploader.uploadImage(multipartFile, "chat");
         final MessageImage message = messageImageRepository.save(new MessageImage(image, sender, room));
+        message.setDtype();
         updateRoom(senderId, room, roomMembers, message);
 
         final MessageResponse response = new MessageResponse(MessageAction.MESSAGE_GET, new MessageDTO(message));

--- a/src/main/java/cloneproject/Instagram/service/PostService.java
+++ b/src/main/java/cloneproject/Instagram/service/PostService.java
@@ -213,6 +213,7 @@ public class PostService {
             }
 
             final MessagePost message = messagePostRepository.save(new MessagePost(post, inviter, room));
+            message.setDtype();
             roomUnreadMemberRepository.save(new RoomUnreadMember(room, message, taggedMember));
 
             final List<Member> privateRoomMembers = List.of(inviter, taggedMember);
@@ -502,6 +503,7 @@ public class PostService {
             }
 
             final MessagePost message = messagePostRepository.save(new MessagePost(post, inviter, room));
+            message.setDtype();
             roomUnreadMemberRepository.save(new RoomUnreadMember(room, message, member));
 
             final List<Member> privateRoomMembers = List.of(inviter, member);


### PR DESCRIPTION
## 변경 사항
- @Transient 메소드 추가
- 동일 트랜잭션에서 Message를 저장 후, setDtype() 호출
## 참고
- [How to get the DiscriminatorValue at run time](https://stackoverflow.com/questions/3005383/how-to-get-the-discriminatorvalue-at-run-time)
## 해결 이슈
- Resolve: #124