### PR TITLE
채팅 API content-type 오류 및 이미지 전송 API http 통신으로 변경

### DIFF
--- a/src/main/java/cloneproject/Instagram/controller/ChatController.java
+++ b/src/main/java/cloneproject/Instagram/controller/ChatController.java
@@ -1,5 +1,6 @@
 package cloneproject.Instagram.controller;
 
+import cloneproject.Instagram.dto.StatusResponse;
 import cloneproject.Instagram.dto.chat.*;
 import cloneproject.Instagram.dto.result.ResultResponse;
 import cloneproject.Instagram.service.ChatService;
@@ -9,6 +10,7 @@ import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.validation.annotation.Validated;
@@ -80,32 +82,32 @@ public class ChatController {
     }
 
     @MessageMapping("/messages/like")
-    public void likeMessage(
-            @NotNull(message = "좋아요할 메시지 PK는 필수입니다.") @RequestParam Long messageId,
-            @NotNull(message = "회원 PK는 필수입니다.") @RequestParam Long memberId) {
-        chatService.likeMessage(messageId, memberId);
+    public void likeMessage(@RequestBody MessageSimpleRequest request) {
+        chatService.likeMessage(request.getMessageId(), request.getMemberId());
     }
 
     @MessageMapping("/messages/unlike")
-    public void unlikeMessage(
-            @NotNull(message = "좋아요 취소할 메시지 PK는 필수입니다.") @RequestParam Long messageId,
-            @NotNull(message = "회원 PK는 필수입니다.") @RequestParam Long memberId) {
-        chatService.unlikeMessage(messageId, memberId);
+    public void unlikeMessage(@RequestBody MessageSimpleRequest request) {
+        chatService.unlikeMessage(request.getMessageId(), request.getMemberId());
     }
 
     @MessageMapping("/messages/delete")
-    public void deleteMessage(
-            @NotNull(message = "삭제할 메시지 PK는 필수입니다.") @RequestParam Long messageId,
-            @NotNull(message = "회원 PK는 필수입니다.") @RequestParam Long memberId) {
-        chatService.deleteMessage(messageId, memberId);
+    public void deleteMessage(@RequestBody MessageSimpleRequest request) {
+        chatService.deleteMessage(request.getMessageId(), request.getMemberId());
     }
 
-    @MessageMapping("/messages/images")
-    public void sendImageMessage(
+    @ApiOperation(value = "이미지 전송")
+    @ApiImplicitParams({
+            @ApiImplicitParam(value = "채팅방 PK", required = true, example = "1"),
+            @ApiImplicitParam(value = "이미지", required = true)
+    })
+    @PostMapping(value = "/messages/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ResultResponse> sendImageMessage(
             @NotNull(message = "채팅방 PK는 필수입니다.") @RequestParam Long roomId,
-            @NotNull(message = "메시지를 전송하는 회원 PK는 필수입니다.") @RequestParam Long senderId,
             @RequestParam MultipartFile image) {
-        chatService.sendImage(roomId, senderId, image);
+        final StatusResponse response = chatService.sendImage(roomId, image);
+
+        return ResponseEntity.ok(ResultResponse.of(SEND_IMAGE_SUCCESS, response));
     }
 
     @MessageMapping("/messages")

--- a/src/main/java/cloneproject/Instagram/dto/chat/MessageSimpleRequest.java
+++ b/src/main/java/cloneproject/Instagram/dto/chat/MessageSimpleRequest.java
@@ -1,0 +1,19 @@
+package cloneproject.Instagram.dto.chat;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MessageSimpleRequest {
+
+    @NotNull(message = "메시지 PK는 필수입니다.")
+    private Long messageId;
+
+    @NotNull(message = "회원 PK는 필수입니다.")
+    private Long memberId;
+}

--- a/src/main/java/cloneproject/Instagram/dto/result/ResultCode.java
+++ b/src/main/java/cloneproject/Instagram/dto/result/ResultCode.java
@@ -79,6 +79,7 @@ public enum ResultCode {
     DELETE_JOIN_ROOM_SUCCESS(200, "C003", "참여 중인 채팅방 삭제 성공"),
     GET_JOIN_ROOMS_SUCCESS(200, "C004", "채팅방 목록 조회 성공"),
     GET_CHAT_MESSAGES_SUCCESS(200, "C005", "채팅 메시지 목록 조회 성공"),
+    SEND_IMAGE_SUCCESS(200, "C006", "이미지 전송 성공"),
     
     // Hashtag
     GET_HASHTAG_POSTS_SUCCESS(200, "H001", "해시태그 게시물 목록 페이징 조회 성공"),


### PR DESCRIPTION
## 변경 사항
### WebSocket 요청 데이터 형식 모두 json 방식으로 변경
- WebSocket Message Payload에는 `Text` or `Binary` 데이터를 포함할 수 있음
- Http와 달리 헤더가 없어서, 따로 content-type을 지정할 수 없으며, text에 json 형식으로 받아서 컨버팅해야 함.
- 따라서 기존 `@RequestParam` -> `@RequestBody`로 변환 및 DTO로 분리
### 이미지 전송 API http 통신으로 변경
- 서버에서 이미지를 받는 방법은 두 가지가 존재함
    1. WebSocket 통신으로 base64로 인코딩해서 Binary 데이터로 받아서 처리하는 방법
    2. http 통신으로 변경해서 이미지를 받아서 처리하는 방법이 존재함.
- 첫 번째 방법은 인코딩 특성 상, 데이터 크기가 30% 증가하고, 별도로 인코딩 및 디코딩 로직이 추가되며, 서버에서도 관련 필터를 추가해야 함
- 두 번째 방법은 WebSocket 대신 Http 통신을 통해 간단히 처리 가능
    - 인스타 웹 어플리케이션도 http 통신으로 이미지를 전송하고, 메시지는 WebSocket으로 받음
- 따라서 두 번째 방법으로 선택함 -> 추후에 문제 생기면 첫 번째 방법으로 변경
## 해결 이슈
- Resolve: #128