### PR TITLE
메시지 삭제 API 로직 오류 해결

### DIFF
--- a/src/main/java/cloneproject/Instagram/repository/chat/JoinRoomRepository.java
+++ b/src/main/java/cloneproject/Instagram/repository/chat/JoinRoomRepository.java
@@ -13,13 +13,14 @@ import java.util.Optional;
 public interface JoinRoomRepository extends JpaRepository<JoinRoom, Long>, JoinRoomRepositoryQuerydsl, JoinRomRepositoryJdbc {
 
     @Query(value = "select j from JoinRoom j join fetch j.member where j.room.id = :id")
-    List<JoinRoom> findAllByRoomId(@Param("id") Long id);
+    List<JoinRoom> findAllWithMemberByRoomId(@Param("id") Long id);
 
     Optional<JoinRoom> findByMemberAndRoom(Member member, Room room);
 
     List<JoinRoom> findByRoomAndMemberIn(Room room, List<Member> members);
 
-    List<JoinRoom> findAllByRoom(Room room);
-
     void deleteByMemberAndRoom(Member member, Room room);
+
+    @Query(value = "select j from JoinRoom j join fetch j.message where j.room.id = :id")
+    List<JoinRoom> findAllWithMessageByRoomId(@Param("id") Long id);
 }

--- a/src/main/java/cloneproject/Instagram/repository/chat/MessageRepository.java
+++ b/src/main/java/cloneproject/Instagram/repository/chat/MessageRepository.java
@@ -8,6 +8,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface MessageRepository extends JpaRepository<Message, Long>, MessageRepositoryQuerydsl {
@@ -16,4 +18,8 @@ public interface MessageRepository extends JpaRepository<Message, Long>, Message
     Optional<Message> findWithRoomById(@Param("id") Long id);
 
     Page<Message> findAllByRoom(Room room, Pageable pageable);
+
+    Long countByCreatedDateBetweenAndRoom(LocalDateTime start, LocalDateTime end, Room room);
+
+    List<Message> findTop2ByCreatedDateBetweenAndRoomOrderByIdDesc(LocalDateTime start, LocalDateTime end, Room room);
 }


### PR DESCRIPTION
## 변경 사항
- 원인 분석: #132 참고
### 메시지 삭제 API 로직 오류 해결
- 채팅방에 참가한 사람마다 `[해당 채팅방에 참여한 날짜, 채팅방 최신 메시지 날짜]`를 비교
- 채팅방에 참여한 날짜 이전의 메시지를 삭제하는 경우, 해당 참가자에게는 아무런 작업이 필요가 없음
- 그 외에는 아래의 조건에 따라 로직 수행
    - 삭제하려는 메시지가 해당 채팅방의 최신 메시지인 경우 아래 로직 수행
        - 해당 참가자가 채팅방에 참여한 이후 발생한 메시지의 총 개수가 1개인 경우
            - 해당 채팅방 삭제(`delete JoinRoom`)
        - 해당 참가자가 채팅방에 참여한 이후 발생한 메시지의 총 개수가 2개 이상인 경우
            - 최신 메시지의 바로 전 메시지로 JoinRoom을 업데이트(`update JoinRoom`)

## 해결 이슈
- Resolve: #132