### PR TITLE
member 도메인 리팩토링

### DIFF
--- a/src/main/java/cloneproject/Instagram/domain/feed/dto/MemberPostDTO.java
+++ b/src/main/java/cloneproject/Instagram/domain/feed/dto/MemberPostDTO.java
@@ -14,7 +14,7 @@ import lombok.Setter;
 public class MemberPostDTO {
 
 	private Long postId;
-	private String postImageUrl;
+	private PostImageDTO postImageDTO;
 	private boolean hasManyPosts;
 	private int postCommentsCount;
 	private int postLikesCount;
@@ -28,7 +28,4 @@ public class MemberPostDTO {
 		this.postLikesCount = postLikesCount;
 	}
 
-	public void setImageUrl(String imageUrl) {
-		this.postImageUrl = imageUrl;
-	}
 }

--- a/src/main/java/cloneproject/Instagram/domain/feed/repository/PostRepository.java
+++ b/src/main/java/cloneproject/Instagram/domain/feed/repository/PostRepository.java
@@ -7,10 +7,13 @@ import org.springframework.data.repository.query.Param;
 import cloneproject.Instagram.domain.feed.entity.Post;
 import cloneproject.Instagram.domain.feed.repository.querydsl.PostRepositoryQuerydsl;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryQuerydsl {
 
 	@Query("select p from Post p join fetch p.member where p.id = :postId")
 	Optional<Post> findWithMemberById(@Param("postId") Long postId);
+
+	List<Post> findTop3ByMemberIdOrderByIdDesc(Long memberId);
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/controller/BlockController.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/controller/BlockController.java
@@ -1,8 +1,7 @@
 package cloneproject.Instagram.domain.member.controller;
 
-import javax.validation.constraints.NotBlank;
+import static cloneproject.Instagram.global.result.ResultCode.*;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -11,7 +10,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import cloneproject.Instagram.domain.member.service.BlockService;
-import cloneproject.Instagram.global.result.ResultCode;
 import cloneproject.Instagram.global.result.ResultResponse;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
@@ -21,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 @Api(tags = "차단 API")
 @RestController
 @RequiredArgsConstructor
+@Validated
 public class BlockController {
 
 	private final BlockService blockService;
@@ -28,23 +27,19 @@ public class BlockController {
 	@ApiOperation(value = "차단")
 	@PostMapping("/{blockMemberUsername}/block")
 	@ApiImplicitParam(name = "blockMemberUsername", value = "차단할 계정의 username", required = true, example = "dlwlrma")
-	public ResponseEntity<ResultResponse> block(
-			@PathVariable("blockMemberUsername") @Validated @NotBlank(message = "username이 필요합니다") String blockMemberUsername) {
-		boolean success = blockService.block(blockMemberUsername);
+	public ResponseEntity<ResultResponse> block(@PathVariable("blockMemberUsername") String blockMemberUsername) {
+		final boolean success = blockService.block(blockMemberUsername);
 
-		ResultResponse result = ResultResponse.of(ResultCode.BLOCK_SUCCESS, success);
-		return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
+		return ResponseEntity.ok(ResultResponse.of(BLOCK_SUCCESS, success));
 	}
 
 	@ApiOperation(value = "차단해제")
 	@DeleteMapping("/{blockMemberUsername}/block")
 	@ApiImplicitParam(name = "blockMemberUsername", value = "차단해제할 계정의 username", required = true, example = "dlwlrma")
-	public ResponseEntity<ResultResponse> unblock(
-			@PathVariable("blockMemberUsername") @Validated @NotBlank(message = "username이 필요합니다") String blockMemberUsername) {
-		boolean success = blockService.unblock(blockMemberUsername);
+	public ResponseEntity<ResultResponse> unblock(@PathVariable("blockMemberUsername") String blockMemberUsername) {
+		final boolean success = blockService.unblock(blockMemberUsername);
 
-		ResultResponse result = ResultResponse.of(ResultCode.UNBLOCK_SUCCESS, success);
-		return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
+		return ResponseEntity.ok(ResultResponse.of(UNBLOCK_SUCCESS, success));
 	}
 
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/controller/BlockController.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/controller/BlockController.java
@@ -22,29 +22,29 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 public class BlockController {
-    
-    private final BlockService blockService;
 
-    @ApiOperation(value = "차단")
-    @PostMapping("/{blockMemberUsername}/block")
-    @ApiImplicitParam(name = "blockMemberUsername", value = "차단할 계정의 username", required = true, example = "dlwlrma")
-    public ResponseEntity<ResultResponse> block(@PathVariable("blockMemberUsername") @Validated
-                                                 @NotBlank(message = "username이 필요합니다") String blockMemberUsername){
-        boolean success = blockService.block(blockMemberUsername);
-        
-        ResultResponse result = ResultResponse.of(ResultCode.BLOCK_SUCCESS, success);
-        return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
-    }
+	private final BlockService blockService;
 
-    @ApiOperation(value = "차단해제")
-    @DeleteMapping("/{blockMemberUsername}/block")
-    @ApiImplicitParam(name = "blockMemberUsername", value = "차단해제할 계정의 username", required = true, example = "dlwlrma")
-    public ResponseEntity<ResultResponse> unblock(@PathVariable("blockMemberUsername") @Validated
-                                                @NotBlank(message = "username이 필요합니다") String blockMemberUsername){
-        boolean success = blockService.unblock(blockMemberUsername);
-        
-        ResultResponse result = ResultResponse.of(ResultCode.UNBLOCK_SUCCESS, success);
-        return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
-    }
+	@ApiOperation(value = "차단")
+	@PostMapping("/{blockMemberUsername}/block")
+	@ApiImplicitParam(name = "blockMemberUsername", value = "차단할 계정의 username", required = true, example = "dlwlrma")
+	public ResponseEntity<ResultResponse> block(
+			@PathVariable("blockMemberUsername") @Validated @NotBlank(message = "username이 필요합니다") String blockMemberUsername) {
+		boolean success = blockService.block(blockMemberUsername);
+
+		ResultResponse result = ResultResponse.of(ResultCode.BLOCK_SUCCESS, success);
+		return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
+	}
+
+	@ApiOperation(value = "차단해제")
+	@DeleteMapping("/{blockMemberUsername}/block")
+	@ApiImplicitParam(name = "blockMemberUsername", value = "차단해제할 계정의 username", required = true, example = "dlwlrma")
+	public ResponseEntity<ResultResponse> unblock(
+			@PathVariable("blockMemberUsername") @Validated @NotBlank(message = "username이 필요합니다") String blockMemberUsername) {
+		boolean success = blockService.unblock(blockMemberUsername);
+
+		ResultResponse result = ResultResponse.of(ResultCode.UNBLOCK_SUCCESS, success);
+		return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
+	}
 
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/controller/MemberAuthController.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/controller/MemberAuthController.java
@@ -27,7 +27,7 @@ import cloneproject.Instagram.domain.member.dto.JwtDto;
 import cloneproject.Instagram.domain.member.dto.JwtResponse;
 import cloneproject.Instagram.domain.member.dto.LoginRequest;
 import cloneproject.Instagram.domain.member.dto.LoginWithCodeRequest;
-import cloneproject.Instagram.domain.member.dto.LoginedDevicesDTO;
+import cloneproject.Instagram.domain.member.dto.LoginDevicesDTO;
 import cloneproject.Instagram.domain.member.dto.RegisterRequest;
 import cloneproject.Instagram.domain.member.dto.ResetPasswordRequest;
 import cloneproject.Instagram.domain.member.dto.SendConfirmationEmailRequest;
@@ -259,7 +259,7 @@ public class MemberAuthController {
 	@ApiOperation(value = "로그인한 기기 조회")
 	@GetMapping(value = "/accounts/login/device")
 	public ResponseEntity<ResultResponse> getLoginDevices() {
-		final List<LoginedDevicesDTO> loginDevicesDTOs = memberAuthService.getLoginDevices();
+		final List<LoginDevicesDTO> loginDevicesDTOs = memberAuthService.getLoginDevices();
 
 		return ResponseEntity.ok(ResultResponse.of(GET_LOGIN_DEVICES_SUCCESS, loginDevicesDTOs));
 	}

--- a/src/main/java/cloneproject/Instagram/domain/member/controller/MemberAuthController.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/controller/MemberAuthController.java
@@ -1,16 +1,18 @@
 package cloneproject.Instagram.domain.member.controller;
 
+import static cloneproject.Instagram.global.result.ResultCode.*;
+
 import java.util.List;
 import java.util.Optional;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.validation.Valid;
 import javax.validation.constraints.Pattern;
 
 import org.hibernate.validator.constraints.Length;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.CookieValue;
@@ -32,7 +34,6 @@ import cloneproject.Instagram.domain.member.dto.SendConfirmationEmailRequest;
 import cloneproject.Instagram.domain.member.dto.UpdatePasswordRequest;
 import cloneproject.Instagram.domain.member.exception.InvalidJwtException;
 import cloneproject.Instagram.domain.member.service.MemberAuthService;
-import cloneproject.Instagram.global.result.ResultCode;
 import cloneproject.Instagram.global.result.ResultResponse;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
@@ -61,119 +62,97 @@ public class MemberAuthController {
 	})
 	@GetMapping(value = "/accounts/check")
 	public ResponseEntity<ResultResponse> checkUsername(
-			@RequestParam
-			@Length(min = 4, max = 12, message = "사용자 이름은 4문자 이상 12문자 이하여야 합니다")
-			@Pattern(regexp = "^[0-9a-zA-Z]+$", message = "username엔 대소문자, 숫자만 사용할 수 있습니다.")
-			String username) {
-		boolean check = memberAuthService.checkUsername(username);
-		ResultResponse result;
+		@RequestParam
+		@Length(min = 4, max = 12, message = "사용자 이름은 4문자 이상 12문자 이하여야 합니다")
+		@Pattern(regexp = "^[0-9a-zA-Z]+$", message = "username엔 대소문자, 숫자만 사용할 수 있습니다.")
+		String username) {
+		final boolean check = memberAuthService.checkUsername(username);
 		if (check) {
-			result = ResultResponse.of(ResultCode.CHECK_USERNAME_GOOD, true);
+			return ResponseEntity.ok(ResultResponse.of(CHECK_USERNAME_GOOD, true));
 		} else {
-			result = ResultResponse.of(ResultCode.CHECK_USERNAME_BAD, false);
+			return ResponseEntity.ok(ResultResponse.of(CHECK_USERNAME_BAD, false));
 		}
-		return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
 	}
 
 	@ApiOperation(value = "회원가입")
 	@ApiImplicitParam(name = "Authorization", value = "불필요", required = false, example = " ")
 	@PostMapping(value = "/accounts")
-	public ResponseEntity<ResultResponse> register(@Validated @RequestBody RegisterRequest registerRequest) {
-		boolean isRegistered = memberAuthService.register(registerRequest);
-		ResultResponse result;
+	public ResponseEntity<ResultResponse> register(@Valid @RequestBody RegisterRequest registerRequest) {
+		final boolean isRegistered = memberAuthService.register(registerRequest);
 		if (isRegistered) {
-			result = ResultResponse.of(ResultCode.REGISTER_SUCCESS, true);
+			return ResponseEntity.ok(ResultResponse.of(REGISTER_SUCCESS, true));
 		} else {
-			result = ResultResponse.of(ResultCode.CONFIRM_EMAIL_FAIL, false);
+			return ResponseEntity.ok(ResultResponse.of(CONFIRM_EMAIL_FAIL, false));
 		}
-		return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
 	}
 
 	@ApiOperation(value = "인증코드 이메일 전송")
 	@ApiImplicitParam(name = "Authorization", value = "불필요", required = false, example = " ")
 	@PostMapping(value = "/accounts/email")
 	public ResponseEntity<ResultResponse> sendConfirmEmail(
-			@Validated @RequestBody SendConfirmationEmailRequest sendConfirmationEmailRequest) {
+		@Valid @RequestBody SendConfirmationEmailRequest sendConfirmationEmailRequest) {
 		memberAuthService.sendEmailConfirmation(sendConfirmationEmailRequest.getUsername(),
-				sendConfirmationEmailRequest.getEmail());
-		ResultResponse result = ResultResponse.of(ResultCode.SEND_CONFIRM_EMAIL_SUCCESS);
-		return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
+			sendConfirmationEmailRequest.getEmail());
+
+		return ResponseEntity.ok(ResultResponse.of(SEND_CONFIRM_EMAIL_SUCCESS));
 	}
 
 	@ApiOperation(value = "로그인")
 	@ApiImplicitParam(name = "Authorization", value = "불필요", required = false, example = " ")
 	@PostMapping(value = "/login")
-	public ResponseEntity<ResultResponse> login(@Validated @RequestBody LoginRequest loginRequest,
-			HttpServletRequest request, HttpServletResponse response) {
-		String device = request.getHeader("user-agent");
-		String ip = getClientIP(request);
+	public ResponseEntity<ResultResponse> login(@Valid @RequestBody LoginRequest loginRequest,
+		HttpServletRequest request, HttpServletResponse response) {
+		final String device = request.getHeader("user-agent");
+		final String ip = getClientIP(request);
 
-		JwtDto jwt = memberAuthService.login(loginRequest, device, ip);
+		final JwtDto jwt = memberAuthService.login(loginRequest, device, ip);
 
-		Cookie cookie = new Cookie("refreshToken", jwt.getRefreshToken());
-
-		cookie.setMaxAge(REFRESH_TOKEN_EXPIRES);
-
-		// cookie.setSecure(true); https 미지원
-		cookie.setHttpOnly(true);
-		cookie.setPath("/");
-		cookie.setDomain(COOKIE_DOMAIN);
+		final Cookie cookie = getRefreshTokenCookie(jwt.getRefreshToken());
 
 		response.addCookie(cookie);
 
-		JwtResponse jwtResponse = JwtResponse.builder()
-				.type(jwt.getType())
-				.accessToken(jwt.getAccessToken())
-				.build();
+		final JwtResponse jwtResponse = JwtResponse.builder()
+			.type(jwt.getType())
+			.accessToken(jwt.getAccessToken())
+			.build();
 
-		ResultResponse result = ResultResponse.of(ResultCode.LOGIN_SUCCESS, jwtResponse);
-		return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
+		return ResponseEntity.ok(ResultResponse.of(LOGIN_SUCCESS, jwtResponse));
 	}
 
 	@ApiOperation(value = "토큰 재발급")
 	@ApiImplicitParam(name = "Authorization", value = "불필요", required = false, example = " ")
 	@PostMapping(value = "/reissue")
 	public ResponseEntity<ResultResponse> reissue(
-			@CookieValue(value = "refreshToken", required = false) Cookie refreshCookie, HttpServletResponse response) {
+		@CookieValue(value = "refreshToken", required = false) Cookie refreshCookie, HttpServletResponse response) {
 		if (refreshCookie == null) {
 			throw new InvalidJwtException();
 		}
-		Optional<JwtDto> optionalJwt = memberAuthService.reisuue(refreshCookie.getValue());
-		ResultResponse result;
+		final Optional<JwtDto> optionalJwt = memberAuthService.reisuue(refreshCookie.getValue());
 		if (optionalJwt.isEmpty()) {
-			result = ResultResponse.of(ResultCode.LOGOUT_BY_ANOTHER_DEVICE);
+			return ResponseEntity.ok(ResultResponse.of(LOGOUT_BY_ANOTHER_DEVICE));
 		} else {
-			JwtDto jwt = optionalJwt.get();
-			Cookie cookie = new Cookie("refreshToken", jwt.getRefreshToken());
-
-			cookie.setMaxAge(REFRESH_TOKEN_EXPIRES);
-
-			// cookie.setSecure(true); https 미지원
-			cookie.setHttpOnly(true);
-			cookie.setPath("/");
-			cookie.setDomain(COOKIE_DOMAIN);
+			final JwtDto jwt = optionalJwt.get();
+			final Cookie cookie = getRefreshTokenCookie(jwt.getRefreshToken());
 
 			response.addCookie(cookie);
 
-			JwtResponse jwtResponse = JwtResponse.builder()
-					.type(jwt.getType())
-					.accessToken(jwt.getAccessToken())
-					.build();
+			final JwtResponse jwtResponse = JwtResponse.builder()
+				.type(jwt.getType())
+				.accessToken(jwt.getAccessToken())
+				.build();
 
-			result = ResultResponse.of(ResultCode.REISSUE_SUCCESS, jwtResponse);
+			return ResponseEntity.ok(ResultResponse.of(REISSUE_SUCCESS, jwtResponse));
 		}
-		return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
 	}
 
 	@ApiOperation(value = "비밀번호 변경")
 	@ApiImplicitParam(name = "Authorization", value = "불필요", required = false, example = " ")
 	@PutMapping(value = "/accounts/password")
 	public ResponseEntity<ResultResponse> updatePassword(
-			@Validated @RequestBody UpdatePasswordRequest updatePasswordRequest) {
+		@Valid @RequestBody UpdatePasswordRequest updatePasswordRequest) {
 		memberAuthService.updatePassword(updatePasswordRequest);
 
-		ResultResponse result = ResultResponse.of(ResultCode.UPDATE_PASSWORD_SUCCESS);
-		return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
+		return ResponseEntity.ok(ResultResponse.of(UPDATE_PASSWORD_SUCCESS));
 	}
 
 	@ApiOperation(value = "비밀번호변경 이메일 전송")
@@ -183,85 +162,68 @@ public class MemberAuthController {
 	})
 	@PostMapping(value = "/accounts/password/email")
 	public ResponseEntity<ResultResponse> sendResetPasswordCode(
-			@RequestParam @Length(min = 4, max = 12, message = "사용자 이름은 4문자 이상 12문자 이하여야 합니다") @Pattern(regexp = "^[0-9a-zA-Z]+$", message = "username엔 대소문자, 숫자만 사용할 수 있습니다.") String username) {
-		String email = memberAuthService.sendResetPasswordCode(username);
-		ResultResponse result = ResultResponse.of(ResultCode.SEND_RESET_PASSWORD_EMAIL_SUCCESS, email);
-		return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
+		@RequestParam @Length(min = 4, max = 12, message = "사용자 이름은 4문자 이상 12문자 이하여야 합니다")
+		@Pattern(regexp = "^[0-9a-zA-Z]+$", message = "username엔 대소문자, 숫자만 사용할 수 있습니다.") String username) {
+		final String email = memberAuthService.sendResetPasswordCode(username);
+
+		return ResponseEntity.ok(ResultResponse.of(SEND_RESET_PASSWORD_EMAIL_SUCCESS, email));
 	}
 
 	@ApiOperation(value = "코드를 통한 비밀번호 재설정")
 	@ApiImplicitParam(name = "Authorization", value = "불필요", required = false, example = " ")
 	@PutMapping(value = "/accounts/password/reset")
-	public ResponseEntity<ResultResponse> resetPassword(
-			@Validated @RequestBody ResetPasswordRequest resetPasswordRequest,
-			HttpServletRequest request,
-			HttpServletResponse response) {
-		String device = request.getHeader("user-agent");
-		String ip = getClientIP(request);
-		JwtDto jwt = memberAuthService.resetPassword(resetPasswordRequest, device, ip);
+	public ResponseEntity<ResultResponse> resetPassword(@Valid @RequestBody ResetPasswordRequest resetPasswordRequest,
+		HttpServletRequest request,
+		HttpServletResponse response) {
+		final String device = request.getHeader("user-agent");
+		final String ip = getClientIP(request);
+		final JwtDto jwt = memberAuthService.resetPassword(resetPasswordRequest, device, ip);
 
-		Cookie cookie = new Cookie("refreshToken", jwt.getRefreshToken());
-
-		cookie.setMaxAge(REFRESH_TOKEN_EXPIRES);
-
-		// cookie.setSecure(true); https 미지원
-		cookie.setHttpOnly(true);
-		cookie.setPath("/");
-		cookie.setDomain(COOKIE_DOMAIN);
+		final Cookie cookie = getRefreshTokenCookie(jwt.getRefreshToken());
 
 		response.addCookie(cookie);
 
-		JwtResponse jwtResponse = JwtResponse.builder()
-				.type(jwt.getType())
-				.accessToken(jwt.getAccessToken())
-				.build();
+		final JwtResponse jwtResponse = JwtResponse.builder()
+			.type(jwt.getType())
+			.accessToken(jwt.getAccessToken())
+			.build();
 
-		ResultResponse result = ResultResponse.of(ResultCode.RESET_PASSWORD_SUCCESS, jwtResponse);
-		return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
+		return ResponseEntity.ok(ResultResponse.of(RESET_PASSWORD_SUCCESS, jwtResponse));
 	}
 
 	@ApiOperation(value = "코드를 통한 로그인")
 	@ApiImplicitParam(name = "Authorization", value = "불필요", required = false, example = " ")
 	@PostMapping(value = "/accounts/login/recovery")
 	public ResponseEntity<ResultResponse> loginWithCode(
-			@Validated @RequestBody LoginWithCodeRequest loginWithCodeRequest,
-			HttpServletRequest request,
-			HttpServletResponse response) {
-		String device = request.getHeader("user-agent");
-		String ip = getClientIP(request);
+		@Valid @RequestBody LoginWithCodeRequest loginWithCodeRequest,
+		HttpServletRequest request,
+		HttpServletResponse response) {
+		final String device = request.getHeader("user-agent");
+		final String ip = getClientIP(request);
 
-		JwtDto jwt = memberAuthService.loginWithCode(loginWithCodeRequest, device, ip);
+		final JwtDto jwt = memberAuthService.loginWithCode(loginWithCodeRequest, device, ip);
 
-		Cookie cookie = new Cookie("refreshToken", jwt.getRefreshToken());
-
-		cookie.setMaxAge(REFRESH_TOKEN_EXPIRES);
-
-		// cookie.setSecure(true); https 미지원
-		cookie.setHttpOnly(true);
-		cookie.setPath("/");
-		cookie.setDomain(COOKIE_DOMAIN);
-
+		final Cookie cookie = getRefreshTokenCookie(jwt.getRefreshToken());
 		response.addCookie(cookie);
 
-		JwtResponse jwtResponse = JwtResponse.builder()
-				.type(jwt.getType())
-				.accessToken(jwt.getAccessToken())
-				.build();
+		final JwtResponse jwtResponse = JwtResponse.builder()
+			.type(jwt.getType())
+			.accessToken(jwt.getAccessToken())
+			.build();
 
-		ResultResponse result = ResultResponse.of(ResultCode.LOGIN_WITH_CODE_SUCCESS, jwtResponse);
-		return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
+		return ResponseEntity.ok(ResultResponse.of(LOGIN_WITH_CODE_SUCCESS, jwtResponse));
 	}
 
 	@ApiOperation(value = "로그아웃")
 	@PostMapping(value = "/logout")
 	public ResponseEntity<ResultResponse> logout(
-			@CookieValue(value = "refreshToken", required = false) Cookie refreshCookie,
-			HttpServletResponse response) {
+		@CookieValue(value = "refreshToken", required = false) Cookie refreshCookie,
+		HttpServletResponse response) {
 		if (refreshCookie != null) {
 			memberAuthService.logout(refreshCookie.getValue());
 		}
 
-		Cookie cookie = new Cookie("refreshToken", null);
+		final Cookie cookie = new Cookie("refreshToken", null);
 
 		cookie.setMaxAge(0);
 
@@ -272,8 +234,7 @@ public class MemberAuthController {
 
 		response.addCookie(cookie);
 
-		ResultResponse result = ResultResponse.of(ResultCode.LOGOUT_SUCCESS);
-		return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
+		return ResponseEntity.ok(ResultResponse.of(LOGOUT_SUCCESS));
 	}
 
 	@ApiOperation(value = "비밀번호 재설정 코드 검증")
@@ -284,32 +245,44 @@ public class MemberAuthController {
 	})
 	@GetMapping(value = "/accounts/password/reset")
 	public ResponseEntity<ResultResponse> checkResetPasswordCode(
-			@RequestParam @Length(min = 4, max = 12, message = "사용자 이름은 4문자 이상 12문자 이하여야 합니다") @Pattern(regexp = "^[0-9a-zA-Z]+$", message = "username엔 대소문자, 숫자만 사용할 수 있습니다.") String username,
-			@RequestParam @Length(min = 30, max = 30, message = "인증코드는 30글자 입니다") String code) {
-		boolean check = memberAuthService.checkResetPasswordCode(username, code);
-		ResultResponse result;
+		@RequestParam @Length(min = 4, max = 12, message = "사용자 이름은 4문자 이상 12문자 이하여야 합니다")
+		@Pattern(regexp = "^[0-9a-zA-Z]+$", message = "username엔 대소문자, 숫자만 사용할 수 있습니다.") String username,
+		@RequestParam @Length(min = 30, max = 30, message = "인증코드는 30글자 입니다") String code) {
+		final boolean check = memberAuthService.checkResetPasswordCode(username, code);
 		if (check) {
-			result = ResultResponse.of(ResultCode.CHECK_RESET_PASSWORD_CODE_GOOD, true);
+			return ResponseEntity.ok(ResultResponse.of(CHECK_RESET_PASSWORD_CODE_GOOD, true));
 		} else {
-			result = ResultResponse.of(ResultCode.CHECK_RESET_PASSWORD_CODE_BAD, false);
+			return ResponseEntity.ok(ResultResponse.of(CHECK_RESET_PASSWORD_CODE_BAD, false));
 		}
-		return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
 	}
 
 	@ApiOperation(value = "로그인한 기기 조회")
-	@GetMapping(value = "/accounts/logined")
-	public ResponseEntity<ResultResponse> getLoginedDevices() {
-		List<LoginedDevicesDTO> loginedDevicesDTOs = memberAuthService.getLoginedDevices();
-		ResultResponse result = ResultResponse.of(ResultCode.GET_LOGIN_DEVICES_SUCCESS, loginedDevicesDTOs);
-		return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
+	@GetMapping(value = "/accounts/login/device")
+	public ResponseEntity<ResultResponse> getLoginDevices() {
+		final List<LoginedDevicesDTO> loginDevicesDTOs = memberAuthService.getLoginedDevices();
+
+		return ResponseEntity.ok(ResultResponse.of(GET_LOGIN_DEVICES_SUCCESS, loginDevicesDTOs));
 	}
 
 	@ApiOperation(value = "기기 로그아웃 시키기")
 	@PostMapping(value = "/logout/device")
 	public ResponseEntity<ResultResponse> logoutDevice(@RequestParam String tokenId) {
 		memberAuthService.logoutDevice(tokenId);
-		ResultResponse result = ResultResponse.of(ResultCode.LOGOUT_DEVICE_SUCCESS);
-		return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
+
+		return ResponseEntity.ok(ResultResponse.of(LOGOUT_DEVICE_SUCCESS));
+	}
+
+	private Cookie getRefreshTokenCookie(String refreshTokenString) {
+		Cookie cookie = new Cookie("refreshToken", refreshTokenString);
+
+		cookie.setMaxAge(REFRESH_TOKEN_EXPIRES);
+
+		// cookie.setSecure(true); https 미지원
+		cookie.setHttpOnly(true);
+		cookie.setPath("/");
+		cookie.setDomain(COOKIE_DOMAIN);
+
+		return cookie;
 	}
 
 	private String getClientIP(HttpServletRequest request) {
@@ -326,4 +299,5 @@ public class MemberAuthController {
 			ip = request.getRemoteAddr();
 		return ip;
 	}
+
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/controller/MemberAuthController.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/controller/MemberAuthController.java
@@ -127,7 +127,7 @@ public class MemberAuthController {
 		if (refreshCookie == null) {
 			throw new InvalidJwtException();
 		}
-		final Optional<JwtDto> optionalJwt = memberAuthService.reisuue(refreshCookie.getValue());
+		final Optional<JwtDto> optionalJwt = memberAuthService.reissue(refreshCookie.getValue());
 		if (optionalJwt.isEmpty()) {
 			return ResponseEntity.ok(ResultResponse.of(LOGOUT_BY_ANOTHER_DEVICE));
 		} else {
@@ -259,7 +259,7 @@ public class MemberAuthController {
 	@ApiOperation(value = "로그인한 기기 조회")
 	@GetMapping(value = "/accounts/login/device")
 	public ResponseEntity<ResultResponse> getLoginDevices() {
-		final List<LoginedDevicesDTO> loginDevicesDTOs = memberAuthService.getLoginedDevices();
+		final List<LoginedDevicesDTO> loginDevicesDTOs = memberAuthService.getLoginDevices();
 
 		return ResponseEntity.ok(ResultResponse.of(GET_LOGIN_DEVICES_SUCCESS, loginDevicesDTOs));
 	}

--- a/src/main/java/cloneproject/Instagram/domain/member/controller/MemberController.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/controller/MemberController.java
@@ -1,7 +1,5 @@
 package cloneproject.Instagram.domain.member.controller;
 
-
-
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
@@ -38,77 +36,76 @@ import org.springframework.web.bind.annotation.RequestParam;
 @RestController
 @RequiredArgsConstructor
 public class MemberController {
-    
-    private final MemberService memberService;
 
-    @ApiOperation(value = "상단 메뉴 로그인한 유저 프로필 조회")
-    @GetMapping(value = "/menu/profile")
-    public ResponseEntity<ResultResponse> getMenuMemberProfile(){
-        MenuMemberDTO menuMemberProfile = memberService.getMenuMemberProfile();
+	private final MemberService memberService;
 
-        ResultResponse result = ResultResponse.of(ResultCode.GET_MENU_MEMBER_SUCCESS, menuMemberProfile);
-        return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
-    }
+	@ApiOperation(value = "상단 메뉴 로그인한 유저 프로필 조회")
+	@GetMapping(value = "/menu/profile")
+	public ResponseEntity<ResultResponse> getMenuMemberProfile() {
+		MenuMemberDTO menuMemberProfile = memberService.getMenuMemberProfile();
 
-    @ApiOperation(value = "유저 프로필 조회")
-    @ApiImplicitParams({
-        @ApiImplicitParam(name = "Authorization", value = "있어도 되고 없어도됨", required = false, example = "Bearer AAA.BBB.CCC"),
-        @ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma")
-    })
-    @GetMapping(value = "/accounts/{username}")
-    public ResponseEntity<ResultResponse> getUserProfile(@PathVariable("username") String username){
-        UserProfileResponse userProfileResponse = memberService.getUserProfile(username);
+		ResultResponse result = ResultResponse.of(ResultCode.GET_MENU_MEMBER_SUCCESS, menuMemberProfile);
+		return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
+	}
 
-        ResultResponse result = ResultResponse.of(ResultCode.GET_USERPROFILE_SUCCESS, userProfileResponse);
-        return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
-    }
+	@ApiOperation(value = "유저 프로필 조회")
+	@ApiImplicitParams({
+		@ApiImplicitParam(name = "Authorization", value = "있어도 되고 없어도됨", required = false, example = "Bearer AAA.BBB.CCC"),
+		@ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma")
+	})
+	@GetMapping(value = "/accounts/{username}")
+	public ResponseEntity<ResultResponse> getUserProfile(@PathVariable("username") String username) {
+		UserProfileResponse userProfileResponse = memberService.getUserProfile(username);
 
-    @ApiOperation(value = "미니 프로필 조회")
-    @ApiImplicitParams({
-        @ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma")
-    })
-    @GetMapping(value = "/accounts/{username}/mini")
-    public ResponseEntity<ResultResponse> getMiniProfile(@PathVariable("username") String username){
-        MiniProfileResponse miniProfileResponse = memberService.getMiniProfile(username);
+		ResultResponse result = ResultResponse.of(ResultCode.GET_USERPROFILE_SUCCESS, userProfileResponse);
+		return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
+	}
 
-        ResultResponse result = ResultResponse.of(ResultCode.GET_MINIPROFILE_SUCCESS, miniProfileResponse);
-        return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
-    }
+	@ApiOperation(value = "미니 프로필 조회")
+	@ApiImplicitParams({
+		@ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma")
+	})
+	@GetMapping(value = "/accounts/{username}/mini")
+	public ResponseEntity<ResultResponse> getMiniProfile(@PathVariable("username") String username) {
+		MiniProfileResponse miniProfileResponse = memberService.getMiniProfile(username);
 
-    @ApiOperation(value = "회원 프로필 사진 업로드")
-    @PostMapping(value = "/accounts/image")
-    public ResponseEntity<ResultResponse> uploadImage(@RequestParam MultipartFile uploadedImage) {
-        memberService.uploadMemberImage(uploadedImage);
+		ResultResponse result = ResultResponse.of(ResultCode.GET_MINIPROFILE_SUCCESS, miniProfileResponse);
+		return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
+	}
 
-        ResultResponse result = ResultResponse.of(ResultCode.UPLOAD_MEMBER_IMAGE_SUCCESS,null);
-        return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
-    }
+	@ApiOperation(value = "회원 프로필 사진 업로드")
+	@PostMapping(value = "/accounts/image")
+	public ResponseEntity<ResultResponse> uploadImage(@RequestParam MultipartFile uploadedImage) {
+		memberService.uploadMemberImage(uploadedImage);
 
-    @ApiOperation(value = "회원 프로필 사진 삭제")
-    @DeleteMapping(value = "/accounts/image")
-    public ResponseEntity<ResultResponse> deleteImage() {
-        memberService.deleteMemberImage();
+		ResultResponse result = ResultResponse.of(ResultCode.UPLOAD_MEMBER_IMAGE_SUCCESS, null);
+		return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
+	}
 
-        ResultResponse result = ResultResponse.of(ResultCode.DELETE_MEMBER_IMAGE_SUCCESS ,null);
-        return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
-    }
+	@ApiOperation(value = "회원 프로필 사진 삭제")
+	@DeleteMapping(value = "/accounts/image")
+	public ResponseEntity<ResultResponse> deleteImage() {
+		memberService.deleteMemberImage();
 
-    @ApiOperation(value = "회원 프로필 수정정보 조회")
-    @GetMapping(value = "/accounts/edit")
-    public ResponseEntity<ResultResponse> getMemberEdit() {
-        EditProfileResponse editProfileResponse = memberService.getEditProfile();
-        
-        ResultResponse result = ResultResponse.of(ResultCode.GET_EDIT_PROFILE_SUCCESS ,editProfileResponse);
-        return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
-    }
+		ResultResponse result = ResultResponse.of(ResultCode.DELETE_MEMBER_IMAGE_SUCCESS, null);
+		return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
+	}
 
-    @ApiOperation(value = "회원 프로필 수정")
-    @PutMapping(value = "/accounts/edit")
-    public ResponseEntity<ResultResponse> editProfile(@Validated @RequestBody EditProfileRequest editProfileRequest) {
-        memberService.editProfile(editProfileRequest);
-        
-        ResultResponse result = ResultResponse.of(ResultCode.EDIT_PROFILE_SUCCESS , null);
-        return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
-    }
+	@ApiOperation(value = "회원 프로필 수정정보 조회")
+	@GetMapping(value = "/accounts/edit")
+	public ResponseEntity<ResultResponse> getMemberEdit() {
+		EditProfileResponse editProfileResponse = memberService.getEditProfile();
 
+		ResultResponse result = ResultResponse.of(ResultCode.GET_EDIT_PROFILE_SUCCESS, editProfileResponse);
+		return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
+	}
+
+	@ApiOperation(value = "회원 프로필 수정")
+	@PutMapping(value = "/accounts/edit")
+	public ResponseEntity<ResultResponse> editProfile(@Validated @RequestBody EditProfileRequest editProfileRequest) {
+		memberService.editProfile(editProfileRequest);
+
+		ResultResponse result = ResultResponse.of(ResultCode.EDIT_PROFILE_SUCCESS, null);
+		return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
+	}
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/controller/MemberController.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/controller/MemberController.java
@@ -1,13 +1,17 @@
 package cloneproject.Instagram.domain.member.controller;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiImplicitParam;
-import io.swagger.annotations.ApiImplicitParams;
-import io.swagger.annotations.ApiOperation;
+import javax.validation.Valid;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -17,35 +21,32 @@ import cloneproject.Instagram.domain.member.dto.MenuMemberDTO;
 import cloneproject.Instagram.domain.member.dto.MiniProfileResponse;
 import cloneproject.Instagram.domain.member.dto.UserProfileResponse;
 import cloneproject.Instagram.domain.member.service.MemberService;
-import cloneproject.Instagram.global.result.ResultCode;
 import cloneproject.Instagram.global.result.ResultResponse;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
+import static cloneproject.Instagram.global.result.ResultCode.*;
 
 @Slf4j
 @Validated
 @Api(tags = "멤버 API")
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("accounts")
 public class MemberController {
 
 	private final MemberService memberService;
 
 	@ApiOperation(value = "상단 메뉴 로그인한 유저 프로필 조회")
-	@GetMapping(value = "/menu/profile")
+	@GetMapping(value = "/profile")
 	public ResponseEntity<ResultResponse> getMenuMemberProfile() {
-		MenuMemberDTO menuMemberProfile = memberService.getMenuMemberProfile();
+		final MenuMemberDTO menuMemberProfile = memberService.getMenuMemberProfile();
 
-		ResultResponse result = ResultResponse.of(ResultCode.GET_MENU_MEMBER_SUCCESS, menuMemberProfile);
-		return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
+		return ResponseEntity.ok(ResultResponse.of(GET_MENU_MEMBER_SUCCESS, menuMemberProfile));
 	}
 
 	@ApiOperation(value = "유저 프로필 조회")
@@ -53,59 +54,54 @@ public class MemberController {
 		@ApiImplicitParam(name = "Authorization", value = "있어도 되고 없어도됨", required = false, example = "Bearer AAA.BBB.CCC"),
 		@ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma")
 	})
-	@GetMapping(value = "/accounts/{username}")
+	@GetMapping(value = "/{username}")
 	public ResponseEntity<ResultResponse> getUserProfile(@PathVariable("username") String username) {
-		UserProfileResponse userProfileResponse = memberService.getUserProfile(username);
+		final UserProfileResponse userProfileResponse = memberService.getUserProfile(username);
 
-		ResultResponse result = ResultResponse.of(ResultCode.GET_USERPROFILE_SUCCESS, userProfileResponse);
-		return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
+		return ResponseEntity.ok(ResultResponse.of(GET_USERPROFILE_SUCCESS, userProfileResponse));
 	}
 
 	@ApiOperation(value = "미니 프로필 조회")
 	@ApiImplicitParams({
 		@ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma")
 	})
-	@GetMapping(value = "/accounts/{username}/mini")
+	@GetMapping(value = "/{username}/mini")
 	public ResponseEntity<ResultResponse> getMiniProfile(@PathVariable("username") String username) {
-		MiniProfileResponse miniProfileResponse = memberService.getMiniProfile(username);
+		final MiniProfileResponse miniProfileResponse = memberService.getMiniProfile(username);
 
-		ResultResponse result = ResultResponse.of(ResultCode.GET_MINIPROFILE_SUCCESS, miniProfileResponse);
-		return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
+		return ResponseEntity.ok(ResultResponse.of(GET_MINIPROFILE_SUCCESS, miniProfileResponse));
 	}
 
 	@ApiOperation(value = "회원 프로필 사진 업로드")
-	@PostMapping(value = "/accounts/image")
+	@PostMapping(value = "/image")
 	public ResponseEntity<ResultResponse> uploadImage(@RequestParam MultipartFile uploadedImage) {
 		memberService.uploadMemberImage(uploadedImage);
 
-		ResultResponse result = ResultResponse.of(ResultCode.UPLOAD_MEMBER_IMAGE_SUCCESS, null);
-		return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
+		return ResponseEntity.ok(ResultResponse.of(UPLOAD_MEMBER_IMAGE_SUCCESS));
 	}
 
 	@ApiOperation(value = "회원 프로필 사진 삭제")
-	@DeleteMapping(value = "/accounts/image")
+	@DeleteMapping(value = "/image")
 	public ResponseEntity<ResultResponse> deleteImage() {
 		memberService.deleteMemberImage();
 
-		ResultResponse result = ResultResponse.of(ResultCode.DELETE_MEMBER_IMAGE_SUCCESS, null);
-		return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
+		return ResponseEntity.ok(ResultResponse.of(DELETE_MEMBER_IMAGE_SUCCESS));
 	}
 
 	@ApiOperation(value = "회원 프로필 수정정보 조회")
-	@GetMapping(value = "/accounts/edit")
+	@GetMapping(value = "/edit")
 	public ResponseEntity<ResultResponse> getMemberEdit() {
-		EditProfileResponse editProfileResponse = memberService.getEditProfile();
+		final EditProfileResponse editProfileResponse = memberService.getEditProfile();
 
-		ResultResponse result = ResultResponse.of(ResultCode.GET_EDIT_PROFILE_SUCCESS, editProfileResponse);
-		return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
+		return ResponseEntity.ok(ResultResponse.of(GET_EDIT_PROFILE_SUCCESS, editProfileResponse));
 	}
 
 	@ApiOperation(value = "회원 프로필 수정")
-	@PutMapping(value = "/accounts/edit")
-	public ResponseEntity<ResultResponse> editProfile(@Validated @RequestBody EditProfileRequest editProfileRequest) {
+	@PutMapping(value = "/edit")
+	public ResponseEntity<ResultResponse> editProfile(@Valid @RequestBody EditProfileRequest editProfileRequest) {
 		memberService.editProfile(editProfileRequest);
 
-		ResultResponse result = ResultResponse.of(ResultCode.EDIT_PROFILE_SUCCESS, null);
-		return new ResponseEntity<>(result, HttpStatus.valueOf(result.getStatus()));
+		return ResponseEntity.ok(ResultResponse.of(EDIT_PROFILE_SUCCESS));
 	}
+
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/controller/MemberPostController.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/controller/MemberPostController.java
@@ -32,12 +32,12 @@ public class MemberPostController {
 
 	@ApiOperation(value = "멤버 게시물 15개 조회")
 	@ApiImplicitParams({
-			@ApiImplicitParam(name = "Authorization", value = "있어도 되고 없어도됨", required = false, example = "Bearer AAA.BBB.CCC"),
-			@ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma")
+		@ApiImplicitParam(name = "Authorization", value = "있어도 되고 없어도됨", example = "Bearer AAA.BBB.CCC"),
+		@ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma")
 	})
 	@GetMapping("/accounts/{username}/posts/recent")
 	public ResponseEntity<ResultResponse> getRecent10Posts(
-			@PathVariable("username") @Validated @NotBlank(message = "username은 필수입니다") String username) {
+		@PathVariable("username") @Validated @NotBlank(message = "username은 필수입니다") String username) {
 		final List<MemberPostDTO> postList = memberPostService.getRecent15PostDTOs(username);
 
 		return ResponseEntity.ok(ResultResponse.of(ResultCode.FIND_RECENT15_MEMBER_POSTS_SUCCESS, postList));
@@ -45,15 +45,15 @@ public class MemberPostController {
 
 	@ApiOperation(value = "멤버 게시물 페이징 조회(무한스크롤)")
 	@ApiImplicitParams({
-			@ApiImplicitParam(name = "Authorization", value = "있어도 되고 없어도됨", required = false, example = "Bearer AAA.BBB.CCC"),
-			@ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma"),
-			@ApiImplicitParam(name = "page", value = "페이지", required = true, example = "1")
+		@ApiImplicitParam(name = "Authorization", value = "있어도 되고 없어도됨", example = "Bearer AAA.BBB.CCC"),
+		@ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma"),
+		@ApiImplicitParam(name = "page", value = "페이지", required = true, example = "1")
 	})
 	@GetMapping("/accounts/{username}/posts")
 	public ResponseEntity<ResultResponse> getPostPage(
-			@PathVariable("username") @Validated @NotBlank(message = "username은 필수입니다") String username,
-			@Validated @NotNull(message = "조회할 게시물 page는 필수입니다.") @RequestParam int page) {
-		final Page<MemberPostDTO> postPage = memberPostService.getMemberPostDto(username, 3, page);
+		@PathVariable("username") @Validated @NotBlank(message = "username은 필수입니다") String username,
+		@Validated @NotNull(message = "조회할 게시물 page는 필수입니다.") @RequestParam int page) {
+		final Page<MemberPostDTO> postPage = memberPostService.getMemberPostDTOs(username, 3, page);
 
 		return ResponseEntity.ok(ResultResponse.of(ResultCode.FIND_MEMBER_POSTS_SUCCESS, postPage));
 	}
@@ -71,8 +71,8 @@ public class MemberPostController {
 	@GetMapping("/accounts/{username}/posts/saved")
 	@ApiImplicitParam(name = "page", value = "페이지", required = true, example = "1")
 	public ResponseEntity<ResultResponse> getSavedPostPage(
-			@Validated @NotNull(message = "조회할 게시물 page는 필수입니다.") @RequestParam int page) {
-		final Page<MemberPostDTO> postPage = memberPostService.getMemberSavedPostDto(3, page);
+		@Validated @NotNull(message = "조회할 게시물 page는 필수입니다.") @RequestParam int page) {
+		final Page<MemberPostDTO> postPage = memberPostService.getMemberSavedPostDTOs(3, page);
 
 		return ResponseEntity.ok(ResultResponse.of(ResultCode.FIND_MEMBER_SAVED_POSTS_SUCCESS, postPage));
 	}
@@ -80,12 +80,12 @@ public class MemberPostController {
 	// ============== 태그 ================
 	@ApiOperation(value = "멤버 태그된 게시물 15개 조회")
 	@ApiImplicitParams({
-			@ApiImplicitParam(name = "Authorization", value = "있어도 되고 없어도됨", required = false, example = "Bearer AAA.BBB.CCC"),
-			@ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma")
+		@ApiImplicitParam(name = "Authorization", value = "있어도 되고 없어도됨", example = "Bearer AAA.BBB.CCC"),
+		@ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma")
 	})
 	@GetMapping("/accounts/{username}/posts/tagged/recent")
 	public ResponseEntity<ResultResponse> getRecent10TaggedPosts(
-			@PathVariable("username") @Validated @NotBlank(message = "username은 필수입니다") String username) {
+		@PathVariable("username") @Validated @NotBlank(message = "username은 필수입니다") String username) {
 		final List<MemberPostDTO> postList = memberPostService.getRecent15TaggedPostDTOs(username);
 
 		return ResponseEntity.ok(ResultResponse.of(ResultCode.FIND_RECENT15_MEMBER_TAGGED_POSTS_SUCCESS, postList));
@@ -93,15 +93,15 @@ public class MemberPostController {
 
 	@ApiOperation(value = "멤버 태그된 게시물 페이징 조회(무한스크롤)")
 	@ApiImplicitParams({
-			@ApiImplicitParam(name = "Authorization", value = "있어도 되고 없어도됨", required = false, example = "Bearer AAA.BBB.CCC"),
-			@ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma"),
-			@ApiImplicitParam(name = "page", value = "페이지", required = true, example = "1")
+		@ApiImplicitParam(name = "Authorization", value = "있어도 되고 없어도됨", example = "Bearer AAA.BBB.CCC"),
+		@ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma"),
+		@ApiImplicitParam(name = "page", value = "페이지", required = true, example = "1")
 	})
 	@GetMapping("/accounts/{username}/posts/tagged")
 	public ResponseEntity<ResultResponse> getTaggedPostPage(
-			@PathVariable("username") @Validated @NotBlank(message = "username은 필수입니다") String username,
-			@Validated @NotNull(message = "조회할 게시물 page는 필수입니다.") @RequestParam int page) {
-		final Page<MemberPostDTO> postPage = memberPostService.getMemberTaggedPostDto(username, 3, page);
+		@PathVariable("username") @Validated @NotBlank(message = "username은 필수입니다") String username,
+		@Validated @NotNull(message = "조회할 게시물 page는 필수입니다.") @RequestParam int page) {
+		final Page<MemberPostDTO> postPage = memberPostService.getMemberTaggedPostDTOs(username, 3, page);
 
 		return ResponseEntity.ok(ResultResponse.of(ResultCode.FIND_MEMBER_TAGGED_POSTS_SUCCESS, postPage));
 	}

--- a/src/main/java/cloneproject/Instagram/domain/member/controller/MemberPostController.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/controller/MemberPostController.java
@@ -2,6 +2,8 @@ package cloneproject.Instagram.domain.member.controller;
 
 import java.util.List;
 
+import javax.validation.constraints.Min;
+
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -48,7 +50,7 @@ public class MemberPostController {
 	})
 	@GetMapping("/accounts/{username}/posts")
 	public ResponseEntity<ResultResponse> getPostPage(@PathVariable("username") String username,
-		@RequestParam int page) {
+		@Min(1) @RequestParam int page) {
 		final Page<MemberPostDTO> postPage = memberPostService.getMemberPostDTOs(username, 3, page);
 
 		return ResponseEntity.ok(ResultResponse.of(ResultCode.FIND_MEMBER_POSTS_SUCCESS, postPage));
@@ -66,7 +68,7 @@ public class MemberPostController {
 	@ApiOperation(value = "멤버 저장한 게시물 페이징 조회(무한스크롤)")
 	@GetMapping("/accounts/posts/saved")
 	@ApiImplicitParam(name = "page", value = "페이지", required = true, example = "1")
-	public ResponseEntity<ResultResponse> getSavedPostPage(@RequestParam int page) {
+	public ResponseEntity<ResultResponse> getSavedPostPage(@Min(1) @RequestParam int page) {
 		final Page<MemberPostDTO> postPage = memberPostService.getMemberSavedPostDTOs(3, page);
 
 		return ResponseEntity.ok(ResultResponse.of(ResultCode.FIND_MEMBER_SAVED_POSTS_SUCCESS, postPage));
@@ -93,7 +95,7 @@ public class MemberPostController {
 	})
 	@GetMapping("/accounts/{username}/posts/tagged")
 	public ResponseEntity<ResultResponse> getTaggedPostPage(@PathVariable("username") String username,
-		@RequestParam int page) {
+		@Min(1) @RequestParam int page) {
 		final Page<MemberPostDTO> postPage = memberPostService.getMemberTaggedPostDTOs(username, 3, page);
 
 		return ResponseEntity.ok(ResultResponse.of(ResultCode.FIND_MEMBER_TAGGED_POSTS_SUCCESS, postPage));

--- a/src/main/java/cloneproject/Instagram/domain/member/controller/MemberPostController.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/controller/MemberPostController.java
@@ -28,81 +28,81 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class MemberPostController {
 
-    private final MemberPostService memberPostService;
+	private final MemberPostService memberPostService;
 
-    @ApiOperation(value = "멤버 게시물 15개 조회")
-    @ApiImplicitParams({
-        @ApiImplicitParam(name = "Authorization", value = "있어도 되고 없어도됨", required = false, example = "Bearer AAA.BBB.CCC"),
-        @ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma")
-    })
-    @GetMapping("/accounts/{username}/posts/recent")
-    public ResponseEntity<ResultResponse> getRecent10Posts(
-            @PathVariable("username") @Validated @NotBlank(message="username은 필수입니다") String username) {
-        final List<MemberPostDTO> postList = memberPostService.getRecent15PostDTOs(username);
+	@ApiOperation(value = "멤버 게시물 15개 조회")
+	@ApiImplicitParams({
+			@ApiImplicitParam(name = "Authorization", value = "있어도 되고 없어도됨", required = false, example = "Bearer AAA.BBB.CCC"),
+			@ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma")
+	})
+	@GetMapping("/accounts/{username}/posts/recent")
+	public ResponseEntity<ResultResponse> getRecent10Posts(
+			@PathVariable("username") @Validated @NotBlank(message = "username은 필수입니다") String username) {
+		final List<MemberPostDTO> postList = memberPostService.getRecent15PostDTOs(username);
 
-        return ResponseEntity.ok(ResultResponse.of(ResultCode.FIND_RECENT15_MEMBER_POSTS_SUCCESS, postList));
-    }
+		return ResponseEntity.ok(ResultResponse.of(ResultCode.FIND_RECENT15_MEMBER_POSTS_SUCCESS, postList));
+	}
 
-    @ApiOperation(value = "멤버 게시물 페이징 조회(무한스크롤)")
-    @ApiImplicitParams({
-        @ApiImplicitParam(name = "Authorization", value = "있어도 되고 없어도됨", required = false, example = "Bearer AAA.BBB.CCC"),
-        @ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma"),
-        @ApiImplicitParam(name = "page", value = "페이지", required = true, example = "1")
-    })
-    @GetMapping("/accounts/{username}/posts")
-    public ResponseEntity<ResultResponse> getPostPage(
-            @PathVariable("username") @Validated @NotBlank(message="username은 필수입니다") String username,
-            @Validated @NotNull(message = "조회할 게시물 page는 필수입니다.") @RequestParam int page) {
-        final Page<MemberPostDTO> postPage = memberPostService.getMemberPostDto(username,3, page);
+	@ApiOperation(value = "멤버 게시물 페이징 조회(무한스크롤)")
+	@ApiImplicitParams({
+			@ApiImplicitParam(name = "Authorization", value = "있어도 되고 없어도됨", required = false, example = "Bearer AAA.BBB.CCC"),
+			@ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma"),
+			@ApiImplicitParam(name = "page", value = "페이지", required = true, example = "1")
+	})
+	@GetMapping("/accounts/{username}/posts")
+	public ResponseEntity<ResultResponse> getPostPage(
+			@PathVariable("username") @Validated @NotBlank(message = "username은 필수입니다") String username,
+			@Validated @NotNull(message = "조회할 게시물 page는 필수입니다.") @RequestParam int page) {
+		final Page<MemberPostDTO> postPage = memberPostService.getMemberPostDto(username, 3, page);
 
-        return ResponseEntity.ok(ResultResponse.of(ResultCode.FIND_MEMBER_POSTS_SUCCESS, postPage));
-    }
+		return ResponseEntity.ok(ResultResponse.of(ResultCode.FIND_MEMBER_POSTS_SUCCESS, postPage));
+	}
 
-    // ============== 저장 ================
-    @ApiOperation(value = "멤버 저장한 게시물 15개 조회")
-    @GetMapping("/accounts/{username}/posts/saved/recent")
-    public ResponseEntity<ResultResponse> getRecent1SavedPosts() {
-        final List<MemberPostDTO> postList = memberPostService.getRecent15SavedPostDTOs();
+	// ============== 저장 ================
+	@ApiOperation(value = "멤버 저장한 게시물 15개 조회")
+	@GetMapping("/accounts/{username}/posts/saved/recent")
+	public ResponseEntity<ResultResponse> getRecent1SavedPosts() {
+		final List<MemberPostDTO> postList = memberPostService.getRecent15SavedPostDTOs();
 
-        return ResponseEntity.ok(ResultResponse.of(ResultCode.FIND_RECENT15_MEMBER_SAVED_POSTS_SUCCESS, postList));
-    }
+		return ResponseEntity.ok(ResultResponse.of(ResultCode.FIND_RECENT15_MEMBER_SAVED_POSTS_SUCCESS, postList));
+	}
 
-    @ApiOperation(value = "멤버 저장한 게시물 페이징 조회(무한스크롤)")
-    @GetMapping("/accounts/{username}/posts/saved")
-    @ApiImplicitParam(name = "page", value = "페이지", required = true, example = "1")
-    public ResponseEntity<ResultResponse> getSavedPostPage(
-            @Validated @NotNull(message = "조회할 게시물 page는 필수입니다.") @RequestParam int page) {
-        final Page<MemberPostDTO> postPage = memberPostService.getMemberSavedPostDto(3, page);
+	@ApiOperation(value = "멤버 저장한 게시물 페이징 조회(무한스크롤)")
+	@GetMapping("/accounts/{username}/posts/saved")
+	@ApiImplicitParam(name = "page", value = "페이지", required = true, example = "1")
+	public ResponseEntity<ResultResponse> getSavedPostPage(
+			@Validated @NotNull(message = "조회할 게시물 page는 필수입니다.") @RequestParam int page) {
+		final Page<MemberPostDTO> postPage = memberPostService.getMemberSavedPostDto(3, page);
 
-        return ResponseEntity.ok(ResultResponse.of(ResultCode.FIND_MEMBER_SAVED_POSTS_SUCCESS, postPage));
-    }
+		return ResponseEntity.ok(ResultResponse.of(ResultCode.FIND_MEMBER_SAVED_POSTS_SUCCESS, postPage));
+	}
 
-    // ============== 태그 ================
-    @ApiOperation(value = "멤버 태그된 게시물 15개 조회")
-    @ApiImplicitParams({
-        @ApiImplicitParam(name = "Authorization", value = "있어도 되고 없어도됨", required = false, example = "Bearer AAA.BBB.CCC"),
-        @ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma")
-    })
-    @GetMapping("/accounts/{username}/posts/tagged/recent")
-    public ResponseEntity<ResultResponse> getRecent10TaggedPosts(
-            @PathVariable("username") @Validated @NotBlank(message="username은 필수입니다") String username) {
-        final List<MemberPostDTO> postList = memberPostService.getRecent15TaggedPostDTOs(username);
+	// ============== 태그 ================
+	@ApiOperation(value = "멤버 태그된 게시물 15개 조회")
+	@ApiImplicitParams({
+			@ApiImplicitParam(name = "Authorization", value = "있어도 되고 없어도됨", required = false, example = "Bearer AAA.BBB.CCC"),
+			@ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma")
+	})
+	@GetMapping("/accounts/{username}/posts/tagged/recent")
+	public ResponseEntity<ResultResponse> getRecent10TaggedPosts(
+			@PathVariable("username") @Validated @NotBlank(message = "username은 필수입니다") String username) {
+		final List<MemberPostDTO> postList = memberPostService.getRecent15TaggedPostDTOs(username);
 
-        return ResponseEntity.ok(ResultResponse.of(ResultCode.FIND_RECENT15_MEMBER_TAGGED_POSTS_SUCCESS, postList));
-    }
+		return ResponseEntity.ok(ResultResponse.of(ResultCode.FIND_RECENT15_MEMBER_TAGGED_POSTS_SUCCESS, postList));
+	}
 
-    @ApiOperation(value = "멤버 태그된 게시물 페이징 조회(무한스크롤)")
-    @ApiImplicitParams({
-        @ApiImplicitParam(name = "Authorization", value = "있어도 되고 없어도됨", required = false, example = "Bearer AAA.BBB.CCC"),
-        @ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma"),
-        @ApiImplicitParam(name = "page", value = "페이지", required = true, example = "1")
-    })
-    @GetMapping("/accounts/{username}/posts/tagged")
-    public ResponseEntity<ResultResponse> getTaggedPostPage(
-            @PathVariable("username") @Validated @NotBlank(message="username은 필수입니다") String username,
-            @Validated @NotNull(message = "조회할 게시물 page는 필수입니다.") @RequestParam int page) {
-        final Page<MemberPostDTO> postPage = memberPostService.getMemberTaggedPostDto(username,3, page);
+	@ApiOperation(value = "멤버 태그된 게시물 페이징 조회(무한스크롤)")
+	@ApiImplicitParams({
+			@ApiImplicitParam(name = "Authorization", value = "있어도 되고 없어도됨", required = false, example = "Bearer AAA.BBB.CCC"),
+			@ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma"),
+			@ApiImplicitParam(name = "page", value = "페이지", required = true, example = "1")
+	})
+	@GetMapping("/accounts/{username}/posts/tagged")
+	public ResponseEntity<ResultResponse> getTaggedPostPage(
+			@PathVariable("username") @Validated @NotBlank(message = "username은 필수입니다") String username,
+			@Validated @NotNull(message = "조회할 게시물 page는 필수입니다.") @RequestParam int page) {
+		final Page<MemberPostDTO> postPage = memberPostService.getMemberTaggedPostDto(username, 3, page);
 
-        return ResponseEntity.ok(ResultResponse.of(ResultCode.FIND_MEMBER_TAGGED_POSTS_SUCCESS, postPage));
-    }
+		return ResponseEntity.ok(ResultResponse.of(ResultCode.FIND_MEMBER_TAGGED_POSTS_SUCCESS, postPage));
+	}
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/controller/MemberPostController.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/controller/MemberPostController.java
@@ -2,9 +2,6 @@ package cloneproject.Instagram.domain.member.controller;
 
 import java.util.List;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
-
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -26,6 +23,7 @@ import lombok.RequiredArgsConstructor;
 @Api(tags = "멤버 게시물 API")
 @RestController
 @RequiredArgsConstructor
+@Validated
 public class MemberPostController {
 
 	private final MemberPostService memberPostService;
@@ -36,8 +34,7 @@ public class MemberPostController {
 		@ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma")
 	})
 	@GetMapping("/accounts/{username}/posts/recent")
-	public ResponseEntity<ResultResponse> getRecent10Posts(
-		@PathVariable("username") @Validated @NotBlank(message = "username은 필수입니다") String username) {
+	public ResponseEntity<ResultResponse> getRecent10Posts(@PathVariable("username") String username) {
 		final List<MemberPostDTO> postList = memberPostService.getRecent15PostDTOs(username);
 
 		return ResponseEntity.ok(ResultResponse.of(ResultCode.FIND_RECENT15_MEMBER_POSTS_SUCCESS, postList));
@@ -50,9 +47,8 @@ public class MemberPostController {
 		@ApiImplicitParam(name = "page", value = "페이지", required = true, example = "1")
 	})
 	@GetMapping("/accounts/{username}/posts")
-	public ResponseEntity<ResultResponse> getPostPage(
-		@PathVariable("username") @Validated @NotBlank(message = "username은 필수입니다") String username,
-		@Validated @NotNull(message = "조회할 게시물 page는 필수입니다.") @RequestParam int page) {
+	public ResponseEntity<ResultResponse> getPostPage(@PathVariable("username") String username,
+		@RequestParam int page) {
 		final Page<MemberPostDTO> postPage = memberPostService.getMemberPostDTOs(username, 3, page);
 
 		return ResponseEntity.ok(ResultResponse.of(ResultCode.FIND_MEMBER_POSTS_SUCCESS, postPage));
@@ -60,7 +56,7 @@ public class MemberPostController {
 
 	// ============== 저장 ================
 	@ApiOperation(value = "멤버 저장한 게시물 15개 조회")
-	@GetMapping("/accounts/{username}/posts/saved/recent")
+	@GetMapping("/accounts/posts/saved/recent")
 	public ResponseEntity<ResultResponse> getRecent1SavedPosts() {
 		final List<MemberPostDTO> postList = memberPostService.getRecent15SavedPostDTOs();
 
@@ -68,10 +64,9 @@ public class MemberPostController {
 	}
 
 	@ApiOperation(value = "멤버 저장한 게시물 페이징 조회(무한스크롤)")
-	@GetMapping("/accounts/{username}/posts/saved")
+	@GetMapping("/accounts/posts/saved")
 	@ApiImplicitParam(name = "page", value = "페이지", required = true, example = "1")
-	public ResponseEntity<ResultResponse> getSavedPostPage(
-		@Validated @NotNull(message = "조회할 게시물 page는 필수입니다.") @RequestParam int page) {
+	public ResponseEntity<ResultResponse> getSavedPostPage(@RequestParam int page) {
 		final Page<MemberPostDTO> postPage = memberPostService.getMemberSavedPostDTOs(3, page);
 
 		return ResponseEntity.ok(ResultResponse.of(ResultCode.FIND_MEMBER_SAVED_POSTS_SUCCESS, postPage));
@@ -84,8 +79,7 @@ public class MemberPostController {
 		@ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma")
 	})
 	@GetMapping("/accounts/{username}/posts/tagged/recent")
-	public ResponseEntity<ResultResponse> getRecent10TaggedPosts(
-		@PathVariable("username") @Validated @NotBlank(message = "username은 필수입니다") String username) {
+	public ResponseEntity<ResultResponse> getRecent10TaggedPosts(@PathVariable("username") String username) {
 		final List<MemberPostDTO> postList = memberPostService.getRecent15TaggedPostDTOs(username);
 
 		return ResponseEntity.ok(ResultResponse.of(ResultCode.FIND_RECENT15_MEMBER_TAGGED_POSTS_SUCCESS, postList));
@@ -98,11 +92,11 @@ public class MemberPostController {
 		@ApiImplicitParam(name = "page", value = "페이지", required = true, example = "1")
 	})
 	@GetMapping("/accounts/{username}/posts/tagged")
-	public ResponseEntity<ResultResponse> getTaggedPostPage(
-		@PathVariable("username") @Validated @NotBlank(message = "username은 필수입니다") String username,
-		@Validated @NotNull(message = "조회할 게시물 page는 필수입니다.") @RequestParam int page) {
+	public ResponseEntity<ResultResponse> getTaggedPostPage(@PathVariable("username") String username,
+		@RequestParam int page) {
 		final Page<MemberPostDTO> postPage = memberPostService.getMemberTaggedPostDTOs(username, 3, page);
 
 		return ResponseEntity.ok(ResultResponse.of(ResultCode.FIND_MEMBER_TAGGED_POSTS_SUCCESS, postPage));
 	}
+
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/dto/EditProfileRequest.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/dto/EditProfileRequest.java
@@ -18,35 +18,36 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 public class EditProfileRequest {
-    @ApiModelProperty(value = "유저네임", example = "dlwlrma", required = true)
-    @NotBlank(message = "username을 입력해주세요")
-    @Length(min = 4, max = 12, message = "ID는 4문자 이상 12문자 이하여야 합니다")
-    String memberUsername;
 
-    @ApiModelProperty(value = "이름", example = "이지금", required = true)
-    @NotBlank(message = "이름을 입력해주세요")
-    @Length(min = 2, max = 12, message = "이름은 2문자 이상 12문자 이하여야 합니다")
-    String memberName;
+	@ApiModelProperty(value = "유저네임", example = "dlwlrma", required = true)
+	@NotBlank(message = "username을 입력해주세요")
+	@Length(min = 4, max = 12, message = "ID는 4문자 이상 12문자 이하여야 합니다")
+	String memberUsername;
 
-    @ApiModelProperty(value = "웹사이트", example = "http://localhost:8080", required = false)
-    @URL(message = "URL 형식이 맞지 않습니다")
-    String memberWebsite;
+	@ApiModelProperty(value = "이름", example = "이지금", required = true)
+	@NotBlank(message = "이름을 입력해주세요")
+	@Length(min = 2, max = 12, message = "이름은 2문자 이상 12문자 이하여야 합니다")
+	String memberName;
 
-    @ApiModelProperty(value = "소개", example = "안녕하세요", required = false)
-    String memberIntroduce;
+	@ApiModelProperty(value = "웹사이트", example = "http://localhost:8080", required = false)
+	@URL(message = "URL 형식이 맞지 않습니다")
+	String memberWebsite;
 
-    @ApiModelProperty(value = "이메일", example = "aaa@gmail.com", required = true)
-    @NotBlank(message = "이메일은 필수입니다")
-    @Email(message = "이메일의 형식이 맞지 않습니다")
-    String memberEmail;
+	@ApiModelProperty(value = "소개", example = "안녕하세요", required = false)
+	String memberIntroduce;
 
-    @ApiModelProperty(value = "전화번호", example = "010-0000-0000", required = false)
-    @Pattern(regexp = "^\\d{3}-\\d{3,4}-\\d{4}$", message = "휴대폰 번호 양식이 맞지 않습니다")
-    String memberPhone;
+	@ApiModelProperty(value = "이메일", example = "aaa@gmail.com", required = true)
+	@NotBlank(message = "이메일은 필수입니다")
+	@Email(message = "이메일의 형식이 맞지 않습니다")
+	String memberEmail;
 
-    @ApiModelProperty(value = "성별", example = "FEMALE", required = true)
-    @Pattern(regexp = "^MALE|FEMALE|PRIVATE$", message = "올바르지 않는 성별입니다")
-    @NotBlank(message = "성별을 입력해주세요")
-    String memberGender;
-    
+	@ApiModelProperty(value = "전화번호", example = "010-0000-0000", required = false)
+	@Pattern(regexp = "^\\d{3}-\\d{3,4}-\\d{4}$", message = "휴대폰 번호 양식이 맞지 않습니다")
+	String memberPhone;
+
+	@ApiModelProperty(value = "성별", example = "FEMALE", required = true)
+	@Pattern(regexp = "^MALE|FEMALE|PRIVATE$", message = "올바르지 않는 성별입니다")
+	@NotBlank(message = "성별을 입력해주세요")
+	String memberGender;
+
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/dto/EditProfileRequest.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/dto/EditProfileRequest.java
@@ -22,32 +22,32 @@ public class EditProfileRequest {
 	@ApiModelProperty(value = "유저네임", example = "dlwlrma", required = true)
 	@NotBlank(message = "username을 입력해주세요")
 	@Length(min = 4, max = 12, message = "ID는 4문자 이상 12문자 이하여야 합니다")
-	String memberUsername;
+	private String memberUsername;
 
 	@ApiModelProperty(value = "이름", example = "이지금", required = true)
 	@NotBlank(message = "이름을 입력해주세요")
 	@Length(min = 2, max = 12, message = "이름은 2문자 이상 12문자 이하여야 합니다")
-	String memberName;
+	private String memberName;
 
 	@ApiModelProperty(value = "웹사이트", example = "http://localhost:8080", required = false)
 	@URL(message = "URL 형식이 맞지 않습니다")
-	String memberWebsite;
+	private String memberWebsite;
 
 	@ApiModelProperty(value = "소개", example = "안녕하세요", required = false)
-	String memberIntroduce;
+	private String memberIntroduce;
 
 	@ApiModelProperty(value = "이메일", example = "aaa@gmail.com", required = true)
 	@NotBlank(message = "이메일은 필수입니다")
 	@Email(message = "이메일의 형식이 맞지 않습니다")
-	String memberEmail;
+	private String memberEmail;
 
 	@ApiModelProperty(value = "전화번호", example = "010-0000-0000", required = false)
 	@Pattern(regexp = "^\\d{3}-\\d{3,4}-\\d{4}$", message = "휴대폰 번호 양식이 맞지 않습니다")
-	String memberPhone;
+	private String memberPhone;
 
 	@ApiModelProperty(value = "성별", example = "FEMALE", required = true)
 	@Pattern(regexp = "^MALE|FEMALE|PRIVATE$", message = "올바르지 않는 성별입니다")
 	@NotBlank(message = "성별을 입력해주세요")
-	String memberGender;
+	private String memberGender;
 
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/dto/EditProfileResponse.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/dto/EditProfileResponse.java
@@ -13,27 +13,27 @@ import lombok.Getter;
 public class EditProfileResponse {
 
 	@ApiModelProperty(value = "유저네임", example = "dlwlrma")
-	String memberUsername;
+	private String memberUsername;
 
 	@ApiModelProperty(value = "프로필사진 URL", example = "https://drive.google.com/file/d/1Gu0DcGCJNs4Vo0bz2U9U6v01d_VwKijs/view?usp=sharing")
-	String memberImageUrl;
+	private String memberImageUrl;
 
 	@ApiModelProperty(value = "이름", example = "이지금")
-	String memberName;
+	private String memberName;
 
 	@ApiModelProperty(value = "웹사이트", example = "http://localhost:8080")
-	String memberWebsite;
+	private String memberWebsite;
 
 	@ApiModelProperty(value = "소개", example = "안녕하세요")
-	String memberIntroduce;
+	private String memberIntroduce;
 
 	@ApiModelProperty(value = "이메일", example = "aaa@gmail.com")
-	String memberEmail;
+	private String memberEmail;
 
 	@ApiModelProperty(value = "전화번호", example = "010-0000-0000")
-	String memberPhone;
+	private String memberPhone;
 
 	@ApiModelProperty(value = "성별", example = "여성")
-	String memberGender;
+	private String memberGender;
 
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/dto/EditProfileResponse.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/dto/EditProfileResponse.java
@@ -12,28 +12,28 @@ import lombok.Getter;
 @AllArgsConstructor
 public class EditProfileResponse {
 
-    @ApiModelProperty(value = "유저네임", example = "dlwlrma")
-    String memberUsername;
+	@ApiModelProperty(value = "유저네임", example = "dlwlrma")
+	String memberUsername;
 
-    @ApiModelProperty(value = "프로필사진 URL", example = "https://drive.google.com/file/d/1Gu0DcGCJNs4Vo0bz2U9U6v01d_VwKijs/view?usp=sharing")
-    String memberImageUrl;
+	@ApiModelProperty(value = "프로필사진 URL", example = "https://drive.google.com/file/d/1Gu0DcGCJNs4Vo0bz2U9U6v01d_VwKijs/view?usp=sharing")
+	String memberImageUrl;
 
-    @ApiModelProperty(value = "이름", example = "이지금")
-    String memberName;
+	@ApiModelProperty(value = "이름", example = "이지금")
+	String memberName;
 
-    @ApiModelProperty(value = "웹사이트", example = "http://localhost:8080")
-    String memberWebsite;
+	@ApiModelProperty(value = "웹사이트", example = "http://localhost:8080")
+	String memberWebsite;
 
-    @ApiModelProperty(value = "소개", example = "안녕하세요")
-    String memberIntroduce;
+	@ApiModelProperty(value = "소개", example = "안녕하세요")
+	String memberIntroduce;
 
-    @ApiModelProperty(value = "이메일", example = "aaa@gmail.com")
-    String memberEmail;
+	@ApiModelProperty(value = "이메일", example = "aaa@gmail.com")
+	String memberEmail;
 
-    @ApiModelProperty(value = "전화번호", example = "010-0000-0000")
-    String memberPhone;
+	@ApiModelProperty(value = "전화번호", example = "010-0000-0000")
+	String memberPhone;
 
-    @ApiModelProperty(value = "성별", example = "여성")
-    String memberGender;
-    
+	@ApiModelProperty(value = "성별", example = "여성")
+	String memberGender;
+
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/dto/JwtDto.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/dto/JwtDto.java
@@ -11,10 +11,10 @@ import lombok.NoArgsConstructor;
 @Builder
 public class JwtDto {
 
-    private String type;
+	private String type;
 
-    private String accessToken;
+	private String accessToken;
 
-    private String refreshToken;
+	private String refreshToken;
 
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/dto/JwtResponse.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/dto/JwtResponse.java
@@ -14,10 +14,10 @@ import lombok.NoArgsConstructor;
 @Builder
 public class JwtResponse {
 
-    @ApiModelProperty(value = "토큰 타입", example = "Bearer")
-    private String type;
+	@ApiModelProperty(value = "토큰 타입", example = "Bearer")
+	private String type;
 
-    @ApiModelProperty(value = "Access 토큰", example = "AAA.BBB.CCC")
-    private String accessToken;
+	@ApiModelProperty(value = "Access 토큰", example = "AAA.BBB.CCC")
+	private String accessToken;
 
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/dto/LikeMembersDTO.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/dto/LikeMembersDTO.java
@@ -10,16 +10,17 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class LikeMembersDTO {
 
-    private MemberDTO member;
-    private boolean isFollowing;
-    private boolean isFollower;
-    private boolean hasStory;
+	private MemberDTO member;
+	private boolean isFollowing;
+	private boolean isFollower;
+	private boolean hasStory;
 
-    @QueryProjection
-    public LikeMembersDTO(Member member, boolean isFollowing, boolean isFollower) {
-        this.member = new MemberDTO(member);
-        this.isFollowing = isFollowing;
-        this.isFollower = isFollower;
-        this.hasStory = false;
-    }
+	@QueryProjection
+	public LikeMembersDTO(Member member, boolean isFollowing, boolean isFollower) {
+		this.member = new MemberDTO(member);
+		this.isFollowing = isFollowing;
+		this.isFollower = isFollower;
+		this.hasStory = false;
+	}
+
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/dto/LoginDevicesDTO.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/dto/LoginDevicesDTO.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Builder
 @Getter
-public class LoginedDevicesDTO {
+public class LoginDevicesDTO {
 
 	private String tokenId;
 	private GeoIP location;

--- a/src/main/java/cloneproject/Instagram/domain/member/dto/LoginRequest.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/dto/LoginRequest.java
@@ -15,15 +15,15 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 public class LoginRequest {
-    
-    @ApiModelProperty(value = "유저네임", example = "dlwlrma", required = true)
-    @NotBlank(message = "ID를 입력해주세요")
-    @Length(min = 4, max = 12, message = "ID는 4문자 이상 12문자 이하여야 합니다")
-    private String username;
 
-    @ApiModelProperty(value = "비밀번호", example = "a12341234", required = true)
-    @NotBlank(message = "비밀번호를 입력해주세요")
-    @Length(max = 20, message = "비밀번호는 20문자 이하여야 합니다")
-    private String password;
+	@ApiModelProperty(value = "유저네임", example = "dlwlrma", required = true)
+	@NotBlank(message = "ID를 입력해주세요")
+	@Length(min = 4, max = 12, message = "ID는 4문자 이상 12문자 이하여야 합니다")
+	private String username;
+
+	@ApiModelProperty(value = "비밀번호", example = "a12341234", required = true)
+	@NotBlank(message = "비밀번호를 입력해주세요")
+	@Length(max = 20, message = "비밀번호는 20문자 이하여야 합니다")
+	private String password;
 
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/dto/LoginWithCodeRequest.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/dto/LoginWithCodeRequest.java
@@ -17,15 +17,15 @@ import lombok.Setter;
 @AllArgsConstructor
 public class LoginWithCodeRequest {
 
-    @ApiModelProperty(value = "유저네임", example = "dlwlrma", required = true)
-    @NotBlank(message = "username을 입력해주세요")
-    @Length(min = 4, max = 12, message = "사용자 이름은 4문자 이상 12문자 이하여야 합니다")
-    @Pattern(regexp = "^[0-9a-zA-Z]+$", message = "username엔 대소문자, 숫자만 사용할 수 있습니다.")
-    private String username;
-    
-    @ApiModelProperty(value = "인증코드", example = "ABC123AAAAAAAA1231313123..", required = true)
-    @NotBlank(message = "인증코드를 입력해주세요")
-    @Length(max = 30, min = 30, message = "인증코드는 30자리 입니다.")
-    private String code;
-    
+	@ApiModelProperty(value = "유저네임", example = "dlwlrma", required = true)
+	@NotBlank(message = "username을 입력해주세요")
+	@Length(min = 4, max = 12, message = "사용자 이름은 4문자 이상 12문자 이하여야 합니다")
+	@Pattern(regexp = "^[0-9a-zA-Z]+$", message = "username엔 대소문자, 숫자만 사용할 수 있습니다.")
+	private String username;
+
+	@ApiModelProperty(value = "인증코드", example = "ABC123AAAAAAAA1231313123..", required = true)
+	@NotBlank(message = "인증코드를 입력해주세요")
+	@Length(max = 30, min = 30, message = "인증코드는 30자리 입니다.")
+	private String code;
+
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/dto/LoginedDevicesDTO.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/dto/LoginedDevicesDTO.java
@@ -1,6 +1,5 @@
 package cloneproject.Instagram.domain.member.dto;
 
-
 import cloneproject.Instagram.infra.geoip.dto.GeoIP;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -12,9 +11,9 @@ import lombok.NoArgsConstructor;
 @Builder
 @Getter
 public class LoginedDevicesDTO {
-    
-    private String tokenId;
-    private GeoIP location;
-    private String device;
+
+	private String tokenId;
+	private GeoIP location;
+	private String device;
 
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/dto/MemberDTO.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/dto/MemberDTO.java
@@ -22,4 +22,5 @@ public class MemberDTO {
 		this.image = member.getImage();
 		this.hasStory = false;
 	}
+
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/dto/MemberDTO.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/dto/MemberDTO.java
@@ -9,17 +9,17 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class MemberDTO {
 
-    private Long id;
-    private String username;
-    private String name;
-    private Image image;
-    private boolean hasStory;
+	private Long id;
+	private String username;
+	private String name;
+	private Image image;
+	private boolean hasStory;
 
-    public MemberDTO(Member member) {
-        this.id = member.getId();
-        this.username = member.getUsername();
-        this.name = member.getName();
-        this.image = member.getImage();
-        this.hasStory = false;
-    }
+	public MemberDTO(Member member) {
+		this.id = member.getId();
+		this.username = member.getUsername();
+		this.name = member.getName();
+		this.image = member.getImage();
+		this.hasStory = false;
+	}
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/dto/MenuMemberDTO.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/dto/MenuMemberDTO.java
@@ -25,4 +25,5 @@ public class MenuMemberDTO {
 
 	@ApiModelProperty(value = "이름", example = "이지금")
 	private String memberName;
+
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/dto/MenuMemberDTO.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/dto/MenuMemberDTO.java
@@ -14,15 +14,15 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class MenuMemberDTO {
 
-    @ApiModelProperty(value = "DB상 유저의 ID(PK)", example = "1")
-    private Long memberId;
+	@ApiModelProperty(value = "DB상 유저의 ID(PK)", example = "1")
+	private Long memberId;
 
-    @ApiModelProperty(value = "유저네임", example = "dlwlrma")
-    private String memberUsername;
+	@ApiModelProperty(value = "유저네임", example = "dlwlrma")
+	private String memberUsername;
 
-    @ApiModelProperty(value = "프로필사진 URL", example = "https://drive.google.com/file/d/1Gu0DcGCJNs4Vo0bz2U9U6v01d_VwKijs/view?usp=sharing")
-    private String memberImageUrl;
+	@ApiModelProperty(value = "프로필사진 URL", example = "https://drive.google.com/file/d/1Gu0DcGCJNs4Vo0bz2U9U6v01d_VwKijs/view?usp=sharing")
+	private String memberImageUrl;
 
-    @ApiModelProperty(value = "이름", example = "이지금")
-    private String memberName;
+	@ApiModelProperty(value = "이름", example = "이지금")
+	private String memberName;
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/dto/MiniProfileResponse.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/dto/MiniProfileResponse.java
@@ -24,91 +24,90 @@ import lombok.Setter;
 @AllArgsConstructor
 public class MiniProfileResponse {
 
-    @ApiModelProperty(value = "유저네임", example = "dlwlrma")
-    private String memberUsername;
+	@ApiModelProperty(value = "유저네임", example = "dlwlrma")
+	private String memberUsername;
 
-    @ApiModelProperty(value = "프로필사진")
-    private Image memberImage;
+	@ApiModelProperty(value = "프로필사진")
+	private Image memberImage;
 
-    @ApiModelProperty(value = "이름", example = "이지금")
-    private String memberName;
+	@ApiModelProperty(value = "이름", example = "이지금")
+	private String memberName;
 
-    @ApiModelProperty(value = "웹사이트", example = "http://localhost:8080")
-    private String memberWebsite;
+	@ApiModelProperty(value = "웹사이트", example = "http://localhost:8080")
+	private String memberWebsite;
 
-    @ApiModelProperty(value = "팔로잉 여부", example = "true")
-    private boolean isFollowing;
+	@ApiModelProperty(value = "팔로잉 여부", example = "true")
+	private boolean isFollowing;
 
-    @ApiModelProperty(value = "팔로워 여부", example = "false")
-    private boolean isFollower;
+	@ApiModelProperty(value = "팔로워 여부", example = "false")
+	private boolean isFollower;
 
-    @ApiModelProperty(value = "차단 여부", example = "false")
-    private boolean isBlocking;
+	@ApiModelProperty(value = "차단 여부", example = "false")
+	private boolean isBlocking;
 
-    @ApiModelProperty(value = "차단당한 여부", example = "false")
-    private boolean isBlocked;
+	@ApiModelProperty(value = "차단당한 여부", example = "false")
+	private boolean isBlocked;
 
-    @ApiModelProperty(value = "포스팅 수", example = "90")
-    private Long memberPostsCount;
+	@ApiModelProperty(value = "포스팅 수", example = "90")
+	private Long memberPostsCount;
 
-    @ApiModelProperty(value = "팔로워 수", example = "100")
-    private Long memberFollowersCount;
+	@ApiModelProperty(value = "팔로워 수", example = "100")
+	private Long memberFollowersCount;
 
-    @ApiModelProperty(value = "팔로잉 수", example = "100")
-    private Long memberFollowingsCount;
+	@ApiModelProperty(value = "팔로잉 수", example = "100")
+	private Long memberFollowingsCount;
 
-    @ApiModelProperty(value = "최근 게시물 3개")
-    private List<MiniProfilePostDTO> memberPosts;
+	@ApiModelProperty(value = "최근 게시물 3개")
+	private List<MiniProfilePostDTO> memberPosts;
 
-    @ApiModelProperty(value = "내 팔로잉 중 해당 유저를 팔로우 하는 사람", example = "dlwlrma")
-    private String followingMemberFollow;
+	@ApiModelProperty(value = "내 팔로잉 중 해당 유저를 팔로우 하는 사람", example = "dlwlrma")
+	private String followingMemberFollow;
 
-    @ApiModelProperty(value = "본인 여부", example = "false")
-    private boolean isMe;
+	@ApiModelProperty(value = "본인 여부", example = "false")
+	private boolean isMe;
 
-    private boolean hasStory;
+	private boolean hasStory;
 
-    @QueryProjection
-    public MiniProfileResponse(String username, String name, Image image, boolean isFollowing, boolean isFollower,
-                               boolean isBlocking, boolean isBlocked, Long postsCount,
-                               Long followingsCount, Long followersCount, boolean isMe) {
-        this.memberUsername = username;
-        this.memberName = name;
-        this.memberImage = image;
-        this.isFollowing = isFollowing;
-        this.isFollower = isFollower;
-        this.isBlocking = isBlocking;
-        this.isBlocked = isBlocked;
-        this.memberPostsCount = postsCount;
-        this.memberFollowingsCount = followingsCount;
-        this.memberFollowersCount = followersCount;
-        this.isMe = isMe;
-        this.hasStory = false;
-    }
+	@QueryProjection
+	public MiniProfileResponse(String username, String name, Image image, boolean isFollowing, boolean isFollower,
+			boolean isBlocking, boolean isBlocked, Long postsCount,
+			Long followingsCount, Long followersCount, boolean isMe) {
+		this.memberUsername = username;
+		this.memberName = name;
+		this.memberImage = image;
+		this.isFollowing = isFollowing;
+		this.isFollower = isFollower;
+		this.isBlocking = isBlocking;
+		this.isBlocked = isBlocked;
+		this.memberPostsCount = postsCount;
+		this.memberFollowingsCount = followingsCount;
+		this.memberFollowersCount = followersCount;
+		this.isMe = isMe;
+		this.hasStory = false;
+	}
 
-    public void setMemberPosts(List<PostImageDTO> postImageDTOs) {
-        final Map<Long, List<PostImageDTO>> postDTOMap = postImageDTOs.stream()
-                .collect(Collectors.groupingBy(PostImageDTO::getPostId));
-        List<MiniProfilePostDTO> results = new ArrayList<MiniProfilePostDTO>();
-        postDTOMap.forEach((id, p) -> results.add(
-                MiniProfilePostDTO.builder()
-                        .postId(id)
-                        .postImageUrl(p.get(0).getPostImageUrl())
-                        .build()
-        ));
-        this.memberPosts = results;
-    }
+	public void setMemberPosts(List<PostImageDTO> postImageDTOs) {
+		final Map<Long, List<PostImageDTO>> postDTOMap = postImageDTOs.stream()
+				.collect(Collectors.groupingBy(PostImageDTO::getPostId));
+		List<MiniProfilePostDTO> results = new ArrayList<MiniProfilePostDTO>();
+		postDTOMap.forEach((id, p) -> results.add(
+				MiniProfilePostDTO.builder()
+						.postId(id)
+						.postImageUrl(p.get(0).getPostImageUrl())
+						.build()));
+		this.memberPosts = results;
+	}
 
-    public void checkBlock() {
-        if (this.isBlocked || this.isBlocking) {
-            this.memberPostsCount = 0L;
-            this.memberFollowersCount = 0L;
-            this.memberFollowingsCount = 0L;
-            this.memberPosts = null;
-        }
-    }
+	public void checkBlock() {
+		if (this.isBlocked || this.isBlocking) {
+			this.memberPostsCount = 0L;
+			this.memberFollowersCount = 0L;
+			this.memberFollowingsCount = 0L;
+			this.memberPosts = null;
+		}
+	}
 
-    public void setFollowingMemberFollow(String followingMemberFollow) {
-        this.followingMemberFollow = followingMemberFollow;
-    }
+	public void setFollowingMemberFollow(String followingMemberFollow) {
+		this.followingMemberFollow = followingMemberFollow;
+	}
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/dto/MiniProfileResponse.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/dto/MiniProfileResponse.java
@@ -1,6 +1,7 @@
 package cloneproject.Instagram.domain.member.dto;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -19,8 +20,6 @@ import lombok.Setter;
 
 @ApiModel("유저 미니프로필 응답 모델")
 @Getter
-@Setter
-@Builder
 @AllArgsConstructor
 public class MiniProfileResponse {
 
@@ -69,9 +68,10 @@ public class MiniProfileResponse {
 	private boolean hasStory;
 
 	@QueryProjection
-	public MiniProfileResponse(String username, String name, Image image, boolean isFollowing, boolean isFollower,
-			boolean isBlocking, boolean isBlocked, Long postsCount,
-			Long followingsCount, Long followersCount, boolean isMe) {
+	public MiniProfileResponse(String username, String name, Image image,
+		boolean isFollowing, boolean isFollower, boolean isBlocking, boolean isBlocked,
+		Long postsCount, Long followingsCount, Long followersCount,
+		boolean isMe, String followingMemberFollow) {
 		this.memberUsername = username;
 		this.memberName = name;
 		this.memberImage = image;
@@ -84,30 +84,28 @@ public class MiniProfileResponse {
 		this.memberFollowersCount = followersCount;
 		this.isMe = isMe;
 		this.hasStory = false;
+		this.followingMemberFollow = followingMemberFollow;
+		checkBlock();
 	}
 
-	public void setMemberPosts(List<PostImageDTO> postImageDTOs) {
-		final Map<Long, List<PostImageDTO>> postDTOMap = postImageDTOs.stream()
-				.collect(Collectors.groupingBy(PostImageDTO::getPostId));
-		List<MiniProfilePostDTO> results = new ArrayList<MiniProfilePostDTO>();
-		postDTOMap.forEach((id, p) -> results.add(
-				MiniProfilePostDTO.builder()
-						.postId(id)
-						.postImageUrl(p.get(0).getPostImageUrl())
-						.build()));
-		this.memberPosts = results;
+	public void setHasStory(boolean hasStory) {
+		this.hasStory = hasStory;
+		checkBlock();
 	}
 
-	public void checkBlock() {
+	public void setMemberPosts(List<MiniProfilePostDTO> miniProfilePostDTOs) {
+		this.memberPosts = miniProfilePostDTOs;
+		checkBlock();
+	}
+
+	private void checkBlock() {
 		if (this.isBlocked || this.isBlocking) {
 			this.memberPostsCount = 0L;
 			this.memberFollowersCount = 0L;
 			this.memberFollowingsCount = 0L;
-			this.memberPosts = null;
+			this.hasStory = false;
+			this.memberPosts = Collections.emptyList();
 		}
 	}
 
-	public void setFollowingMemberFollow(String followingMemberFollow) {
-		this.followingMemberFollow = followingMemberFollow;
-	}
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/dto/RegisterRequest.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/dto/RegisterRequest.java
@@ -39,12 +39,12 @@ public class RegisterRequest {
 	@ApiModelProperty(value = "이메일", example = "aaa@gmail.com", required = true)
 	@NotBlank(message = "이메일을 입력해주세요")
 	@Email(message = "이메일의 형식이 맞지 않습니다")
-	String email;
+	private String email;
 
 	@ApiModelProperty(value = "이메일 인증코드", example = "ABC123", required = true)
 	@NotBlank(message = "이메일 인증코드를 입력해주세요")
 	@Length(max = 6, min = 6, message = "인증코드는 6자리 입니다.")
-	String code;
+	private String code;
 
 	public Member convert() {
 		return Member.builder()

--- a/src/main/java/cloneproject/Instagram/domain/member/dto/RegisterRequest.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/dto/RegisterRequest.java
@@ -18,42 +18,41 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 public class RegisterRequest {
-    
-    @ApiModelProperty(value = "유저네임", example = "dlwlrma", required = true)
-    @NotBlank(message = "username을 입력해주세요")
-    @Length(min = 4, max = 12, message = "사용자 이름은 4문자 이상 12문자 이하여야 합니다")
-    @Pattern(regexp = "^[0-9a-zA-Z]+$", message = "username엔 대소문자, 숫자만 사용할 수 있습니다.")
-    private String username;
-    
-    @ApiModelProperty(value = "이름", example = "이지금", required = true)
-    @NotBlank(message = "이름을 입력해주세요")
-    @Length(min = 2, max = 12, message = "이름은 2문자 이상 12문자 이하여야 합니다")
-    private String name;
 
-    @ApiModelProperty(value = "비밀번호", example = "a12341234", required = true)
-    @NotBlank(message = "비밀번호를 입력해주세요")
-    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,}$", 
-                message = "비밀번호는 8자 이상, 최소 하나의 문자와 숫자가 필요합니다")
-    @Length(max = 20, message = "비밀번호는 20문자 이하여야 합니다")
-    private String password;
-    
-    @ApiModelProperty(value = "이메일", example = "aaa@gmail.com", required = true)
-    @NotBlank(message = "이메일을 입력해주세요")
-    @Email(message = "이메일의 형식이 맞지 않습니다")
-    String email;
+	@ApiModelProperty(value = "유저네임", example = "dlwlrma", required = true)
+	@NotBlank(message = "username을 입력해주세요")
+	@Length(min = 4, max = 12, message = "사용자 이름은 4문자 이상 12문자 이하여야 합니다")
+	@Pattern(regexp = "^[0-9a-zA-Z]+$", message = "username엔 대소문자, 숫자만 사용할 수 있습니다.")
+	private String username;
 
-    @ApiModelProperty(value = "이메일 인증코드", example = "ABC123", required = true)
-    @NotBlank(message = "이메일 인증코드를 입력해주세요")
-    @Length(max = 6, min = 6, message = "인증코드는 6자리 입니다.")
-    String code;
-    
-    public Member convert(){
-        return Member.builder()
-                    .username(getUsername())
-                    .name(getName())
-                    .password(getPassword())
-                    .email(getEmail())
-                    .build();
-    }    
+	@ApiModelProperty(value = "이름", example = "이지금", required = true)
+	@NotBlank(message = "이름을 입력해주세요")
+	@Length(min = 2, max = 12, message = "이름은 2문자 이상 12문자 이하여야 합니다")
+	private String name;
+
+	@ApiModelProperty(value = "비밀번호", example = "a12341234", required = true)
+	@NotBlank(message = "비밀번호를 입력해주세요")
+	@Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,}$", message = "비밀번호는 8자 이상, 최소 하나의 문자와 숫자가 필요합니다")
+	@Length(max = 20, message = "비밀번호는 20문자 이하여야 합니다")
+	private String password;
+
+	@ApiModelProperty(value = "이메일", example = "aaa@gmail.com", required = true)
+	@NotBlank(message = "이메일을 입력해주세요")
+	@Email(message = "이메일의 형식이 맞지 않습니다")
+	String email;
+
+	@ApiModelProperty(value = "이메일 인증코드", example = "ABC123", required = true)
+	@NotBlank(message = "이메일 인증코드를 입력해주세요")
+	@Length(max = 6, min = 6, message = "인증코드는 6자리 입니다.")
+	String code;
+
+	public Member convert() {
+		return Member.builder()
+				.username(getUsername())
+				.name(getName())
+				.password(getPassword())
+				.email(getEmail())
+				.build();
+	}
 
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/dto/ResetPasswordRequest.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/dto/ResetPasswordRequest.java
@@ -16,23 +16,22 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ResetPasswordRequest {
-    
-    @ApiModelProperty(value = "유저네임", example = "dlwlrma", required = true)
-    @NotBlank(message = "username을 입력해주세요")
-    @Length(min = 4, max = 12, message = "사용자 이름은 4문자 이상 12문자 이하여야 합니다")
-    @Pattern(regexp = "^[0-9a-zA-Z]+$", message = "username엔 대소문자, 숫자만 사용할 수 있습니다.")
-    private String username;
-    
-    @ApiModelProperty(value = "인증코드", example = "ABC123AAAAAAAA1231313123..", required = true)
-    @NotBlank(message = "인증코드를 입력해주세요")
-    @Length(max = 30, min = 30, message = "인증코드는 30자리 입니다.")
-    private String code;
 
-    @ApiModelProperty(value = "새비밀번호", example = "a12341234", required = true)
-    @NotBlank(message = "새비밀번호를 입력해주세요")
-    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,}$", 
-                message = "비밀번호는 8자 이상, 최소 하나의 문자와 숫자가 필요합니다")
-    @Length(max = 20, message = "비밀번호는 20문자 이하여야 합니다")
-    private String newPassword;
-    
+	@ApiModelProperty(value = "유저네임", example = "dlwlrma", required = true)
+	@NotBlank(message = "username을 입력해주세요")
+	@Length(min = 4, max = 12, message = "사용자 이름은 4문자 이상 12문자 이하여야 합니다")
+	@Pattern(regexp = "^[0-9a-zA-Z]+$", message = "username엔 대소문자, 숫자만 사용할 수 있습니다.")
+	private String username;
+
+	@ApiModelProperty(value = "인증코드", example = "ABC123AAAAAAAA1231313123..", required = true)
+	@NotBlank(message = "인증코드를 입력해주세요")
+	@Length(max = 30, min = 30, message = "인증코드는 30자리 입니다.")
+	private String code;
+
+	@ApiModelProperty(value = "새비밀번호", example = "a12341234", required = true)
+	@NotBlank(message = "새비밀번호를 입력해주세요")
+	@Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,}$", message = "비밀번호는 8자 이상, 최소 하나의 문자와 숫자가 필요합니다")
+	@Length(max = 20, message = "비밀번호는 20문자 이하여야 합니다")
+	private String newPassword;
+
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/dto/SendConfirmationEmailRequest.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/dto/SendConfirmationEmailRequest.java
@@ -18,15 +18,15 @@ import lombok.NoArgsConstructor;
 @Builder
 public class SendConfirmationEmailRequest {
 
-    @ApiModelProperty(value = "유저네임", example = "dlwlrma", required = true)
-    @NotBlank(message = "username을 입력해주세요")
-    @Length(min = 4, max = 12, message = "사용자 이름은 4문자 이상 12문자 이하여야 합니다")
-    @Pattern(regexp = "^[0-9a-zA-Z]+$", message = "username엔 대소문자, 숫자만 사용할 수 있습니다.")
-    String username;
-    
-    @ApiModelProperty(value = "이메일", example = "aaa@gmail.com", required = true)
-    @NotBlank(message = "이메일을 입력해주세요")
-    @Email(message = "이메일의 형식이 맞지 않습니다")
-    String email;
+	@ApiModelProperty(value = "유저네임", example = "dlwlrma", required = true)
+	@NotBlank(message = "username을 입력해주세요")
+	@Length(min = 4, max = 12, message = "사용자 이름은 4문자 이상 12문자 이하여야 합니다")
+	@Pattern(regexp = "^[0-9a-zA-Z]+$", message = "username엔 대소문자, 숫자만 사용할 수 있습니다.")
+	String username;
+
+	@ApiModelProperty(value = "이메일", example = "aaa@gmail.com", required = true)
+	@NotBlank(message = "이메일을 입력해주세요")
+	@Email(message = "이메일의 형식이 맞지 않습니다")
+	String email;
 
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/dto/SendConfirmationEmailRequest.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/dto/SendConfirmationEmailRequest.java
@@ -22,11 +22,11 @@ public class SendConfirmationEmailRequest {
 	@NotBlank(message = "username을 입력해주세요")
 	@Length(min = 4, max = 12, message = "사용자 이름은 4문자 이상 12문자 이하여야 합니다")
 	@Pattern(regexp = "^[0-9a-zA-Z]+$", message = "username엔 대소문자, 숫자만 사용할 수 있습니다.")
-	String username;
+	private String username;
 
 	@ApiModelProperty(value = "이메일", example = "aaa@gmail.com", required = true)
 	@NotBlank(message = "이메일을 입력해주세요")
 	@Email(message = "이메일의 형식이 맞지 않습니다")
-	String email;
+	private String email;
 
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/dto/UpdatePasswordRequest.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/dto/UpdatePasswordRequest.java
@@ -17,17 +17,15 @@ import lombok.Setter;
 @AllArgsConstructor
 public class UpdatePasswordRequest {
 
-    @ApiModelProperty(value = "이전비밀번호", example = "b12341234", required = true)
-    @NotBlank(message = "이전비밀번호를 입력해주세요")
-    @Length(max = 20, message = "비밀번호는 20문자 이하여야 합니다")
-    private String oldPassword;
-    
-    
-    @ApiModelProperty(value = "새비밀번호", example = "a12341234", required = true)
-    @NotBlank(message = "새비밀번호를 입력해주세요")
-    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,}$", 
-                message = "비밀번호는 8자 이상, 최소 하나의 문자와 숫자가 필요합니다")
-    @Length(max = 20, message = "비밀번호는 20문자 이하여야 합니다")
-    private String newPassword;
-    
+	@ApiModelProperty(value = "이전비밀번호", example = "b12341234", required = true)
+	@NotBlank(message = "이전비밀번호를 입력해주세요")
+	@Length(max = 20, message = "비밀번호는 20문자 이하여야 합니다")
+	private String oldPassword;
+
+	@ApiModelProperty(value = "새비밀번호", example = "a12341234", required = true)
+	@NotBlank(message = "새비밀번호를 입력해주세요")
+	@Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,}$", message = "비밀번호는 8자 이상, 최소 하나의 문자와 숫자가 필요합니다")
+	@Length(max = 20, message = "비밀번호는 20문자 이하여야 합니다")
+	private String newPassword;
+
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/dto/UserProfileResponse.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/dto/UserProfileResponse.java
@@ -13,79 +13,80 @@ import lombok.Setter;
 @Setter
 public class UserProfileResponse {
 
-    @ApiModelProperty(value = "유저네임", example = "dlwlrma")
-    private String memberUsername;
+	@ApiModelProperty(value = "유저네임", example = "dlwlrma")
+	private String memberUsername;
 
-    @ApiModelProperty(value = "이름", example = "이지금")
-    private String memberName;
+	@ApiModelProperty(value = "이름", example = "이지금")
+	private String memberName;
 
-    @ApiModelProperty(value = "웹사이트", example = "http://localhost:8080")
-    private String memberWebsite;
+	@ApiModelProperty(value = "웹사이트", example = "http://localhost:8080")
+	private String memberWebsite;
 
-    @ApiModelProperty(value = "프로필사진")
-    private Image memberImage;
+	@ApiModelProperty(value = "프로필사진")
+	private Image memberImage;
 
-    @ApiModelProperty(value = "팔로잉 여부", example = "true")
-    private boolean isFollowing;
+	@ApiModelProperty(value = "팔로잉 여부", example = "true")
+	private boolean isFollowing;
 
-    @ApiModelProperty(value = "팔로워 여부", example = "false")
-    private boolean isFollower;
+	@ApiModelProperty(value = "팔로워 여부", example = "false")
+	private boolean isFollower;
 
-    @ApiModelProperty(value = "차단 여부", example = "false")
-    private boolean isBlocking;
+	@ApiModelProperty(value = "차단 여부", example = "false")
+	private boolean isBlocking;
 
-    @ApiModelProperty(value = "차단당한 여부", example = "false")
-    private boolean isBlocked;
+	@ApiModelProperty(value = "차단당한 여부", example = "false")
+	private boolean isBlocked;
 
-    @ApiModelProperty(value = "소개", example = "안녕하세요")
-    private String memberIntroduce;
+	@ApiModelProperty(value = "소개", example = "안녕하세요")
+	private String memberIntroduce;
 
-    @ApiModelProperty(value = "포스팅 수", example = "90")
-    private Long memberPostsCount;
+	@ApiModelProperty(value = "포스팅 수", example = "90")
+	private Long memberPostsCount;
 
-    @ApiModelProperty(value = "팔로잉 수", example = "100")
-    private Long memberFollowingsCount;
+	@ApiModelProperty(value = "팔로잉 수", example = "100")
+	private Long memberFollowingsCount;
 
-    @ApiModelProperty(value = "팔로워 수", example = "100")
-    private Long memberFollowersCount;
+	@ApiModelProperty(value = "팔로워 수", example = "100")
+	private Long memberFollowersCount;
 
-    @ApiModelProperty(value = "내 팔로잉 중 해당 유저를 팔로우 하는 사람", example = "dlwlrma")
-    private String followingMemberFollow;
+	@ApiModelProperty(value = "내 팔로잉 중 해당 유저를 팔로우 하는 사람", example = "dlwlrma")
+	private String followingMemberFollow;
 
-    @ApiModelProperty(value = "본인 여부", example = "false")
-    private boolean isMe;
+	@ApiModelProperty(value = "본인 여부", example = "false")
+	private boolean isMe;
 
-    private boolean hasStory;
+	private boolean hasStory;
 
-    @QueryProjection
-    public UserProfileResponse(String username, String name, String website, Image image, boolean isFollowing, boolean isFollower,
-                               boolean isBlocking, boolean isBlocked, String introduce, Long postsCount,
-                               Long followingsCount, Long followersCount, boolean isMe) {
-        this.memberUsername = username;
-        this.memberName = name;
-        this.memberWebsite = website;
-        this.memberImage = image;
-        this.isFollowing = isFollowing;
-        this.isFollower = isFollower;
-        this.isBlocking = isBlocking;
-        this.isBlocked = isBlocked;
-        this.memberIntroduce = introduce;
-        this.memberPostsCount = postsCount;
-        this.memberFollowingsCount = followingsCount;
-        this.memberFollowersCount = followersCount;
-        this.isMe = isMe;
-        this.hasStory = false;
-    }
+	@QueryProjection
+	public UserProfileResponse(String username, String name, String website, Image image, boolean isFollowing,
+			boolean isFollower,
+			boolean isBlocking, boolean isBlocked, String introduce, Long postsCount,
+			Long followingsCount, Long followersCount, boolean isMe) {
+		this.memberUsername = username;
+		this.memberName = name;
+		this.memberWebsite = website;
+		this.memberImage = image;
+		this.isFollowing = isFollowing;
+		this.isFollower = isFollower;
+		this.isBlocking = isBlocking;
+		this.isBlocked = isBlocked;
+		this.memberIntroduce = introduce;
+		this.memberPostsCount = postsCount;
+		this.memberFollowingsCount = followingsCount;
+		this.memberFollowersCount = followersCount;
+		this.isMe = isMe;
+		this.hasStory = false;
+	}
 
-    public void checkBlock() {
-        if (this.isBlocked || this.isBlocking) {
-            this.memberPostsCount = 0L;
-            this.memberFollowingsCount = 0L;
-            this.memberFollowersCount = 0L;
-        }
-    }
+	public void checkBlock() {
+		if (this.isBlocked || this.isBlocking) {
+			this.memberPostsCount = 0L;
+			this.memberFollowingsCount = 0L;
+			this.memberFollowersCount = 0L;
+		}
+	}
 
-    public void setFollowingMemberFollow(String followingMemberFollow) {
-        this.followingMemberFollow = followingMemberFollow;
-    }
+	public void setFollowingMemberFollow(String followingMemberFollow) {
+		this.followingMemberFollow = followingMemberFollow;
+	}
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/dto/UserProfileResponse.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/dto/UserProfileResponse.java
@@ -58,10 +58,10 @@ public class UserProfileResponse {
 	private boolean hasStory;
 
 	@QueryProjection
-	public UserProfileResponse(String username, String name, String website, Image image, boolean isFollowing,
-			boolean isFollower,
-			boolean isBlocking, boolean isBlocked, String introduce, Long postsCount,
-			Long followingsCount, Long followersCount, boolean isMe) {
+	public UserProfileResponse(String username, String name, String website, Image image,
+		boolean isFollowing, boolean isFollower, boolean isBlocking, boolean isBlocked,
+		String introduce, Long postsCount, Long followingsCount, Long followersCount,
+		boolean isMe, String followingMemberFollow) {
 		this.memberUsername = username;
 		this.memberName = name;
 		this.memberWebsite = website;
@@ -76,17 +76,22 @@ public class UserProfileResponse {
 		this.memberFollowersCount = followersCount;
 		this.isMe = isMe;
 		this.hasStory = false;
+		this.followingMemberFollow = followingMemberFollow;
+		checkBlock();
 	}
 
-	public void checkBlock() {
+	public void setHasStory(boolean hasStory) {
+		this.hasStory = hasStory;
+		checkBlock();
+	}
+
+	private void checkBlock() {
 		if (this.isBlocked || this.isBlocking) {
 			this.memberPostsCount = 0L;
 			this.memberFollowingsCount = 0L;
 			this.memberFollowersCount = 0L;
+			this.hasStory = false;
 		}
 	}
 
-	public void setFollowingMemberFollow(String followingMemberFollow) {
-		this.followingMemberFollow = followingMemberFollow;
-	}
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/entity/Block.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/entity/Block.java
@@ -13,22 +13,22 @@ import lombok.NoArgsConstructor;
 @Table(name = "blocks")
 public class Block {
 
-    @Id
-    @Column(name = "block_id")
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+	@Id
+	@Column(name = "block_id")
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
-    private Member member;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id")
+	private Member member;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "block_member_id")
-    private Member blockMember;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "block_member_id")
+	private Member blockMember;
 
-    @Builder
-    public Block(Member member, Member blockMember) {
-        this.member = member;
-        this.blockMember = blockMember;
-    }
+	@Builder
+	public Block(Member member, Member blockMember) {
+		this.member = member;
+		this.blockMember = blockMember;
+	}
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/entity/Block.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/entity/Block.java
@@ -1,6 +1,14 @@
 package cloneproject.Instagram.domain.member.entity;
 
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
 
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -31,4 +39,5 @@ public class Block {
 		this.member = member;
 		this.blockMember = blockMember;
 	}
+
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/entity/Gender.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/entity/Gender.java
@@ -3,4 +3,5 @@ package cloneproject.Instagram.domain.member.entity;
 public enum Gender {
 	// 남성, 여성, 밝히고싶지않음
 	MALE, FEMALE, PRIVATE;
+
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/entity/Gender.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/entity/Gender.java
@@ -1,6 +1,6 @@
 package cloneproject.Instagram.domain.member.entity;
 
 public enum Gender {
-    // 남성, 여성, 밝히고싶지않음
-    MALE, FEMALE, PRIVATE;
+	// 남성, 여성, 밝히고싶지않음
+	MALE, FEMALE, PRIVATE;
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/entity/Member.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/entity/Member.java
@@ -22,118 +22,118 @@ import java.util.List;
 @Table(name = "members")
 public class Member {
 
-    @Id
-    @Column(name = "member_id")
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+	@Id
+	@Column(name = "member_id")
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
 
-    @Column(name = "member_username", nullable = false, length = 20, unique = true)
-    private String username;
+	@Column(name = "member_username", nullable = false, length = 20, unique = true)
+	private String username;
 
-    @Column(name = "member_role")
-    @Enumerated(EnumType.STRING)
-    private MemberRole role;
+	@Column(name = "member_role")
+	@Enumerated(EnumType.STRING)
+	private MemberRole role;
 
-    @Column(name = "member_password", nullable = false)
-    private String password;
+	@Column(name = "member_password", nullable = false)
+	private String password;
 
-    @Column(name = "member_name", nullable = false, length = 20)
-    private String name;
+	@Column(name = "member_name", nullable = false, length = 20)
+	private String name;
 
-    @Column(name = "member_website")
-    private String website;
+	@Column(name = "member_website")
+	private String website;
 
-    @Lob
-    @Column(name = "member_introduce")
-    private String introduce;
+	@Lob
+	@Column(name = "member_introduce")
+	private String introduce;
 
-    @Column(name = "member_email")
-    private String email;
+	@Column(name = "member_email")
+	private String email;
 
-    @Column(name = "member_phone")
-    private String phone;
+	@Column(name = "member_phone")
+	private String phone;
 
-    @Column(name = "member_gender")
-    @Enumerated(EnumType.STRING)
-    private Gender gender;
+	@Column(name = "member_gender")
+	@Enumerated(EnumType.STRING)
+	private Gender gender;
 
-    @OneToMany(mappedBy = "member")
-    private List<Follow> followings = new ArrayList<>();
+	@OneToMany(mappedBy = "member")
+	private List<Follow> followings = new ArrayList<>();
 
-    @Embedded
-    @AttributeOverrides({
-            @AttributeOverride(name = "imageUrl", column = @Column(name = "member_image_url")),
-            @AttributeOverride(name = "imageType", column = @Column(name = "member_image_type")),
-            @AttributeOverride(name = "imageName", column = @Column(name = "member_image_name")),
-            @AttributeOverride(name = "imageUUID", column = @Column(name = "member_image_uuid"))
-    })
-    private Image image;
+	@Embedded
+	@AttributeOverrides({
+			@AttributeOverride(name = "imageUrl", column = @Column(name = "member_image_url")),
+			@AttributeOverride(name = "imageType", column = @Column(name = "member_image_type")),
+			@AttributeOverride(name = "imageName", column = @Column(name = "member_image_name")),
+			@AttributeOverride(name = "imageUUID", column = @Column(name = "member_image_uuid"))
+	})
+	private Image image;
 
-    public void updateUsername(String username) {
-        this.username = username;
-    }
+	public void updateUsername(String username) {
+		this.username = username;
+	}
 
-    public void updateName(String name) {
-        this.name = name;
-    }
+	public void updateName(String name) {
+		this.name = name;
+	}
 
-    public void updateWebsite(String website) {
-        this.website = website;
-    }
+	public void updateWebsite(String website) {
+		this.website = website;
+	}
 
-    public void updateIntroduce(String introduce) {
-        this.introduce = introduce;
-    }
+	public void updateIntroduce(String introduce) {
+		this.introduce = introduce;
+	}
 
-    public void updatePhone(String phone) {
-        this.phone = phone;
-    }
+	public void updatePhone(String phone) {
+		this.phone = phone;
+	}
 
-    public void updateEmail(String email) {
-        this.email = email;
-    }
+	public void updateEmail(String email) {
+		this.email = email;
+	}
 
-    public void updateGender(Gender gender) {
-        this.gender = gender;
-    }
+	public void updateGender(Gender gender) {
+		this.gender = gender;
+	}
 
-    public void setEncryptedPassword(String encryptedPassword) {
-        this.password = encryptedPassword;
-    }
+	public void setEncryptedPassword(String encryptedPassword) {
+		this.password = encryptedPassword;
+	}
 
-    public void uploadImage(Image image) {
-        deleteImage();
-        this.image = image;
-    }
+	public void uploadImage(Image image) {
+		deleteImage();
+		this.image = image;
+	}
 
-    public void deleteImage() {
-        if (this.image.getImageUUID().equals("base-UUID"))
-            return;
+	public void deleteImage() {
+		if (this.image.getImageUUID().equals("base-UUID"))
+			return;
 
-        this.image = Image.builder()
-                .imageName("base")
-                .imageType(ImageType.PNG)
-                .imageUrl("https://bluetifulc-spring-bucket.s3.ap-northeast-2.amazonaws.com/member/base-UUID_base.PNG")
-                .imageUUID("base-UUID")
-                .build();
-    }
+		this.image = Image.builder()
+				.imageName("base")
+				.imageType(ImageType.PNG)
+				.imageUrl("https://bluetifulc-spring-bucket.s3.ap-northeast-2.amazonaws.com/member/base-UUID_base.PNG")
+				.imageUUID("base-UUID")
+				.build();
+	}
 
-    @Builder
-    public Member(String username, String name, String password, String email) {
-        this.username = username;
-        this.name = name;
-        this.password = password;
-        this.email = email;
+	@Builder
+	public Member(String username, String name, String password, String email) {
+		this.username = username;
+		this.name = name;
+		this.password = password;
+		this.email = email;
 
-        // 자동 초기화
-        this.role = MemberRole.ROLE_USER;
-        this.gender = Gender.PRIVATE;
-        this.image = Image.builder()
-                .imageName("base")
-                .imageType(ImageType.PNG)
-                .imageUrl("https://bluetifulc-spring-bucket.s3.ap-northeast-2.amazonaws.com/member/base-UUID_base.PNG")
-                .imageUUID("base-UUID")
-                .build();
-    }
+		// 자동 초기화
+		this.role = MemberRole.ROLE_USER;
+		this.gender = Gender.PRIVATE;
+		this.image = Image.builder()
+				.imageName("base")
+				.imageType(ImageType.PNG)
+				.imageUrl("https://bluetifulc-spring-bucket.s3.ap-northeast-2.amazonaws.com/member/base-UUID_base.PNG")
+				.imageUUID("base-UUID")
+				.build();
+	}
 
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/entity/Member.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/entity/Member.java
@@ -1,6 +1,22 @@
 package cloneproject.Instagram.domain.member.entity;
 
-import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.persistence.AttributeOverride;
+import javax.persistence.AttributeOverrides;
+import javax.persistence.Column;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Lob;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
 
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -11,9 +27,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Getter
 @Entity
@@ -62,10 +75,10 @@ public class Member {
 
 	@Embedded
 	@AttributeOverrides({
-			@AttributeOverride(name = "imageUrl", column = @Column(name = "member_image_url")),
-			@AttributeOverride(name = "imageType", column = @Column(name = "member_image_type")),
-			@AttributeOverride(name = "imageName", column = @Column(name = "member_image_name")),
-			@AttributeOverride(name = "imageUUID", column = @Column(name = "member_image_uuid"))
+		@AttributeOverride(name = "imageUrl", column = @Column(name = "member_image_url")),
+		@AttributeOverride(name = "imageType", column = @Column(name = "member_image_type")),
+		@AttributeOverride(name = "imageName", column = @Column(name = "member_image_name")),
+		@AttributeOverride(name = "imageUUID", column = @Column(name = "member_image_uuid"))
 	})
 	private Image image;
 
@@ -111,11 +124,11 @@ public class Member {
 			return;
 
 		this.image = Image.builder()
-				.imageName("base")
-				.imageType(ImageType.PNG)
-				.imageUrl("https://bluetifulc-spring-bucket.s3.ap-northeast-2.amazonaws.com/member/base-UUID_base.PNG")
-				.imageUUID("base-UUID")
-				.build();
+			.imageName("base")
+			.imageType(ImageType.PNG)
+			.imageUrl("https://bluetifulc-spring-bucket.s3.ap-northeast-2.amazonaws.com/member/base-UUID_base.PNG")
+			.imageUUID("base-UUID")
+			.build();
 	}
 
 	@Builder
@@ -129,11 +142,11 @@ public class Member {
 		this.role = MemberRole.ROLE_USER;
 		this.gender = Gender.PRIVATE;
 		this.image = Image.builder()
-				.imageName("base")
-				.imageType(ImageType.PNG)
-				.imageUrl("https://bluetifulc-spring-bucket.s3.ap-northeast-2.amazonaws.com/member/base-UUID_base.PNG")
-				.imageUUID("base-UUID")
-				.build();
+			.imageName("base")
+			.imageType(ImageType.PNG)
+			.imageUrl("https://bluetifulc-spring-bucket.s3.ap-northeast-2.amazonaws.com/member/base-UUID_base.PNG")
+			.imageUUID("base-UUID")
+			.build();
 	}
 
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/entity/MemberRole.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/entity/MemberRole.java
@@ -2,4 +2,5 @@ package cloneproject.Instagram.domain.member.entity;
 
 public enum MemberRole {
 	ROLE_USER, ROLE_ADMIN;
+
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/entity/MemberRole.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/entity/MemberRole.java
@@ -1,5 +1,5 @@
 package cloneproject.Instagram.domain.member.entity;
 
 public enum MemberRole {
-    ROLE_USER, ROLE_ADMIN;
+	ROLE_USER, ROLE_ADMIN;
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/entity/redis/EmailCode.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/entity/redis/EmailCode.java
@@ -13,23 +13,23 @@ import lombok.Getter;
 
 @Getter
 @RedisHash("EmailCode")
-public class EmailCode implements Serializable{
-    
-    @Id
-    @Indexed // Redis 에선 Indexed 어노테이션이 있어야 find 가능
-    private String username;
+public class EmailCode implements Serializable {
 
-    private String email;
+	@Id
+	@Indexed // Redis 에선 Indexed 어노테이션이 있어야 find 가능
+	private String username;
 
-    private String code;
+	private String email;
 
-    @TimeToLive(unit = TimeUnit.SECONDS)
-    private Long timeout = 300L;
+	private String code;
 
-    @Builder
-    public EmailCode(String username, String code, String email) {
-        this.username = username;
-        this.code = code;
-        this.email = email;
-    }
+	@TimeToLive(unit = TimeUnit.SECONDS)
+	private Long timeout = 300L;
+
+	@Builder
+	public EmailCode(String username, String code, String email) {
+		this.username = username;
+		this.code = code;
+		this.email = email;
+	}
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/entity/redis/EmailCode.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/entity/redis/EmailCode.java
@@ -32,4 +32,5 @@ public class EmailCode implements Serializable {
 		this.code = code;
 		this.email = email;
 	}
+
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/entity/redis/RefreshToken.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/entity/redis/RefreshToken.java
@@ -1,6 +1,8 @@
 package cloneproject.Instagram.domain.member.entity.redis;
 
-import lombok.*;
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import java.util.concurrent.TimeUnit;
 
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
@@ -8,10 +10,10 @@ import org.springframework.data.redis.core.TimeToLive;
 import org.springframework.data.redis.core.index.Indexed;
 
 import cloneproject.Instagram.infra.geoip.dto.GeoIP;
-
-import java.io.Serializable;
-import java.time.LocalDateTime;
-import java.util.concurrent.TimeUnit;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @RedisHash("refresh_tokens")
 @Getter

--- a/src/main/java/cloneproject/Instagram/domain/member/entity/redis/RefreshToken.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/entity/redis/RefreshToken.java
@@ -13,53 +13,52 @@ import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.concurrent.TimeUnit;
 
-
 @RedisHash("refresh_tokens")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class RefreshToken implements Serializable{
+public class RefreshToken implements Serializable {
 
-    @Id
-    @Indexed
-    private String id;
-    // Long으로 하면 find 쿼리가 정상 작동하지 않음
+	@Id
+	@Indexed
+	private String id;
+	// Long으로 하면 find 쿼리가 정상 작동하지 않음
 
-    @Indexed
-    private String value;
+	@Indexed
+	private String value;
 
-    @Indexed
-    private Long memberId;
+	@Indexed
+	private Long memberId;
 
-    @TimeToLive(unit = TimeUnit.DAYS)
-    private Long timeout = 7L;
+	@TimeToLive(unit = TimeUnit.DAYS)
+	private Long timeout = 7L;
 
-    private LocalDateTime createdAt;
+	private LocalDateTime createdAt;
 
-    private String city;
+	private String city;
 
-    private String longitude;
+	private String longitude;
 
-    private String latitude;
+	private String latitude;
 
-    private String device;
+	private String device;
 
-    public void updateToken(String newValue){
-        this.value = newValue;  
-    }
+	public void updateToken(String newValue) {
+		this.value = newValue;
+	}
 
-    public GeoIP getGeoIP(){
-        return new GeoIP(city, longitude, latitude);
-    }
+	public GeoIP getGeoIP() {
+		return new GeoIP(city, longitude, latitude);
+	}
 
-    @Builder
-    public RefreshToken(Long memberId, String value, GeoIP geoip, String device){
-        this.createdAt = LocalDateTime.now();
-        this.memberId = memberId;
-        this.value = value;
-        this.city = geoip.getCity();
-        this.longitude = geoip.getLongitude();
-        this.latitude = geoip.getLatitude();
-        this.device = device;
-    }
+	@Builder
+	public RefreshToken(Long memberId, String value, GeoIP geoip, String device) {
+		this.createdAt = LocalDateTime.now();
+		this.memberId = memberId;
+		this.value = value;
+		this.city = geoip.getCity();
+		this.longitude = geoip.getLongitude();
+		this.latitude = geoip.getLatitude();
+		this.device = device;
+	}
 
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/entity/redis/ResetPasswordCode.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/entity/redis/ResetPasswordCode.java
@@ -29,4 +29,5 @@ public class ResetPasswordCode implements Serializable {
 		this.username = username;
 		this.code = code;
 	}
+
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/entity/redis/ResetPasswordCode.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/entity/redis/ResetPasswordCode.java
@@ -13,20 +13,20 @@ import lombok.Getter;
 
 @Getter
 @RedisHash("ResetPasswordCode")
-public class ResetPasswordCode implements Serializable{
-    
-    @Id
-    @Indexed // Redis 에선 Indexed 어노테이션이 있어야 find 가능
-    private String username;
+public class ResetPasswordCode implements Serializable {
 
-    private String code;
+	@Id
+	@Indexed // Redis 에선 Indexed 어노테이션이 있어야 find 가능
+	private String username;
 
-    @TimeToLive(unit = TimeUnit.SECONDS)
-    private Long timeout = 1800L; // 30분
+	private String code;
 
-    @Builder
-    public ResetPasswordCode(String username, String code) {
-        this.username = username;
-        this.code = code;
-    }
+	@TimeToLive(unit = TimeUnit.SECONDS)
+	private Long timeout = 1800L; // 30분
+
+	@Builder
+	public ResetPasswordCode(String username, String code) {
+		this.username = username;
+		this.code = code;
+	}
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/exception/AccountMismatchException.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/exception/AccountMismatchException.java
@@ -3,8 +3,8 @@ package cloneproject.Instagram.domain.member.exception;
 import cloneproject.Instagram.global.error.ErrorCode;
 import cloneproject.Instagram.global.error.exception.BusinessException;
 
-public class AccountMismatchException extends BusinessException{
-    public AccountMismatchException(){
-        super(ErrorCode.ACCOUNT_MISMATCH);
-    }
+public class AccountMismatchException extends BusinessException {
+	public AccountMismatchException() {
+		super(ErrorCode.ACCOUNT_MISMATCH);
+	}
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/exception/AccountMismatchException.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/exception/AccountMismatchException.java
@@ -7,4 +7,5 @@ public class AccountMismatchException extends BusinessException {
 	public AccountMismatchException() {
 		super(ErrorCode.ACCOUNT_MISMATCH);
 	}
+
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/exception/AlreadyBlockException.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/exception/AlreadyBlockException.java
@@ -3,9 +3,9 @@ package cloneproject.Instagram.domain.member.exception;
 import cloneproject.Instagram.global.error.ErrorCode;
 import cloneproject.Instagram.global.error.exception.BusinessException;
 
-public class AlreadyBlockException extends BusinessException{
-    public AlreadyBlockException(){
-        super(ErrorCode.ALREADY_BLOCK);
-    }
-    
+public class AlreadyBlockException extends BusinessException {
+	public AlreadyBlockException() {
+		super(ErrorCode.ALREADY_BLOCK);
+	}
+
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/exception/CantBlockMyselfException.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/exception/CantBlockMyselfException.java
@@ -4,7 +4,7 @@ import cloneproject.Instagram.global.error.ErrorCode;
 import cloneproject.Instagram.global.error.exception.BusinessException;
 
 public class CantBlockMyselfException extends BusinessException {
-    public CantBlockMyselfException(){
-        super(ErrorCode.CANT_BLOCK_MYSELF);
-    }
+	public CantBlockMyselfException() {
+		super(ErrorCode.CANT_BLOCK_MYSELF);
+	}
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/exception/CantBlockMyselfException.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/exception/CantBlockMyselfException.java
@@ -7,4 +7,5 @@ public class CantBlockMyselfException extends BusinessException {
 	public CantBlockMyselfException() {
 		super(ErrorCode.CANT_BLOCK_MYSELF);
 	}
+
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/exception/CantUnblockException.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/exception/CantUnblockException.java
@@ -7,4 +7,5 @@ public class CantUnblockException extends BusinessException {
 	public CantUnblockException() {
 		super(ErrorCode.CANT_UNBLOCK);
 	}
+
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/exception/CantUnblockException.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/exception/CantUnblockException.java
@@ -4,7 +4,7 @@ import cloneproject.Instagram.global.error.ErrorCode;
 import cloneproject.Instagram.global.error.exception.BusinessException;
 
 public class CantUnblockException extends BusinessException {
-    public CantUnblockException(){
-        super(ErrorCode.CANT_UNBLOCK);
-    }
+	public CantUnblockException() {
+		super(ErrorCode.CANT_UNBLOCK);
+	}
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/exception/CantUnblockMyselfException.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/exception/CantUnblockMyselfException.java
@@ -7,4 +7,5 @@ public class CantUnblockMyselfException extends BusinessException {
 	public CantUnblockMyselfException() {
 		super(ErrorCode.CANT_UNBLOCK_MYSELF);
 	}
+
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/exception/CantUnblockMyselfException.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/exception/CantUnblockMyselfException.java
@@ -4,7 +4,7 @@ import cloneproject.Instagram.global.error.ErrorCode;
 import cloneproject.Instagram.global.error.exception.BusinessException;
 
 public class CantUnblockMyselfException extends BusinessException {
-    public CantUnblockMyselfException(){
-        super(ErrorCode.CANT_UNBLOCK_MYSELF);
-    }
+	public CantUnblockMyselfException() {
+		super(ErrorCode.CANT_UNBLOCK_MYSELF);
+	}
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/exception/ExpiredAccessTokenException.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/exception/ExpiredAccessTokenException.java
@@ -3,8 +3,8 @@ package cloneproject.Instagram.domain.member.exception;
 import cloneproject.Instagram.global.error.ErrorCode;
 import cloneproject.Instagram.global.error.exception.BusinessException;
 
-public class ExpiredAccessTokenException extends BusinessException{
-    public ExpiredAccessTokenException(){
-        super(ErrorCode.EXPIRED_ACCESS_TOKEN);
-    }
+public class ExpiredAccessTokenException extends BusinessException {
+	public ExpiredAccessTokenException() {
+		super(ErrorCode.EXPIRED_ACCESS_TOKEN);
+	}
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/exception/ExpiredAccessTokenException.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/exception/ExpiredAccessTokenException.java
@@ -7,4 +7,5 @@ public class ExpiredAccessTokenException extends BusinessException {
 	public ExpiredAccessTokenException() {
 		super(ErrorCode.EXPIRED_ACCESS_TOKEN);
 	}
+
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/exception/ExpiredRefreshTokenException.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/exception/ExpiredRefreshTokenException.java
@@ -3,8 +3,8 @@ package cloneproject.Instagram.domain.member.exception;
 import cloneproject.Instagram.global.error.ErrorCode;
 import cloneproject.Instagram.global.error.exception.BusinessException;
 
-public class ExpiredRefreshTokenException extends BusinessException{
-    public ExpiredRefreshTokenException(){
-        super(ErrorCode.EXPIRED_REFRESH_TOKEN);
-    }
+public class ExpiredRefreshTokenException extends BusinessException {
+	public ExpiredRefreshTokenException() {
+		super(ErrorCode.EXPIRED_REFRESH_TOKEN);
+	}
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/exception/ExpiredRefreshTokenException.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/exception/ExpiredRefreshTokenException.java
@@ -7,4 +7,5 @@ public class ExpiredRefreshTokenException extends BusinessException {
 	public ExpiredRefreshTokenException() {
 		super(ErrorCode.EXPIRED_REFRESH_TOKEN);
 	}
+
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/exception/InvalidJwtException.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/exception/InvalidJwtException.java
@@ -3,8 +3,8 @@ package cloneproject.Instagram.domain.member.exception;
 import cloneproject.Instagram.global.error.ErrorCode;
 import cloneproject.Instagram.global.error.exception.BusinessException;
 
-public class InvalidJwtException extends BusinessException{
-    public InvalidJwtException(){
-        super(ErrorCode.INVALID_JWT);
-    }
+public class InvalidJwtException extends BusinessException {
+	public InvalidJwtException() {
+		super(ErrorCode.INVALID_JWT);
+	}
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/exception/InvalidJwtException.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/exception/InvalidJwtException.java
@@ -7,4 +7,5 @@ public class InvalidJwtException extends BusinessException {
 	public InvalidJwtException() {
 		super(ErrorCode.INVALID_JWT);
 	}
+
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/exception/MemberDoesNotExistException.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/exception/MemberDoesNotExistException.java
@@ -7,4 +7,5 @@ public class MemberDoesNotExistException extends BusinessException {
 	public MemberDoesNotExistException() {
 		super(ErrorCode.MEMBER_NOT_FOUND);
 	}
+
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/exception/MemberDoesNotExistException.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/exception/MemberDoesNotExistException.java
@@ -3,8 +3,8 @@ package cloneproject.Instagram.domain.member.exception;
 import cloneproject.Instagram.global.error.ErrorCode;
 import cloneproject.Instagram.global.error.exception.BusinessException;
 
-public class MemberDoesNotExistException extends BusinessException{
-    public MemberDoesNotExistException(){
-        super(ErrorCode.MEMBER_NOT_FOUND);
-    }
+public class MemberDoesNotExistException extends BusinessException {
+	public MemberDoesNotExistException() {
+		super(ErrorCode.MEMBER_NOT_FOUND);
+	}
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/exception/NoConfirmEmailException.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/exception/NoConfirmEmailException.java
@@ -7,4 +7,5 @@ public class NoConfirmEmailException extends BusinessException {
 	public NoConfirmEmailException() {
 		super(ErrorCode.EMAIL_NOT_CONFIRMED);
 	}
+
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/exception/NoConfirmEmailException.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/exception/NoConfirmEmailException.java
@@ -3,8 +3,8 @@ package cloneproject.Instagram.domain.member.exception;
 import cloneproject.Instagram.global.error.ErrorCode;
 import cloneproject.Instagram.global.error.exception.BusinessException;
 
-public class NoConfirmEmailException extends BusinessException{
-    public NoConfirmEmailException(){
-        super(ErrorCode.EMAIL_NOT_CONFIRMED);
-    }
+public class NoConfirmEmailException extends BusinessException {
+	public NoConfirmEmailException() {
+		super(ErrorCode.EMAIL_NOT_CONFIRMED);
+	}
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/exception/PasswordResetFailException.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/exception/PasswordResetFailException.java
@@ -3,8 +3,8 @@ package cloneproject.Instagram.domain.member.exception;
 import cloneproject.Instagram.global.error.ErrorCode;
 import cloneproject.Instagram.global.error.exception.BusinessException;
 
-public class PasswordResetFailException extends BusinessException{
-    public PasswordResetFailException(){
-        super(ErrorCode.PASSWORD_RESET_FAIL);
-    }
+public class PasswordResetFailException extends BusinessException {
+	public PasswordResetFailException() {
+		super(ErrorCode.PASSWORD_RESET_FAIL);
+	}
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/exception/PasswordResetFailException.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/exception/PasswordResetFailException.java
@@ -7,4 +7,5 @@ public class PasswordResetFailException extends BusinessException {
 	public PasswordResetFailException() {
 		super(ErrorCode.PASSWORD_RESET_FAIL);
 	}
+
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/exception/UsernameAlreadyExistException.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/exception/UsernameAlreadyExistException.java
@@ -7,4 +7,5 @@ public class UsernameAlreadyExistException extends BusinessException {
 	public UsernameAlreadyExistException() {
 		super(ErrorCode.USERNAME_ALREADY_EXIST);
 	}
+
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/exception/UsernameAlreadyExistException.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/exception/UsernameAlreadyExistException.java
@@ -3,8 +3,8 @@ package cloneproject.Instagram.domain.member.exception;
 import cloneproject.Instagram.global.error.ErrorCode;
 import cloneproject.Instagram.global.error.exception.BusinessException;
 
-public class UsernameAlreadyExistException extends BusinessException{
-        public UsernameAlreadyExistException(){
-            super(ErrorCode.USERNAME_ALREADY_EXIST);
-        }
+public class UsernameAlreadyExistException extends BusinessException {
+	public UsernameAlreadyExistException() {
+		super(ErrorCode.USERNAME_ALREADY_EXIST);
+	}
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/repository/BlockRepository.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/repository/BlockRepository.java
@@ -5,11 +5,12 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import cloneproject.Instagram.domain.member.entity.Block;
+import cloneproject.Instagram.domain.member.repository.querydsl.BlockRepositoryQuerydsl;
 
-public interface BlockRepository extends JpaRepository<Block, Long> {
+public interface BlockRepository extends JpaRepository<Block, Long>, BlockRepositoryQuerydsl {
 
-	public boolean existsByMemberIdAndBlockMemberId(Long memberId, Long blockMemberId);
+	boolean existsByMemberIdAndBlockMemberId(Long memberId, Long blockMemberId);
 
-	public Optional<Block> findByMemberIdAndBlockMemberId(Long memberId, Long blockMemberId);
+	Optional<Block> findByMemberIdAndBlockMemberId(Long memberId, Long blockMemberId);
 
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/repository/BlockRepository.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/repository/BlockRepository.java
@@ -6,9 +6,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import cloneproject.Instagram.domain.member.entity.Block;
 
-public interface BlockRepository extends JpaRepository<Block, Long>{
+public interface BlockRepository extends JpaRepository<Block, Long> {
 
-    public boolean existsByMemberIdAndBlockMemberId(Long memberId, Long blockMemberId);
-    public Optional<Block> findByMemberIdAndBlockMemberId(Long memberId, Long blockMemberId);
+	public boolean existsByMemberIdAndBlockMemberId(Long memberId, Long blockMemberId);
+
+	public Optional<Block> findByMemberIdAndBlockMemberId(Long memberId, Long blockMemberId);
 
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/repository/MemberRepository.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/repository/MemberRepository.java
@@ -20,4 +20,5 @@ public interface MemberRepository
 	boolean existsByUsername(String username);
 
 	List<Member> findAllByUsernameIn(Collection<String> usernames);
+
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/repository/MemberRepository.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/repository/MemberRepository.java
@@ -4,22 +4,18 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
-import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 import cloneproject.Instagram.domain.member.entity.Member;
 import cloneproject.Instagram.domain.member.repository.querydsl.MemberPostRepositoryQuerydsl;
 import cloneproject.Instagram.domain.member.repository.querydsl.MemberRepositoryQuerydsl;
 
-public interface MemberRepository extends JpaRepository<Member, Long>, JpaSpecificationExecutor<Member>,
-		MemberPostRepositoryQuerydsl, MemberRepositoryQuerydsl {
+public interface MemberRepository
+		extends JpaRepository<Member, Long>, MemberPostRepositoryQuerydsl, MemberRepositoryQuerydsl {
 
 	Optional<Member> findByUsername(String username);
 
 	Optional<Member> findById(Long id);
-
-	List<Member> findAll(Specification<Member> spec);
 
 	boolean existsByUsername(String username);
 

--- a/src/main/java/cloneproject/Instagram/domain/member/repository/querydsl/BlockRepositoryQuerydsl.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/repository/querydsl/BlockRepositoryQuerydsl.java
@@ -1,0 +1,7 @@
+package cloneproject.Instagram.domain.member.repository.querydsl;
+
+public interface BlockRepositoryQuerydsl {
+
+    boolean isBlockingOrIsBlocked(Long loginUserId, Long targetMemberId);
+
+}

--- a/src/main/java/cloneproject/Instagram/domain/member/repository/querydsl/BlockRepositoryQuerydslImpl.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/repository/querydsl/BlockRepositoryQuerydslImpl.java
@@ -1,0 +1,26 @@
+package cloneproject.Instagram.domain.member.repository.querydsl;
+
+import lombok.RequiredArgsConstructor;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import static cloneproject.Instagram.domain.member.entity.QBlock.block;
+
+@RequiredArgsConstructor
+public class BlockRepositoryQuerydslImpl implements BlockRepositoryQuerydsl {
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public boolean isBlockingOrIsBlocked(Long loginUserId, Long targetMemberId) {
+		Integer result = queryFactory
+			.selectOne()
+			.from(block)
+			.where((block.member.id.eq(loginUserId).and(block.blockMember.id.eq(targetMemberId)))
+				.or(block.member.id.eq(targetMemberId).and(block.blockMember.id.eq(loginUserId))))
+			.fetchFirst();
+
+		return result != null;
+	}
+
+}

--- a/src/main/java/cloneproject/Instagram/domain/member/repository/querydsl/BlockRepositoryQuerydslImpl.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/repository/querydsl/BlockRepositoryQuerydslImpl.java
@@ -13,7 +13,7 @@ public class BlockRepositoryQuerydslImpl implements BlockRepositoryQuerydsl {
 
 	@Override
 	public boolean isBlockingOrIsBlocked(Long loginUserId, Long targetMemberId) {
-		Integer result = queryFactory
+		final Integer result = queryFactory
 			.selectOne()
 			.from(block)
 			.where((block.member.id.eq(loginUserId).and(block.blockMember.id.eq(targetMemberId)))

--- a/src/main/java/cloneproject/Instagram/domain/member/repository/querydsl/MemberPostRepositoryQuerydsl.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/repository/querydsl/MemberPostRepositoryQuerydsl.java
@@ -8,14 +8,17 @@ import org.springframework.data.domain.Pageable;
 import cloneproject.Instagram.domain.feed.dto.MemberPostDTO;
 
 public interface MemberPostRepositoryQuerydsl {
-    
-    List<MemberPostDTO> getRecent15PostDTOs(Long loginedUserId, String username);
-    Page<MemberPostDTO> getMemberPostDto(Long loginedUserId, String username, Pageable pageable);
 
-    List<MemberPostDTO> getRecent15SavedPostDTOs(Long loginedUserId);
-    Page<MemberPostDTO> getMemberSavedPostDto(Long loginedUserId, Pageable pageable);
+	List<MemberPostDTO> getRecent15PostDTOs(Long loginedUserId, String username);
 
-    List<MemberPostDTO> getRecent15TaggedPostDTOs(Long loginedUserId, String username);
-    Page<MemberPostDTO> getMemberTaggedPostDto(Long loginedUserId, String username, Pageable pageable);
-    
+	Page<MemberPostDTO> getMemberPostDto(Long loginedUserId, String username, Pageable pageable);
+
+	List<MemberPostDTO> getRecent15SavedPostDTOs(Long loginedUserId);
+
+	Page<MemberPostDTO> getMemberSavedPostDto(Long loginedUserId, Pageable pageable);
+
+	List<MemberPostDTO> getRecent15TaggedPostDTOs(Long loginedUserId, String username);
+
+	Page<MemberPostDTO> getMemberTaggedPostDto(Long loginedUserId, String username, Pageable pageable);
+
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/repository/querydsl/MemberPostRepositoryQuerydsl.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/repository/querydsl/MemberPostRepositoryQuerydsl.java
@@ -1,7 +1,5 @@
 package cloneproject.Instagram.domain.member.repository.querydsl;
 
-import java.util.List;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -9,16 +7,10 @@ import cloneproject.Instagram.domain.feed.dto.MemberPostDTO;
 
 public interface MemberPostRepositoryQuerydsl {
 
-	List<MemberPostDTO> getRecent15PostDTOs(Long loginedUserId, String username);
+	Page<MemberPostDTO> getMemberPostDTOs(String username, Pageable pageable);
 
-	Page<MemberPostDTO> getMemberPostDto(Long loginedUserId, String username, Pageable pageable);
+	Page<MemberPostDTO> getMemberSavedPostDTOs(Long loginUserId, Pageable pageable);
 
-	List<MemberPostDTO> getRecent15SavedPostDTOs(Long loginedUserId);
-
-	Page<MemberPostDTO> getMemberSavedPostDto(Long loginedUserId, Pageable pageable);
-
-	List<MemberPostDTO> getRecent15TaggedPostDTOs(Long loginedUserId, String username);
-
-	Page<MemberPostDTO> getMemberTaggedPostDto(Long loginedUserId, String username, Pageable pageable);
+	Page<MemberPostDTO> getMemberTaggedPostDTOs(String username, Pageable pageable);
 
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/repository/querydsl/MemberPostRepositoryQuerydslImpl.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/repository/querydsl/MemberPostRepositoryQuerydslImpl.java
@@ -1,8 +1,6 @@
 package cloneproject.Instagram.domain.member.repository.querydsl;
 
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
@@ -11,14 +9,10 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
 import cloneproject.Instagram.domain.feed.dto.MemberPostDTO;
-import cloneproject.Instagram.domain.feed.dto.PostImageDTO;
 import cloneproject.Instagram.domain.feed.dto.QMemberPostDTO;
-import cloneproject.Instagram.domain.feed.dto.QPostImageDTO;
 import lombok.RequiredArgsConstructor;
 
-import static cloneproject.Instagram.domain.member.entity.QMember.member;
 import static cloneproject.Instagram.domain.feed.entity.QPost.post;
-import static cloneproject.Instagram.domain.feed.entity.QPostImage.postImage;
 import static cloneproject.Instagram.domain.feed.entity.QBookmark.bookmark;
 import static cloneproject.Instagram.domain.feed.entity.QPostTag.postTag;
 
@@ -28,239 +22,71 @@ public class MemberPostRepositoryQuerydslImpl implements MemberPostRepositoryQue
 	private final JPAQueryFactory queryFactory;
 
 	@Override
-	public List<MemberPostDTO> getRecent15PostDTOs(Long loginedUserId, String username) {
+	public Page<MemberPostDTO> getMemberPostDTOs(String username, Pageable pageable) {
 		final List<MemberPostDTO> posts = queryFactory
-				.select(new QMemberPostDTO(
-						post.id,
-						post.postImages.size().gt(1),
-						post.comments.size(),
-						post.postLikes.size()))
-				.from(post, member)
-				.where(post.member.username.eq(username))
-				.limit(15)
-				.orderBy(post.id.desc())
-				.distinct()
-				.fetch();
-
-		final List<Long> postIds = posts.stream()
-				.map(MemberPostDTO::getPostId)
-				.collect(Collectors.toList());
-
-		final List<PostImageDTO> postImageDTOs = queryFactory
-				.select(new QPostImageDTO(
-						postImage.post.id,
-						postImage.id,
-						postImage.image.imageUrl,
-						postImage.altText))
-				.from(postImage)
-				.where(postImage.post.id.in(postIds))
-				.fetch();
-
-		final Map<Long, List<PostImageDTO>> postImageDTOMap = postImageDTOs.stream()
-				.collect(Collectors.groupingBy(PostImageDTO::getPostId));
-
-		posts.forEach(p -> p.setImageUrl(postImageDTOMap.get(p.getPostId()).get(0).getPostImageUrl()));
-		return posts;
-	}
-
-	@Override
-	public Page<MemberPostDTO> getMemberPostDto(Long loginedUserId, String username, Pageable pageable) {
-		final List<MemberPostDTO> posts = queryFactory
-				.select(new QMemberPostDTO(
-						post.id,
-						post.postImages.size().gt(1),
-						post.comments.size(),
-						post.postLikes.size()))
-				.from(post)
-				.where(post.member.username.eq(username))
-				.offset(pageable.getOffset())
-				.limit(pageable.getPageSize())
-				.orderBy(post.id.desc())
-				.distinct()
-				.fetch();
+			.select(new QMemberPostDTO(
+				post.id,
+				post.postImages.size().gt(1),
+				post.comments.size(),
+				post.postLikes.size()))
+			.from(post)
+			.where(post.member.username.eq(username))
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.orderBy(post.id.desc())
+			.distinct()
+			.fetch();
 
 		final long total = queryFactory
-				.selectFrom(post)
-				.where(post.member.username.eq(username))
-				.fetchCount();
-
-		final List<Long> postIds = posts.stream()
-				.map(MemberPostDTO::getPostId)
-				.collect(Collectors.toList());
-
-		final List<PostImageDTO> postImageDTOs = queryFactory
-				.select(new QPostImageDTO(
-						postImage.post.id,
-						postImage.id,
-						postImage.image.imageUrl,
-						postImage.altText))
-				.from(postImage)
-				.where(postImage.post.id.in(postIds))
-				.fetch();
-
-		final Map<Long, List<PostImageDTO>> postImageDTOMap = postImageDTOs.stream()
-				.collect(Collectors.groupingBy(PostImageDTO::getPostId));
-
-		posts.forEach(p -> p.setImageUrl(postImageDTOMap.get(p.getPostId()).get(0).getPostImageUrl()));
-
+			.selectFrom(post)
+			.where(post.member.username.eq(username))
+			.fetchCount();
 		return new PageImpl<>(posts, pageable, total);
 	}
 
 	@Override
-	public List<MemberPostDTO> getRecent15SavedPostDTOs(Long loginedUserId) {
+	public Page<MemberPostDTO> getMemberSavedPostDTOs(Long loginUserId, Pageable pageable) {
 		final List<MemberPostDTO> posts = queryFactory
-				.select(new QMemberPostDTO(
-						bookmark.post.id,
-						bookmark.post.postImages.size().gt(1),
-						bookmark.post.comments.size(),
-						bookmark.post.postLikes.size()))
-				.from(bookmark)
-				.where(bookmark.member.id.eq(loginedUserId))
-				.limit(15)
-				.orderBy(bookmark.post.id.desc())
-				.distinct()
-				.fetch();
-
-		final List<Long> postIds = posts.stream()
-				.map(MemberPostDTO::getPostId)
-				.collect(Collectors.toList());
-
-		final List<PostImageDTO> postImageDTOs = queryFactory
-				.select(new QPostImageDTO(
-						postImage.post.id,
-						postImage.id,
-						postImage.image.imageUrl,
-						postImage.altText))
-				.from(postImage)
-				.where(postImage.post.id.in(postIds))
-				.fetch();
-
-		final Map<Long, List<PostImageDTO>> postImageDTOMap = postImageDTOs.stream()
-				.collect(Collectors.groupingBy(PostImageDTO::getPostId));
-
-		posts.forEach(p -> p.setImageUrl(postImageDTOMap.get(p.getPostId()).get(0).getPostImageUrl()));
-		return posts;
-	}
-
-	@Override
-	public Page<MemberPostDTO> getMemberSavedPostDto(Long loginedUserId, Pageable pageable) {
-		final List<MemberPostDTO> posts = queryFactory
-				.select(new QMemberPostDTO(
-						bookmark.post.id,
-						bookmark.post.postImages.size().gt(1),
-						bookmark.post.comments.size(),
-						bookmark.post.postLikes.size()))
-				.from(bookmark)
-				.where(bookmark.member.id.eq(loginedUserId))
-				.offset(pageable.getOffset())
-				.limit(pageable.getPageSize())
-				.orderBy(bookmark.post.id.desc())
-				.distinct()
-				.fetch();
+			.select(new QMemberPostDTO(
+				bookmark.post.id,
+				bookmark.post.postImages.size().gt(1),
+				bookmark.post.comments.size(),
+				bookmark.post.postLikes.size()))
+			.from(bookmark)
+			.where(bookmark.member.id.eq(loginUserId))
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.orderBy(bookmark.post.id.desc())
+			.distinct()
+			.fetch();
 
 		final long total = queryFactory
-				.selectFrom(bookmark)
-				.where(bookmark.member.id.eq(loginedUserId))
-				.fetchCount();
-
-		final List<Long> postIds = posts.stream()
-				.map(MemberPostDTO::getPostId)
-				.collect(Collectors.toList());
-
-		final List<PostImageDTO> postImageDTOs = queryFactory
-				.select(new QPostImageDTO(
-						postImage.post.id,
-						postImage.id,
-						postImage.image.imageUrl,
-						postImage.altText))
-				.from(postImage)
-				.where(postImage.post.id.in(postIds))
-				.fetch();
-
-		final Map<Long, List<PostImageDTO>> postImageDTOMap = postImageDTOs.stream()
-				.collect(Collectors.groupingBy(PostImageDTO::getPostId));
-
-		posts.forEach(p -> p.setImageUrl(postImageDTOMap.get(p.getPostId()).get(0).getPostImageUrl()));
-
+			.selectFrom(bookmark)
+			.where(bookmark.member.id.eq(loginUserId))
+			.fetchCount();
 		return new PageImpl<>(posts, pageable, total);
 	}
 
 	@Override
-	public List<MemberPostDTO> getRecent15TaggedPostDTOs(Long loginedUserId, String username) {
+	public Page<MemberPostDTO> getMemberTaggedPostDTOs(String username, Pageable pageable) {
 		final List<MemberPostDTO> posts = queryFactory
-				.select(new QMemberPostDTO(
-						postTag.postImage.post.id,
-						postTag.postImage.post.postImages.size().gt(1),
-						postTag.postImage.post.comments.size(),
-						postTag.postImage.post.postLikes.size()))
-				.from(postTag)
-				.where(postTag.tag.username.eq(username))
-				.limit(15)
-				.orderBy(postTag.postImage.post.id.desc())
-				.distinct()
-				.fetch();
-
-		final List<Long> postIds = posts.stream()
-				.map(MemberPostDTO::getPostId)
-				.collect(Collectors.toList());
-
-		final List<PostImageDTO> postImageDTOs = queryFactory
-				.select(new QPostImageDTO(
-						postImage.post.id,
-						postImage.id,
-						postImage.image.imageUrl,
-						postImage.altText))
-				.from(postImage)
-				.where(postImage.post.id.in(postIds))
-				.fetch();
-
-		final Map<Long, List<PostImageDTO>> postImageDTOMap = postImageDTOs.stream()
-				.collect(Collectors.groupingBy(PostImageDTO::getPostId));
-
-		posts.forEach(p -> p.setImageUrl(postImageDTOMap.get(p.getPostId()).get(0).getPostImageUrl()));
-		return posts;
-	}
-
-	@Override
-	public Page<MemberPostDTO> getMemberTaggedPostDto(Long loginedUserId, String username, Pageable pageable) {
-		final List<MemberPostDTO> posts = queryFactory
-				.select(new QMemberPostDTO(
-						postTag.postImage.post.id,
-						postTag.postImage.post.postImages.size().gt(1),
-						postTag.postImage.post.comments.size(),
-						postTag.postImage.post.postLikes.size()))
-				.from(postTag)
-				.where(postTag.tag.username.eq(username))
-				.offset(pageable.getOffset())
-				.limit(pageable.getPageSize())
-				.orderBy(postTag.postImage.post.id.desc())
-				.distinct()
-				.fetch();
+			.select(new QMemberPostDTO(
+				postTag.postImage.post.id,
+				postTag.postImage.post.postImages.size().gt(1),
+				postTag.postImage.post.comments.size(),
+				postTag.postImage.post.postLikes.size()))
+			.from(postTag)
+			.where(postTag.tag.username.eq(username))
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.orderBy(postTag.postImage.post.id.desc())
+			.distinct()
+			.fetch();
 
 		final long total = queryFactory
-				.selectFrom(postTag)
-				.where(postTag.tag.username.eq(username))
-				.fetchCount();
-
-		final List<Long> postIds = posts.stream()
-				.map(MemberPostDTO::getPostId)
-				.collect(Collectors.toList());
-
-		final List<PostImageDTO> postImageDTOs = queryFactory
-				.select(new QPostImageDTO(
-						postImage.post.id,
-						postImage.id,
-						postImage.image.imageUrl,
-						postImage.altText))
-				.from(postImage)
-				.where(postImage.post.id.in(postIds))
-				.fetch();
-
-		final Map<Long, List<PostImageDTO>> postImageDTOMap = postImageDTOs.stream()
-				.collect(Collectors.groupingBy(PostImageDTO::getPostId));
-
-		posts.forEach(p -> p.setImageUrl(postImageDTOMap.get(p.getPostId()).get(0).getPostImageUrl()));
-
+			.selectFrom(postTag)
+			.where(postTag.tag.username.eq(username))
+			.fetchCount();
 		return new PageImpl<>(posts, pageable, total);
 	}
 

--- a/src/main/java/cloneproject/Instagram/domain/member/repository/querydsl/MemberPostRepositoryQuerydslImpl.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/repository/querydsl/MemberPostRepositoryQuerydslImpl.java
@@ -23,254 +23,245 @@ import static cloneproject.Instagram.domain.feed.entity.QBookmark.bookmark;
 import static cloneproject.Instagram.domain.feed.entity.QPostTag.postTag;
 
 @RequiredArgsConstructor
-public class MemberPostRepositoryQuerydslImpl implements MemberPostRepositoryQuerydsl{
-    
-    private final JPAQueryFactory queryFactory;
-    
-    @Override
-    public List<MemberPostDTO> getRecent15PostDTOs(Long loginedUserId, String username){
-        final List<MemberPostDTO> posts = queryFactory
-                                            .select(new QMemberPostDTO(
-                                                post.id, 
-                                                post.postImages.size().gt(1), 
-                                                post.comments.size(), 
-                                                post.postLikes.size()))
-                                            .from(post, member)
-                                            .where(post.member.username.eq(username))
-                                            .limit(15)
-                                            .orderBy(post.id.desc())
-                                            .distinct()
-                                            .fetch();
-        
-        final List<Long> postIds = posts.stream()
-                                    .map(MemberPostDTO::getPostId)
-                                    .collect(Collectors.toList());
+public class MemberPostRepositoryQuerydslImpl implements MemberPostRepositoryQuerydsl {
 
-        final List<PostImageDTO> postImageDTOs = queryFactory
-                                    .select(new QPostImageDTO(
-                                            postImage.post.id,
-                                            postImage.id,
-                                            postImage.image.imageUrl,
-                                            postImage.altText
-                                    ))
-                                    .from(postImage)
-                                    .where(postImage.post.id.in(postIds))
-                                    .fetch();
+	private final JPAQueryFactory queryFactory;
 
-        final Map<Long, List<PostImageDTO>> postImageDTOMap = postImageDTOs.stream()
-                                                                .collect(Collectors.groupingBy(PostImageDTO::getPostId));
-                                        
-        posts.forEach(p->p.setImageUrl(postImageDTOMap.get(p.getPostId()).get(0).getPostImageUrl()));
-        return posts;
-    }
-    
-    @Override
-    public Page<MemberPostDTO> getMemberPostDto(Long loginedUserId, String username, Pageable pageable){
-        final List<MemberPostDTO> posts = queryFactory
-                                            .select(new QMemberPostDTO(
-                                                post.id, 
-                                                post.postImages.size().gt(1), 
-                                                post.comments.size(), 
-                                                post.postLikes.size()))
-                                            .from(post)
-                                            .where(post.member.username.eq(username))
-                                            .offset(pageable.getOffset())
-                                            .limit(pageable.getPageSize())
-                                            .orderBy(post.id.desc())
-                                            .distinct()
-                                            .fetch();
+	@Override
+	public List<MemberPostDTO> getRecent15PostDTOs(Long loginedUserId, String username) {
+		final List<MemberPostDTO> posts = queryFactory
+				.select(new QMemberPostDTO(
+						post.id,
+						post.postImages.size().gt(1),
+						post.comments.size(),
+						post.postLikes.size()))
+				.from(post, member)
+				.where(post.member.username.eq(username))
+				.limit(15)
+				.orderBy(post.id.desc())
+				.distinct()
+				.fetch();
 
-        final long total = queryFactory
-                .selectFrom(post)
-                .where(post.member.username.eq(username))
-                .fetchCount();
+		final List<Long> postIds = posts.stream()
+				.map(MemberPostDTO::getPostId)
+				.collect(Collectors.toList());
 
-        final List<Long> postIds = posts.stream()
-                                    .map(MemberPostDTO::getPostId)
-                                    .collect(Collectors.toList());
+		final List<PostImageDTO> postImageDTOs = queryFactory
+				.select(new QPostImageDTO(
+						postImage.post.id,
+						postImage.id,
+						postImage.image.imageUrl,
+						postImage.altText))
+				.from(postImage)
+				.where(postImage.post.id.in(postIds))
+				.fetch();
 
-        final List<PostImageDTO> postImageDTOs = queryFactory
-                                    .select(new QPostImageDTO(
-                                            postImage.post.id,
-                                            postImage.id,
-                                            postImage.image.imageUrl,
-                                            postImage.altText
-                                    ))
-                                    .from(postImage)
-                                    .where(postImage.post.id.in(postIds))
-                                    .fetch();
+		final Map<Long, List<PostImageDTO>> postImageDTOMap = postImageDTOs.stream()
+				.collect(Collectors.groupingBy(PostImageDTO::getPostId));
 
-        final Map<Long, List<PostImageDTO>> postImageDTOMap = postImageDTOs.stream()
-                                                                .collect(Collectors.groupingBy(PostImageDTO::getPostId));
-    
-        posts.forEach(p->p.setImageUrl(postImageDTOMap.get(p.getPostId()).get(0).getPostImageUrl()));    
-                            
-        
-        return new PageImpl<>(posts, pageable, total);
-    }
+		posts.forEach(p -> p.setImageUrl(postImageDTOMap.get(p.getPostId()).get(0).getPostImageUrl()));
+		return posts;
+	}
 
-    @Override
-    public List<MemberPostDTO> getRecent15SavedPostDTOs(Long loginedUserId){
-        final List<MemberPostDTO> posts = queryFactory
-                                            .select(new QMemberPostDTO(
-                                                bookmark.post.id, 
-                                                bookmark.post.postImages.size().gt(1), 
-                                                bookmark.post.comments.size(), 
-                                                bookmark.post.postLikes.size()))
-                                            .from(bookmark)
-                                            .where(bookmark.member.id.eq(loginedUserId))
-                                            .limit(15)
-                                            .orderBy(bookmark.post.id.desc())
-                                            .distinct()
-                                            .fetch();
+	@Override
+	public Page<MemberPostDTO> getMemberPostDto(Long loginedUserId, String username, Pageable pageable) {
+		final List<MemberPostDTO> posts = queryFactory
+				.select(new QMemberPostDTO(
+						post.id,
+						post.postImages.size().gt(1),
+						post.comments.size(),
+						post.postLikes.size()))
+				.from(post)
+				.where(post.member.username.eq(username))
+				.offset(pageable.getOffset())
+				.limit(pageable.getPageSize())
+				.orderBy(post.id.desc())
+				.distinct()
+				.fetch();
 
-        final List<Long> postIds = posts.stream()
-                                    .map(MemberPostDTO::getPostId)
-                                    .collect(Collectors.toList());
+		final long total = queryFactory
+				.selectFrom(post)
+				.where(post.member.username.eq(username))
+				.fetchCount();
 
-        final List<PostImageDTO> postImageDTOs = queryFactory
-                                    .select(new QPostImageDTO(
-                                            postImage.post.id,
-                                            postImage.id,
-                                            postImage.image.imageUrl,
-                                            postImage.altText
-                                    ))
-                                    .from(postImage)
-                                    .where(postImage.post.id.in(postIds))
-                                    .fetch();
+		final List<Long> postIds = posts.stream()
+				.map(MemberPostDTO::getPostId)
+				.collect(Collectors.toList());
 
-        final Map<Long, List<PostImageDTO>> postImageDTOMap = postImageDTOs.stream()
-                                                                .collect(Collectors.groupingBy(PostImageDTO::getPostId));
-                                        
-        posts.forEach(p->p.setImageUrl(postImageDTOMap.get(p.getPostId()).get(0).getPostImageUrl()));
-        return posts;
-    }
+		final List<PostImageDTO> postImageDTOs = queryFactory
+				.select(new QPostImageDTO(
+						postImage.post.id,
+						postImage.id,
+						postImage.image.imageUrl,
+						postImage.altText))
+				.from(postImage)
+				.where(postImage.post.id.in(postIds))
+				.fetch();
 
-    @Override
-    public Page<MemberPostDTO> getMemberSavedPostDto(Long loginedUserId, Pageable pageable){
-        final List<MemberPostDTO> posts = queryFactory
-                                            .select(new QMemberPostDTO(
-                                                bookmark.post.id, 
-                                                bookmark.post.postImages.size().gt(1), 
-                                                bookmark.post.comments.size(), 
-                                                bookmark.post.postLikes.size()))
-                                            .from(bookmark)
-                                            .where(bookmark.member.id.eq(loginedUserId))
-                                            .offset(pageable.getOffset())
-                                            .limit(pageable.getPageSize())
-                                            .orderBy(bookmark.post.id.desc())
-                                            .distinct()
-                                            .fetch();
+		final Map<Long, List<PostImageDTO>> postImageDTOMap = postImageDTOs.stream()
+				.collect(Collectors.groupingBy(PostImageDTO::getPostId));
 
-        final long total = queryFactory
-                .selectFrom(bookmark)
-                .where(bookmark.member.id.eq(loginedUserId))
-                .fetchCount();
+		posts.forEach(p -> p.setImageUrl(postImageDTOMap.get(p.getPostId()).get(0).getPostImageUrl()));
 
-        final List<Long> postIds = posts.stream()
-                                    .map(MemberPostDTO::getPostId)
-                                    .collect(Collectors.toList());
+		return new PageImpl<>(posts, pageable, total);
+	}
 
-        final List<PostImageDTO> postImageDTOs = queryFactory
-                                    .select(new QPostImageDTO(
-                                            postImage.post.id,
-                                            postImage.id,
-                                            postImage.image.imageUrl,
-                                            postImage.altText
-                                    ))
-                                    .from(postImage)
-                                    .where(postImage.post.id.in(postIds))
-                                    .fetch();
+	@Override
+	public List<MemberPostDTO> getRecent15SavedPostDTOs(Long loginedUserId) {
+		final List<MemberPostDTO> posts = queryFactory
+				.select(new QMemberPostDTO(
+						bookmark.post.id,
+						bookmark.post.postImages.size().gt(1),
+						bookmark.post.comments.size(),
+						bookmark.post.postLikes.size()))
+				.from(bookmark)
+				.where(bookmark.member.id.eq(loginedUserId))
+				.limit(15)
+				.orderBy(bookmark.post.id.desc())
+				.distinct()
+				.fetch();
 
-        final Map<Long, List<PostImageDTO>> postImageDTOMap = postImageDTOs.stream()
-                                                                .collect(Collectors.groupingBy(PostImageDTO::getPostId));
-    
-        posts.forEach(p->p.setImageUrl(postImageDTOMap.get(p.getPostId()).get(0).getPostImageUrl()));    
-                            
-        
-        return new PageImpl<>(posts, pageable, total);
-    }
+		final List<Long> postIds = posts.stream()
+				.map(MemberPostDTO::getPostId)
+				.collect(Collectors.toList());
 
-    @Override
-    public List<MemberPostDTO> getRecent15TaggedPostDTOs(Long loginedUserId, String username){
-        final List<MemberPostDTO> posts = queryFactory
-                                            .select(new QMemberPostDTO(
-                                                postTag.postImage.post.id, 
-                                                postTag.postImage.post.postImages.size().gt(1), 
-                                                postTag.postImage.post.comments.size(), 
-                                                postTag.postImage.post.postLikes.size()))
-                                            .from(postTag)
-                                            .where(postTag.tag.username.eq(username))
-                                            .limit(15)
-                                            .orderBy(postTag.postImage.post.id.desc())
-                                            .distinct()
-                                            .fetch();
-        
-        final List<Long> postIds = posts.stream()
-                                    .map(MemberPostDTO::getPostId)
-                                    .collect(Collectors.toList());
+		final List<PostImageDTO> postImageDTOs = queryFactory
+				.select(new QPostImageDTO(
+						postImage.post.id,
+						postImage.id,
+						postImage.image.imageUrl,
+						postImage.altText))
+				.from(postImage)
+				.where(postImage.post.id.in(postIds))
+				.fetch();
 
-        final List<PostImageDTO> postImageDTOs = queryFactory
-                                    .select(new QPostImageDTO(
-                                            postImage.post.id,
-                                            postImage.id,
-                                            postImage.image.imageUrl,
-                                            postImage.altText
-                                    ))
-                                    .from(postImage)
-                                    .where(postImage.post.id.in(postIds))
-                                    .fetch();
+		final Map<Long, List<PostImageDTO>> postImageDTOMap = postImageDTOs.stream()
+				.collect(Collectors.groupingBy(PostImageDTO::getPostId));
 
-        final Map<Long, List<PostImageDTO>> postImageDTOMap = postImageDTOs.stream()
-                                                                .collect(Collectors.groupingBy(PostImageDTO::getPostId));
-                                        
-        posts.forEach(p->p.setImageUrl(postImageDTOMap.get(p.getPostId()).get(0).getPostImageUrl()));
-        return posts;
-    }
+		posts.forEach(p -> p.setImageUrl(postImageDTOMap.get(p.getPostId()).get(0).getPostImageUrl()));
+		return posts;
+	}
 
-    @Override
-    public Page<MemberPostDTO> getMemberTaggedPostDto(Long loginedUserId, String username, Pageable pageable){
-        final List<MemberPostDTO> posts = queryFactory
-                                            .select(new QMemberPostDTO(
-                                                postTag.postImage.post.id, 
-                                                postTag.postImage.post.postImages.size().gt(1), 
-                                                postTag.postImage.post.comments.size(), 
-                                                postTag.postImage.post.postLikes.size()))
-                                            .from(postTag)
-                                            .where(postTag.tag.username.eq(username))
-                                            .offset(pageable.getOffset())
-                                            .limit(pageable.getPageSize())
-                                            .orderBy(postTag.postImage.post.id.desc())
-                                            .distinct()
-                                            .fetch();
+	@Override
+	public Page<MemberPostDTO> getMemberSavedPostDto(Long loginedUserId, Pageable pageable) {
+		final List<MemberPostDTO> posts = queryFactory
+				.select(new QMemberPostDTO(
+						bookmark.post.id,
+						bookmark.post.postImages.size().gt(1),
+						bookmark.post.comments.size(),
+						bookmark.post.postLikes.size()))
+				.from(bookmark)
+				.where(bookmark.member.id.eq(loginedUserId))
+				.offset(pageable.getOffset())
+				.limit(pageable.getPageSize())
+				.orderBy(bookmark.post.id.desc())
+				.distinct()
+				.fetch();
 
-        final long total = queryFactory
-                .selectFrom(postTag)
-                .where(postTag.tag.username.eq(username))
-                .fetchCount();
+		final long total = queryFactory
+				.selectFrom(bookmark)
+				.where(bookmark.member.id.eq(loginedUserId))
+				.fetchCount();
 
-        final List<Long> postIds = posts.stream()
-                                    .map(MemberPostDTO::getPostId)
-                                    .collect(Collectors.toList());
+		final List<Long> postIds = posts.stream()
+				.map(MemberPostDTO::getPostId)
+				.collect(Collectors.toList());
 
-        final List<PostImageDTO> postImageDTOs = queryFactory
-                                    .select(new QPostImageDTO(
-                                            postImage.post.id,
-                                            postImage.id,
-                                            postImage.image.imageUrl,
-                                            postImage.altText
-                                    ))
-                                    .from(postImage)
-                                    .where(postImage.post.id.in(postIds))
-                                    .fetch();
+		final List<PostImageDTO> postImageDTOs = queryFactory
+				.select(new QPostImageDTO(
+						postImage.post.id,
+						postImage.id,
+						postImage.image.imageUrl,
+						postImage.altText))
+				.from(postImage)
+				.where(postImage.post.id.in(postIds))
+				.fetch();
 
-        final Map<Long, List<PostImageDTO>> postImageDTOMap = postImageDTOs.stream()
-                                                                .collect(Collectors.groupingBy(PostImageDTO::getPostId));
-    
-        posts.forEach(p->p.setImageUrl(postImageDTOMap.get(p.getPostId()).get(0).getPostImageUrl()));    
-                            
-        
-        return new PageImpl<>(posts, pageable, total);
-    }
-    
+		final Map<Long, List<PostImageDTO>> postImageDTOMap = postImageDTOs.stream()
+				.collect(Collectors.groupingBy(PostImageDTO::getPostId));
+
+		posts.forEach(p -> p.setImageUrl(postImageDTOMap.get(p.getPostId()).get(0).getPostImageUrl()));
+
+		return new PageImpl<>(posts, pageable, total);
+	}
+
+	@Override
+	public List<MemberPostDTO> getRecent15TaggedPostDTOs(Long loginedUserId, String username) {
+		final List<MemberPostDTO> posts = queryFactory
+				.select(new QMemberPostDTO(
+						postTag.postImage.post.id,
+						postTag.postImage.post.postImages.size().gt(1),
+						postTag.postImage.post.comments.size(),
+						postTag.postImage.post.postLikes.size()))
+				.from(postTag)
+				.where(postTag.tag.username.eq(username))
+				.limit(15)
+				.orderBy(postTag.postImage.post.id.desc())
+				.distinct()
+				.fetch();
+
+		final List<Long> postIds = posts.stream()
+				.map(MemberPostDTO::getPostId)
+				.collect(Collectors.toList());
+
+		final List<PostImageDTO> postImageDTOs = queryFactory
+				.select(new QPostImageDTO(
+						postImage.post.id,
+						postImage.id,
+						postImage.image.imageUrl,
+						postImage.altText))
+				.from(postImage)
+				.where(postImage.post.id.in(postIds))
+				.fetch();
+
+		final Map<Long, List<PostImageDTO>> postImageDTOMap = postImageDTOs.stream()
+				.collect(Collectors.groupingBy(PostImageDTO::getPostId));
+
+		posts.forEach(p -> p.setImageUrl(postImageDTOMap.get(p.getPostId()).get(0).getPostImageUrl()));
+		return posts;
+	}
+
+	@Override
+	public Page<MemberPostDTO> getMemberTaggedPostDto(Long loginedUserId, String username, Pageable pageable) {
+		final List<MemberPostDTO> posts = queryFactory
+				.select(new QMemberPostDTO(
+						postTag.postImage.post.id,
+						postTag.postImage.post.postImages.size().gt(1),
+						postTag.postImage.post.comments.size(),
+						postTag.postImage.post.postLikes.size()))
+				.from(postTag)
+				.where(postTag.tag.username.eq(username))
+				.offset(pageable.getOffset())
+				.limit(pageable.getPageSize())
+				.orderBy(postTag.postImage.post.id.desc())
+				.distinct()
+				.fetch();
+
+		final long total = queryFactory
+				.selectFrom(postTag)
+				.where(postTag.tag.username.eq(username))
+				.fetchCount();
+
+		final List<Long> postIds = posts.stream()
+				.map(MemberPostDTO::getPostId)
+				.collect(Collectors.toList());
+
+		final List<PostImageDTO> postImageDTOs = queryFactory
+				.select(new QPostImageDTO(
+						postImage.post.id,
+						postImage.id,
+						postImage.image.imageUrl,
+						postImage.altText))
+				.from(postImage)
+				.where(postImage.post.id.in(postIds))
+				.fetch();
+
+		final Map<Long, List<PostImageDTO>> postImageDTOMap = postImageDTOs.stream()
+				.collect(Collectors.groupingBy(PostImageDTO::getPostId));
+
+		posts.forEach(p -> p.setImageUrl(postImageDTOMap.get(p.getPostId()).get(0).getPostImageUrl()));
+
+		return new PageImpl<>(posts, pageable, total);
+	}
+
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/repository/querydsl/MemberRepositoryQuerydsl.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/repository/querydsl/MemberRepositoryQuerydsl.java
@@ -1,6 +1,5 @@
 package cloneproject.Instagram.domain.member.repository.querydsl;
 
-
 import java.util.List;
 
 import cloneproject.Instagram.domain.member.dto.MiniProfileResponse;
@@ -8,9 +7,11 @@ import cloneproject.Instagram.domain.member.dto.UserProfileResponse;
 import cloneproject.Instagram.domain.member.entity.Member;
 
 public interface MemberRepositoryQuerydsl {
-    
-    UserProfileResponse getUserProfile(Long loginedUserId, String username);
-    MiniProfileResponse getMiniProfile(Long loginedUserId, String username);
-    List<Member> findAllByUsernames(List<String> usernames);
+
+	UserProfileResponse getUserProfile(Long loginedUserId, String username);
+
+	MiniProfileResponse getMiniProfile(Long loginedUserId, String username);
+
+	List<Member> findAllByUsernames(List<String> usernames);
 
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/repository/querydsl/MemberRepositoryQuerydsl.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/repository/querydsl/MemberRepositoryQuerydsl.java
@@ -8,9 +8,9 @@ import cloneproject.Instagram.domain.member.entity.Member;
 
 public interface MemberRepositoryQuerydsl {
 
-	UserProfileResponse getUserProfile(Long loginedUserId, String username);
+	UserProfileResponse getUserProfile(Long loginUserId, String username);
 
-	MiniProfileResponse getMiniProfile(Long loginedUserId, String username);
+	MiniProfileResponse getMiniProfile(Long loginUserId, String username);
 
 	List<Member> findAllByUsernames(List<String> usernames);
 

--- a/src/main/java/cloneproject/Instagram/domain/member/repository/querydsl/MemberRepositoryQuerydslImpl.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/repository/querydsl/MemberRepositoryQuerydslImpl.java
@@ -1,12 +1,5 @@
 package cloneproject.Instagram.domain.member.repository.querydsl;
 
-import cloneproject.Instagram.domain.member.dto.MiniProfileResponse;
-import cloneproject.Instagram.domain.member.dto.QMiniProfileResponse;
-import cloneproject.Instagram.domain.member.dto.QUserProfileResponse;
-import cloneproject.Instagram.domain.member.dto.UserProfileResponse;
-import cloneproject.Instagram.domain.member.entity.Member;
-import lombok.RequiredArgsConstructor;
-
 import java.util.List;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -14,10 +7,17 @@ import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
-import static cloneproject.Instagram.domain.feed.entity.QPost.post;
-import static cloneproject.Instagram.domain.follow.entity.QFollow.follow;
-import static cloneproject.Instagram.domain.member.entity.QBlock.block;
-import static cloneproject.Instagram.domain.member.entity.QMember.member;
+import cloneproject.Instagram.domain.member.dto.MiniProfileResponse;
+import cloneproject.Instagram.domain.member.dto.QMiniProfileResponse;
+import cloneproject.Instagram.domain.member.dto.QUserProfileResponse;
+import cloneproject.Instagram.domain.member.dto.UserProfileResponse;
+import cloneproject.Instagram.domain.member.entity.Member;
+import lombok.RequiredArgsConstructor;
+
+import static cloneproject.Instagram.domain.feed.entity.QPost.*;
+import static cloneproject.Instagram.domain.follow.entity.QFollow.*;
+import static cloneproject.Instagram.domain.member.entity.QBlock.*;
+import static cloneproject.Instagram.domain.member.entity.QMember.*;
 
 @RequiredArgsConstructor
 public class MemberRepositoryQuerydslImpl implements MemberRepositoryQuerydsl {
@@ -26,7 +26,6 @@ public class MemberRepositoryQuerydslImpl implements MemberRepositoryQuerydsl {
 
 	@Override
 	public UserProfileResponse getUserProfile(Long loginUserId, String username) {
-
 		return queryFactory
 			.select(new QUserProfileResponse(
 				member.username,
@@ -50,7 +49,6 @@ public class MemberRepositoryQuerydslImpl implements MemberRepositoryQuerydsl {
 
 	@Override
 	public MiniProfileResponse getMiniProfile(Long loginUserId, String username) {
-
 		return queryFactory
 			.select(new QMiniProfileResponse(
 				member.username,
@@ -68,7 +66,6 @@ public class MemberRepositoryQuerydslImpl implements MemberRepositoryQuerydsl {
 			.from(member)
 			.where(member.username.eq(username))
 			.fetchOne();
-
 	}
 
 	@Override

--- a/src/main/java/cloneproject/Instagram/domain/member/repository/querydsl/MemberRepositoryQuerydslImpl.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/repository/querydsl/MemberRepositoryQuerydslImpl.java
@@ -1,199 +1,147 @@
 package cloneproject.Instagram.domain.member.repository.querydsl;
 
-import cloneproject.Instagram.domain.feed.dto.PostImageDTO;
 import cloneproject.Instagram.domain.member.dto.MiniProfileResponse;
+import cloneproject.Instagram.domain.member.dto.QMiniProfileResponse;
+import cloneproject.Instagram.domain.member.dto.QUserProfileResponse;
 import cloneproject.Instagram.domain.member.dto.UserProfileResponse;
 import cloneproject.Instagram.domain.member.entity.Member;
-import cloneproject.Instagram.domain.story.repository.MemberStoryRedisRepository;
-import cloneproject.Instagram.domain.member.dto.*;
-import cloneproject.Instagram.domain.member.entity.QMember;
-
-import com.querydsl.jpa.JPAExpressions;
-import com.querydsl.jpa.impl.JPAQueryFactory;
-
-import cloneproject.Instagram.domain.feed.dto.QPostImageDTO;
 import lombok.RequiredArgsConstructor;
 
-import static cloneproject.Instagram.domain.follow.entity.QFollow.follow;
-import static cloneproject.Instagram.domain.member.entity.QMember.member;
-import static cloneproject.Instagram.domain.member.entity.QBlock.block;
-import static cloneproject.Instagram.domain.feed.entity.QPost.post;
-import static cloneproject.Instagram.domain.feed.entity.QPostImage.postImage;
-
 import java.util.List;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.JPQLQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import static cloneproject.Instagram.domain.feed.entity.QPost.post;
+import static cloneproject.Instagram.domain.follow.entity.QFollow.follow;
+import static cloneproject.Instagram.domain.member.entity.QBlock.block;
+import static cloneproject.Instagram.domain.member.entity.QMember.member;
 
 @RequiredArgsConstructor
 public class MemberRepositoryQuerydslImpl implements MemberRepositoryQuerydsl {
 
 	private final JPAQueryFactory queryFactory;
-	private final MemberStoryRedisRepository memberStoryRedisRepository;
 
 	@Override
-	public UserProfileResponse getUserProfile(Long loginedUserId, String username) {
-		final String followingMemberFollow = queryFactory
-				.select(follow.member.username)
-				.from(follow)
-				.where(follow.followMember.username.eq(username)
-						.and(follow.member.id.in(
-								JPAExpressions
-										.select(follow.followMember.id)
-										.from(follow)
-										.where(follow.member.id
-												.eq(loginedUserId)))))
-				.fetchFirst();
+	public UserProfileResponse getUserProfile(Long loginUserId, String username) {
 
-		final UserProfileResponse result = queryFactory
-				.select(new QUserProfileResponse(
-						member.username,
-						member.name,
-						member.website,
-						member.image,
-						JPAExpressions
-								.selectFrom(follow)
-								.where(follow.member.id.eq(loginedUserId)
-										.and(follow.followMember.username
-												.eq(username)))
-								.exists(),
-						JPAExpressions
-								.selectFrom(follow)
-								.where(follow.member.username.eq(username)
-										.and(follow.followMember.id
-												.eq(loginedUserId)))
-								.exists(),
-						JPAExpressions
-								.selectFrom(block)
-								.where(block.member.id.eq(loginedUserId)
-										.and(block.blockMember.username
-												.eq(username)))
-								.exists(),
-						JPAExpressions
-								.selectFrom(block)
-								.where(block.member.username.eq(username).and(
-										block.blockMember.id.eq(loginedUserId)))
-								.exists(),
-						member.introduce,
-						JPAExpressions
-								.select(post.count())
-								.from(post)
-								.where(post.member.username.eq(username)),
-						JPAExpressions
-								.select(follow.count())
-								.from(follow)
-								.where(follow.member.username.eq(username)),
-						JPAExpressions
-								.select(follow.count())
-								.from(follow)
-								.where(follow.followMember.username.eq(username)),
-						member.id.eq(loginedUserId)))
-				.from(member)
-				.where(member.username.eq(username))
-				.fetchOne();
-
-		final Member member = queryFactory
-				.selectFrom(QMember.member)
-				.where(QMember.member.username.eq(username))
-				.fetchOne();
-		result.setHasStory(memberStoryRedisRepository.findAllByMemberId(member.getId()).size() > 0);
-		result.checkBlock();
-		result.setFollowingMemberFollow(followingMemberFollow);
-
-		return result;
+		return queryFactory
+			.select(new QUserProfileResponse(
+				member.username,
+				member.name,
+				member.website,
+				member.image,
+				isFollowing(loginUserId, username),
+				isFollower(loginUserId, username),
+				isBlocking(loginUserId, username),
+				isBlocked(loginUserId, username),
+				member.introduce,
+				getPostCount(username),
+				getFollowingCount(username),
+				getFollowerCount(username),
+				member.id.eq(loginUserId),
+				getFollowingMemberFollow(loginUserId, username)))
+			.from(member)
+			.where(member.username.eq(username))
+			.fetchOne();
 	}
 
 	@Override
-	public MiniProfileResponse getMiniProfile(Long loginedUserId, String username) {
-		final String followingMemberFollow = queryFactory
-				.select(follow.member.username)
-				.from(follow)
-				.where(follow.followMember.username.eq(username)
-						.and(follow.member.id.in(
-								JPAExpressions
-										.select(follow.followMember.id)
-										.from(follow)
-										.where(follow.member.id
-												.eq(loginedUserId)))))
-				.fetchFirst();
+	public MiniProfileResponse getMiniProfile(Long loginUserId, String username) {
 
-		final MiniProfileResponse result = queryFactory
-				.select(new QMiniProfileResponse(
-						member.username,
-						member.name,
-						member.image,
-						JPAExpressions
-								.selectFrom(follow)
-								.where(follow.member.id.eq(loginedUserId)
-										.and(follow.followMember.username
-												.eq(username)))
-								.exists(),
-						JPAExpressions
-								.selectFrom(follow)
-								.where(follow.member.username.eq(username)
-										.and(follow.followMember.id
-												.eq(loginedUserId)))
-								.exists(),
-						JPAExpressions
-								.selectFrom(block)
-								.where(block.member.id.eq(loginedUserId)
-										.and(block.blockMember.username
-												.eq(username)))
-								.exists(),
-						JPAExpressions
-								.selectFrom(block)
-								.where(block.member.username.eq(username).and(
-										block.blockMember.id.eq(loginedUserId)))
-								.exists(),
-						JPAExpressions
-								.select(post.count())
-								.from(post)
-								.where(post.member.username.eq(username)),
-						JPAExpressions
-								.select(follow.count())
-								.from(follow)
-								.where(follow.member.username.eq(username)),
-						JPAExpressions
-								.select(follow.count())
-								.from(follow)
-								.where(follow.followMember.username.eq(username)),
-						member.id.eq(loginedUserId)))
-				.from(member)
-				.where(member.username.eq(username))
-				.fetchOne();
-
-		final List<Long> postIds = queryFactory
-				.select(post.id)
-				.from(post)
-				.where(post.member.username.eq(username))
-				.limit(3)
-				.orderBy(post.uploadDate.desc())
-				.fetch();
-
-		final List<PostImageDTO> postImageDTOs = queryFactory
-				.select(new QPostImageDTO(
-						postImage.post.id,
-						postImage.id,
-						postImage.image.imageUrl,
-						postImage.altText))
-				.from(postImage)
-				.where(postImage.post.id.in(postIds))
-				.fetch();
-
-		final Member member = queryFactory
-				.selectFrom(QMember.member)
-				.where(QMember.member.username.eq(username))
-				.fetchOne();
-		result.setHasStory(memberStoryRedisRepository.findAllByMemberId(member.getId()).size() > 0);
-		result.setMemberPosts(postImageDTOs);
-		result.checkBlock();
-		result.setFollowingMemberFollow(followingMemberFollow);
-		return result;
+		return queryFactory
+			.select(new QMiniProfileResponse(
+				member.username,
+				member.name,
+				member.image,
+				isFollowing(loginUserId, username),
+				isFollower(loginUserId, username),
+				isBlocking(loginUserId, username),
+				isBlocked(loginUserId, username),
+				getPostCount(username),
+				getFollowingCount(username),
+				getFollowerCount(username),
+				member.id.eq(loginUserId),
+				getFollowingMemberFollow(loginUserId, username)))
+			.from(member)
+			.where(member.username.eq(username))
+			.fetchOne();
 
 	}
 
 	@Override
 	public List<Member> findAllByUsernames(List<String> usernames) {
 		return queryFactory
-				.selectFrom(member)
-				.where(member.username.in(usernames))
-				.fetch();
+			.selectFrom(member)
+			.where(member.username.in(usernames))
+			.fetch();
 	}
+
+	private JPQLQuery<String> getFollowingMemberFollow(Long loginUserId, String targetUsername) {
+		return JPAExpressions
+			.select(follow.member.username)
+			.from(follow)
+			.where(follow.followMember.username.eq(targetUsername)
+				.and(follow.member.id.in(
+					JPAExpressions
+						.select(follow.followMember.id)
+						.from(follow)
+						.where(follow.member.id.eq(loginUserId)))));
+	}
+
+	private JPQLQuery<Long> getPostCount(String targetUsername) {
+		return JPAExpressions
+			.select(post.count())
+			.from(post)
+			.where(post.member.username.eq(targetUsername));
+	}
+
+	private JPQLQuery<Long> getFollowingCount(String targetUsername) {
+		return JPAExpressions
+			.select(follow.count())
+			.from(follow)
+			.where(follow.member.username.eq(targetUsername));
+	}
+
+	private JPQLQuery<Long> getFollowerCount(String targetUsername) {
+		return JPAExpressions
+			.select(follow.count())
+			.from(follow)
+			.where(follow.followMember.username.eq(targetUsername));
+	}
+
+	private BooleanExpression isFollowing(Long loginUserId, String targetUsername) {
+		return JPAExpressions
+			.selectFrom(follow)
+			.where(follow.member.id.eq(loginUserId)
+				.and(follow.followMember.username.eq(targetUsername)))
+			.exists();
+	}
+
+	private BooleanExpression isFollower(Long loginUserId, String targetUsername) {
+		return JPAExpressions
+			.selectFrom(follow)
+			.where(follow.member.username.eq(targetUsername)
+				.and(follow.followMember.id.eq(loginUserId)))
+			.exists();
+	}
+
+	private BooleanExpression isBlocking(Long loginUserId, String targetUsername) {
+		return JPAExpressions
+			.selectFrom(block)
+			.where(block.member.id.eq(loginUserId)
+				.and(block.blockMember.username.eq(targetUsername)))
+			.exists();
+	}
+
+	private BooleanExpression isBlocked(Long loginUserId, String targetUsername) {
+		return JPAExpressions
+			.selectFrom(block)
+			.where(block.member.username.eq(targetUsername).and(
+				block.blockMember.id.eq(loginUserId)))
+			.exists();
+	}
+
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/repository/querydsl/MemberRepositoryQuerydslImpl.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/repository/querydsl/MemberRepositoryQuerydslImpl.java
@@ -25,164 +25,175 @@ import java.util.List;
 @RequiredArgsConstructor
 public class MemberRepositoryQuerydslImpl implements MemberRepositoryQuerydsl {
 
-    private final JPAQueryFactory queryFactory;
-    private final MemberStoryRedisRepository memberStoryRedisRepository;
+	private final JPAQueryFactory queryFactory;
+	private final MemberStoryRedisRepository memberStoryRedisRepository;
 
-    @Override
-    public UserProfileResponse getUserProfile(Long loginedUserId, String username) {
-        final String followingMemberFollow = queryFactory
-                .select(follow.member.username)
-                .from(follow)
-                .where(follow.followMember.username.eq(username)
-                        .and(follow.member.id.in(
-                                JPAExpressions
-                                        .select(follow.followMember.id)
-                                        .from(follow)
-                                        .where(follow.member.id.eq(loginedUserId))
-                        )))
-                .fetchFirst();
+	@Override
+	public UserProfileResponse getUserProfile(Long loginedUserId, String username) {
+		final String followingMemberFollow = queryFactory
+				.select(follow.member.username)
+				.from(follow)
+				.where(follow.followMember.username.eq(username)
+						.and(follow.member.id.in(
+								JPAExpressions
+										.select(follow.followMember.id)
+										.from(follow)
+										.where(follow.member.id
+												.eq(loginedUserId)))))
+				.fetchFirst();
 
-        final UserProfileResponse result = queryFactory
-                .select(new QUserProfileResponse(
-                        member.username,
-                        member.name,
-                        member.website,
-                        member.image,
-                        JPAExpressions
-                                .selectFrom(follow)
-                                .where(follow.member.id.eq(loginedUserId).and(follow.followMember.username.eq(username)))
-                                .exists(),
-                        JPAExpressions
-                                .selectFrom(follow)
-                                .where(follow.member.username.eq(username).and(follow.followMember.id.eq(loginedUserId)))
-                                .exists(),
-                        JPAExpressions
-                                .selectFrom(block)
-                                .where(block.member.id.eq(loginedUserId).and(block.blockMember.username.eq(username)))
-                                .exists(),
-                        JPAExpressions
-                                .selectFrom(block)
-                                .where(block.member.username.eq(username).and(block.blockMember.id.eq(loginedUserId)))
-                                .exists(),
-                        member.introduce,
-                        JPAExpressions
-                                .select(post.count())
-                                .from(post)
-                                .where(post.member.username.eq(username)),
-                        JPAExpressions
-                                .select(follow.count())
-                                .from(follow)
-                                .where(follow.member.username.eq(username)),
-                        JPAExpressions
-                                .select(follow.count())
-                                .from(follow)
-                                .where(follow.followMember.username.eq(username)),
-                        member.id.eq(loginedUserId)
-                ))
-                .from(member)
-                .where(member.username.eq(username))
-                .fetchOne();
+		final UserProfileResponse result = queryFactory
+				.select(new QUserProfileResponse(
+						member.username,
+						member.name,
+						member.website,
+						member.image,
+						JPAExpressions
+								.selectFrom(follow)
+								.where(follow.member.id.eq(loginedUserId)
+										.and(follow.followMember.username
+												.eq(username)))
+								.exists(),
+						JPAExpressions
+								.selectFrom(follow)
+								.where(follow.member.username.eq(username)
+										.and(follow.followMember.id
+												.eq(loginedUserId)))
+								.exists(),
+						JPAExpressions
+								.selectFrom(block)
+								.where(block.member.id.eq(loginedUserId)
+										.and(block.blockMember.username
+												.eq(username)))
+								.exists(),
+						JPAExpressions
+								.selectFrom(block)
+								.where(block.member.username.eq(username).and(
+										block.blockMember.id.eq(loginedUserId)))
+								.exists(),
+						member.introduce,
+						JPAExpressions
+								.select(post.count())
+								.from(post)
+								.where(post.member.username.eq(username)),
+						JPAExpressions
+								.select(follow.count())
+								.from(follow)
+								.where(follow.member.username.eq(username)),
+						JPAExpressions
+								.select(follow.count())
+								.from(follow)
+								.where(follow.followMember.username.eq(username)),
+						member.id.eq(loginedUserId)))
+				.from(member)
+				.where(member.username.eq(username))
+				.fetchOne();
 
-        final Member member = queryFactory
-                .selectFrom(QMember.member)
-                .where(QMember.member.username.eq(username))
-                .fetchOne();
-        result.setHasStory(memberStoryRedisRepository.findAllByMemberId(member.getId()).size() > 0);
-        result.checkBlock();
-        result.setFollowingMemberFollow(followingMemberFollow);
+		final Member member = queryFactory
+				.selectFrom(QMember.member)
+				.where(QMember.member.username.eq(username))
+				.fetchOne();
+		result.setHasStory(memberStoryRedisRepository.findAllByMemberId(member.getId()).size() > 0);
+		result.checkBlock();
+		result.setFollowingMemberFollow(followingMemberFollow);
 
-        return result;
-    }
+		return result;
+	}
 
-    @Override
-    public MiniProfileResponse getMiniProfile(Long loginedUserId, String username) {
-        final String followingMemberFollow = queryFactory
-                .select(follow.member.username)
-                .from(follow)
-                .where(follow.followMember.username.eq(username)
-                        .and(follow.member.id.in(
-                                JPAExpressions
-                                        .select(follow.followMember.id)
-                                        .from(follow)
-                                        .where(follow.member.id.eq(loginedUserId))
-                        )))
-                .fetchFirst();
+	@Override
+	public MiniProfileResponse getMiniProfile(Long loginedUserId, String username) {
+		final String followingMemberFollow = queryFactory
+				.select(follow.member.username)
+				.from(follow)
+				.where(follow.followMember.username.eq(username)
+						.and(follow.member.id.in(
+								JPAExpressions
+										.select(follow.followMember.id)
+										.from(follow)
+										.where(follow.member.id
+												.eq(loginedUserId)))))
+				.fetchFirst();
 
-        final MiniProfileResponse result = queryFactory
-                .select(new QMiniProfileResponse(
-                        member.username,
-                        member.name,
-                        member.image,
-                        JPAExpressions
-                                .selectFrom(follow)
-                                .where(follow.member.id.eq(loginedUserId).and(follow.followMember.username.eq(username)))
-                                .exists(),
-                        JPAExpressions
-                                .selectFrom(follow)
-                                .where(follow.member.username.eq(username).and(follow.followMember.id.eq(loginedUserId)))
-                                .exists(),
-                        JPAExpressions
-                                .selectFrom(block)
-                                .where(block.member.id.eq(loginedUserId).and(block.blockMember.username.eq(username)))
-                                .exists(),
-                        JPAExpressions
-                                .selectFrom(block)
-                                .where(block.member.username.eq(username).and(block.blockMember.id.eq(loginedUserId)))
-                                .exists(),
-                        JPAExpressions
-                                .select(post.count())
-                                .from(post)
-                                .where(post.member.username.eq(username)),
-                        JPAExpressions
-                                .select(follow.count())
-                                .from(follow)
-                                .where(follow.member.username.eq(username)),
-                        JPAExpressions
-                                .select(follow.count())
-                                .from(follow)
-                                .where(follow.followMember.username.eq(username)),
-                        member.id.eq(loginedUserId)
-                ))
-                .from(member)
-                .where(member.username.eq(username))
-                .fetchOne();
+		final MiniProfileResponse result = queryFactory
+				.select(new QMiniProfileResponse(
+						member.username,
+						member.name,
+						member.image,
+						JPAExpressions
+								.selectFrom(follow)
+								.where(follow.member.id.eq(loginedUserId)
+										.and(follow.followMember.username
+												.eq(username)))
+								.exists(),
+						JPAExpressions
+								.selectFrom(follow)
+								.where(follow.member.username.eq(username)
+										.and(follow.followMember.id
+												.eq(loginedUserId)))
+								.exists(),
+						JPAExpressions
+								.selectFrom(block)
+								.where(block.member.id.eq(loginedUserId)
+										.and(block.blockMember.username
+												.eq(username)))
+								.exists(),
+						JPAExpressions
+								.selectFrom(block)
+								.where(block.member.username.eq(username).and(
+										block.blockMember.id.eq(loginedUserId)))
+								.exists(),
+						JPAExpressions
+								.select(post.count())
+								.from(post)
+								.where(post.member.username.eq(username)),
+						JPAExpressions
+								.select(follow.count())
+								.from(follow)
+								.where(follow.member.username.eq(username)),
+						JPAExpressions
+								.select(follow.count())
+								.from(follow)
+								.where(follow.followMember.username.eq(username)),
+						member.id.eq(loginedUserId)))
+				.from(member)
+				.where(member.username.eq(username))
+				.fetchOne();
 
-        final List<Long> postIds = queryFactory
-                .select(post.id)
-                .from(post)
-                .where(post.member.username.eq(username))
-                .limit(3)
-                .orderBy(post.uploadDate.desc())
-                .fetch();
+		final List<Long> postIds = queryFactory
+				.select(post.id)
+				.from(post)
+				.where(post.member.username.eq(username))
+				.limit(3)
+				.orderBy(post.uploadDate.desc())
+				.fetch();
 
-        final List<PostImageDTO> postImageDTOs = queryFactory
-                .select(new QPostImageDTO(
-                        postImage.post.id,
-                        postImage.id,
-                        postImage.image.imageUrl,
-                        postImage.altText
-                ))
-                .from(postImage)
-                .where(postImage.post.id.in(postIds))
-                .fetch();
+		final List<PostImageDTO> postImageDTOs = queryFactory
+				.select(new QPostImageDTO(
+						postImage.post.id,
+						postImage.id,
+						postImage.image.imageUrl,
+						postImage.altText))
+				.from(postImage)
+				.where(postImage.post.id.in(postIds))
+				.fetch();
 
-        final Member member = queryFactory
-                .selectFrom(QMember.member)
-                .where(QMember.member.username.eq(username))
-                .fetchOne();
-        result.setHasStory(memberStoryRedisRepository.findAllByMemberId(member.getId()).size() > 0);
-        result.setMemberPosts(postImageDTOs);
-        result.checkBlock();
-        result.setFollowingMemberFollow(followingMemberFollow);
-        return result;
+		final Member member = queryFactory
+				.selectFrom(QMember.member)
+				.where(QMember.member.username.eq(username))
+				.fetchOne();
+		result.setHasStory(memberStoryRedisRepository.findAllByMemberId(member.getId()).size() > 0);
+		result.setMemberPosts(postImageDTOs);
+		result.checkBlock();
+		result.setFollowingMemberFollow(followingMemberFollow);
+		return result;
 
-    }
+	}
 
-    @Override
-    public List<Member> findAllByUsernames(List<String> usernames) {
-        return queryFactory
-                .selectFrom(member)
-                .where(member.username.in(usernames))
-                .fetch();
-    }
+	@Override
+	public List<Member> findAllByUsernames(List<String> usernames) {
+		return queryFactory
+				.selectFrom(member)
+				.where(member.username.in(usernames))
+				.fetch();
+	}
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/repository/redis/EmailCodeRedisRepository.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/repository/redis/EmailCodeRedisRepository.java
@@ -6,8 +6,8 @@ import org.springframework.data.repository.CrudRepository;
 
 import cloneproject.Instagram.domain.member.entity.redis.EmailCode;
 
-public interface EmailCodeRedisRepository extends CrudRepository<EmailCode, String>{
-    
-    public Optional<EmailCode> findByUsername(String username);
-    
+public interface EmailCodeRedisRepository extends CrudRepository<EmailCode, String> {
+
+	public Optional<EmailCode> findByUsername(String username);
+
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/repository/redis/RefreshTokenRedisRepository.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/repository/redis/RefreshTokenRedisRepository.java
@@ -7,11 +7,14 @@ import org.springframework.data.repository.CrudRepository;
 
 import cloneproject.Instagram.domain.member.entity.redis.RefreshToken;
 
-public interface RefreshTokenRedisRepository extends CrudRepository<RefreshToken, String>{
-    
-    List<RefreshToken> findByMemberId(Long memberId);
-    boolean existsByMemberIdAndValue(Long memberId, String value);
-    Optional<RefreshToken> findByMemberIdAndValue(Long memberId, String value);
-    Optional<RefreshToken> findByMemberIdAndId(Long MemberId, String id);
+public interface RefreshTokenRedisRepository extends CrudRepository<RefreshToken, String> {
+
+	List<RefreshToken> findByMemberId(Long memberId);
+
+	boolean existsByMemberIdAndValue(Long memberId, String value);
+
+	Optional<RefreshToken> findByMemberIdAndValue(Long memberId, String value);
+
+	Optional<RefreshToken> findByMemberIdAndId(Long MemberId, String id);
 
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/repository/redis/ResetPasswordCodeRedisRepository.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/repository/redis/ResetPasswordCodeRedisRepository.java
@@ -6,8 +6,8 @@ import org.springframework.data.repository.CrudRepository;
 
 import cloneproject.Instagram.domain.member.entity.redis.ResetPasswordCode;
 
-public interface ResetPasswordCodeRedisRepository extends CrudRepository<ResetPasswordCode, String>{
-    
-    public Optional<ResetPasswordCode> findByUsername(String username);
+public interface ResetPasswordCodeRedisRepository extends CrudRepository<ResetPasswordCode, String> {
+
+	public Optional<ResetPasswordCode> findByUsername(String username);
 
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/service/BlockService.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/service/BlockService.java
@@ -17,6 +17,7 @@ import cloneproject.Instagram.domain.member.exception.CantUnblockMyselfException
 import cloneproject.Instagram.domain.member.exception.MemberDoesNotExistException;
 import cloneproject.Instagram.domain.member.repository.BlockRepository;
 import cloneproject.Instagram.domain.member.repository.MemberRepository;
+import cloneproject.Instagram.global.util.AuthUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -25,51 +26,54 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class BlockService {
 
-    private final BlockRepository blockRepository;
-    private final MemberRepository memberRepository;
-    private final FollowRepository followRepository;
+	private final AuthUtil authUtil;
+	private final BlockRepository blockRepository;
+	private final MemberRepository memberRepository;
+	private final FollowRepository followRepository;
 
-    @Transactional
-    public boolean block(String blockMemberUsername){
-        final String memberId = SecurityContextHolder.getContext().getAuthentication().getName();
-        final Member member = memberRepository.findById(Long.valueOf(memberId))
-                                        .orElseThrow(MemberDoesNotExistException::new);
-        final Member blockMember = memberRepository.findByUsername(blockMemberUsername)
-                                                .orElseThrow(MemberDoesNotExistException::new);
-        if(member.getId().equals(blockMember.getId())){
-            throw new CantBlockMyselfException();
-        }
-        if(blockRepository.existsByMemberIdAndBlockMemberId(member.getId(), blockMember.getId())){
-            throw new AlreadyBlockException();
-        }
+	@Transactional
+	public boolean block(String blockMemberUsername) {
+		final Member member = authUtil.getLoginMember();
+		final Member blockMember = memberRepository.findByUsername(blockMemberUsername)
+				.orElseThrow(MemberDoesNotExistException::new);
 
-        // 팔로우가 되어있었다면 언팔로우
-        Optional<Follow> follow = followRepository.findByMemberIdAndFollowMemberId(member.getId(), blockMember.getId());
-        if(follow.isPresent()){
-            followRepository.delete(follow.get());
-        }
-        follow = followRepository.findByMemberIdAndFollowMemberId(blockMember.getId(), member.getId());
-        if(follow.isPresent()){
-            followRepository.delete(follow.get());
-        }
+		if (member.getId().equals(blockMember.getId())) {
+			throw new CantBlockMyselfException();
+		}
+		if (blockRepository.existsByMemberIdAndBlockMemberId(member.getId(), blockMember.getId())) {
+			throw new AlreadyBlockException();
+		}
 
-        Block block = new Block(member, blockMember);
-        blockRepository.save(block);
-        return true;
-    }
+		// 팔로우가 되어있었다면 언팔로우
+		Optional<Follow> follow = followRepository.findByMemberIdAndFollowMemberId(member.getId(), blockMember.getId());
 
-    @Transactional
-    public boolean unblock(String blockMemberUsername){
-        final String memberId = SecurityContextHolder.getContext().getAuthentication().getName();
-        final Member blockMember = memberRepository.findByUsername(blockMemberUsername)
-                                                .orElseThrow(MemberDoesNotExistException::new);
-        if(Long.valueOf(memberId).equals(blockMember.getId())){
-            throw new CantUnblockMyselfException();
-        }
-        Block block = blockRepository.findByMemberIdAndBlockMemberId(Long.valueOf(memberId), blockMember.getId())
-                                        .orElseThrow(CantUnblockException::new);
-        blockRepository.delete(block);
-        return true;
-    }
+		if (follow.isPresent()) {
+			followRepository.delete(follow.get());
+		}
+		follow = followRepository.findByMemberIdAndFollowMemberId(blockMember.getId(), member.getId());
+		if (follow.isPresent()) {
+			followRepository.delete(follow.get());
+		}
+
+		Block block = new Block(member, blockMember);
+		blockRepository.save(block);
+		return true;
+	}
+
+	@Transactional
+	public boolean unblock(String blockMemberUsername) {
+		final Long memberId = authUtil.getLoginMemberId();
+		final Member blockMember = memberRepository.findByUsername(blockMemberUsername)
+				.orElseThrow(MemberDoesNotExistException::new);
+
+		if (memberId.equals(blockMember.getId())) {
+			throw new CantUnblockMyselfException();
+		}
+
+		Block block = blockRepository.findByMemberIdAndBlockMemberId(Long.valueOf(memberId), blockMember.getId())
+				.orElseThrow(CantUnblockException::new);
+		blockRepository.delete(block);
+		return true;
+	}
 
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/service/BlockService.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/service/BlockService.java
@@ -2,7 +2,6 @@ package cloneproject.Instagram.domain.member.service;
 
 import java.util.Optional;
 
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,7 +34,7 @@ public class BlockService {
 	public boolean block(String blockMemberUsername) {
 		final Member member = authUtil.getLoginMember();
 		final Member blockMember = memberRepository.findByUsername(blockMemberUsername)
-				.orElseThrow(MemberDoesNotExistException::new);
+			.orElseThrow(MemberDoesNotExistException::new);
 
 		if (member.getId().equals(blockMember.getId())) {
 			throw new CantBlockMyselfException();
@@ -46,14 +45,10 @@ public class BlockService {
 
 		// 팔로우가 되어있었다면 언팔로우
 		Optional<Follow> follow = followRepository.findByMemberIdAndFollowMemberId(member.getId(), blockMember.getId());
+		follow.ifPresent(followRepository::delete);
 
-		if (follow.isPresent()) {
-			followRepository.delete(follow.get());
-		}
 		follow = followRepository.findByMemberIdAndFollowMemberId(blockMember.getId(), member.getId());
-		if (follow.isPresent()) {
-			followRepository.delete(follow.get());
-		}
+		follow.ifPresent(followRepository::delete);
 
 		Block block = new Block(member, blockMember);
 		blockRepository.save(block);
@@ -64,14 +59,14 @@ public class BlockService {
 	public boolean unblock(String blockMemberUsername) {
 		final Long memberId = authUtil.getLoginMemberId();
 		final Member blockMember = memberRepository.findByUsername(blockMemberUsername)
-				.orElseThrow(MemberDoesNotExistException::new);
+			.orElseThrow(MemberDoesNotExistException::new);
 
 		if (memberId.equals(blockMember.getId())) {
 			throw new CantUnblockMyselfException();
 		}
 
-		Block block = blockRepository.findByMemberIdAndBlockMemberId(Long.valueOf(memberId), blockMember.getId())
-				.orElseThrow(CantUnblockException::new);
+		Block block = blockRepository.findByMemberIdAndBlockMemberId(memberId, blockMember.getId())
+			.orElseThrow(CantUnblockException::new);
 		blockRepository.delete(block);
 		return true;
 	}

--- a/src/main/java/cloneproject/Instagram/domain/member/service/EmailCodeService.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/service/EmailCodeService.java
@@ -1,5 +1,7 @@
 package cloneproject.Instagram.domain.member.service;
 
+import static cloneproject.Instagram.global.error.ErrorCode.*;
+
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
@@ -13,8 +15,8 @@ import org.springframework.stereotype.Service;
 import cloneproject.Instagram.domain.member.entity.Member;
 import cloneproject.Instagram.domain.member.entity.redis.EmailCode;
 import cloneproject.Instagram.domain.member.entity.redis.ResetPasswordCode;
-import cloneproject.Instagram.domain.member.exception.PasswordResetFailException;
 import cloneproject.Instagram.domain.member.exception.NoConfirmEmailException;
+import cloneproject.Instagram.domain.member.exception.PasswordResetFailException;
 import cloneproject.Instagram.domain.member.repository.MemberRepository;
 import cloneproject.Instagram.domain.member.repository.redis.EmailCodeRedisRepository;
 import cloneproject.Instagram.domain.member.repository.redis.ResetPasswordCodeRedisRepository;
@@ -23,8 +25,6 @@ import cloneproject.Instagram.global.error.exception.EntityNotFoundException;
 import cloneproject.Instagram.infra.email.EmailService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
-import static cloneproject.Instagram.global.error.ErrorCode.*;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -53,26 +53,26 @@ public class EmailCodeService {
 	}
 
 	public void sendEmailConfirmationCode(String username, String email) {
-		String code = createConfirmationCode(6);
-		String text = String.format(confirmEmailUI, email, code, email);
+		final String code = createConfirmationCode(6);
+		final String text = String.format(confirmEmailUI, email, code, email);
 		emailService.sendHtmlTextEmail(username + ", Welcome to Instagram.", text, email);
 
-		EmailCode emailCode = EmailCode.builder()
-				.username(username)
-				.email(email)
-				.code(code)
-				.build();
+		final EmailCode emailCode = EmailCode.builder()
+			.username(username)
+			.email(email)
+			.code(code)
+			.build();
 		emailCodeRedisRepository.save(emailCode);
 	}
 
 	public boolean checkEmailCode(String username, String email, String code) {
-		Optional<EmailCode> optionalEmailCode = emailCodeRedisRepository.findByUsername(username);
+		final Optional<EmailCode> optionalEmailCode = emailCodeRedisRepository.findByUsername(username);
 
 		if (optionalEmailCode.isEmpty()) {
 			throw new NoConfirmEmailException();
 		}
 
-		EmailCode emailCode = optionalEmailCode.get();
+		final EmailCode emailCode = optionalEmailCode.get();
 
 		if (!emailCode.getCode().equals(code) || !emailCode.getEmail().equals(email)) {
 			return false;
@@ -83,53 +83,50 @@ public class EmailCodeService {
 	}
 
 	public String sendResetPasswordCode(String username) {
-		Member member = memberRepository.findByUsername(username)
-				.orElseThrow(() -> new EntityNotFoundException(MEMBER_NOT_FOUND));
+		final Member member = memberRepository.findByUsername(username)
+			.orElseThrow(() -> new EntityNotFoundException(MEMBER_NOT_FOUND));
 
-		String code = createConfirmationCode(30);
-		String email = member.getEmail();
-		String text = String.format(resetPasswordEmailUI, username, code, username, code, email, username);
+		final String code = createConfirmationCode(30);
+		final String email = member.getEmail();
+		final String text = String.format(resetPasswordEmailUI, username, code, username, code, email, username);
 		emailService.sendHtmlTextEmail(username + ", recover your account's password.", text, email);
 
-		ResetPasswordCode resetPasswordCode = ResetPasswordCode.builder()
-				.username(username)
-				.code(code)
-				.build();
+		final ResetPasswordCode resetPasswordCode = ResetPasswordCode.builder()
+			.username(username)
+			.code(code)
+			.build();
 		resetPasswordCodeRedisRepository.save(resetPasswordCode);
 
 		return email;
 	}
 
 	public boolean checkResetPasswordCode(String username, String code) {
-		Optional<ResetPasswordCode> optionalResetPasswordCode = resetPasswordCodeRedisRepository
-				.findByUsername(username);
+		final Optional<ResetPasswordCode> optionalResetPasswordCode = resetPasswordCodeRedisRepository
+			.findByUsername(username);
 
 		if (optionalResetPasswordCode.isEmpty()) {
 			throw new PasswordResetFailException();
 		}
 
-		ResetPasswordCode resetPasswordCode = optionalResetPasswordCode.get();
+		final ResetPasswordCode resetPasswordCode = optionalResetPasswordCode.get();
 
-		if (!resetPasswordCode.getCode().equals(code)) {
-			return false;
-		}
-		return true;
+		return resetPasswordCode.getCode().equals(code);
 	}
 
 	public void deleteResetPasswordCode(String username) {
-		ResetPasswordCode resetPasswordCode = resetPasswordCodeRedisRepository.findByUsername(username)
-				.orElseThrow(PasswordResetFailException::new);
+		final ResetPasswordCode resetPasswordCode = resetPasswordCodeRedisRepository.findByUsername(username)
+			.orElseThrow(PasswordResetFailException::new);
 		resetPasswordCodeRedisRepository.delete(resetPasswordCode);
 	}
 
 	public String createConfirmationCode(int length) {
-		StringBuffer key = new StringBuffer();
-		Random random = new Random();
+		final StringBuilder key = new StringBuilder();
+		final Random random = new Random();
 		for (int i = 0; i < length; i++) {
-			boolean isAlphabet = random.nextBoolean();
+			final boolean isAlphabet = random.nextBoolean();
 
 			if (isAlphabet) {
-				key.append((char) ((int) (random.nextInt(26)) + 65));
+				key.append((char)((random.nextInt(26)) + 65));
 			} else {
 				key.append((random.nextInt(10)));
 			}

--- a/src/main/java/cloneproject/Instagram/domain/member/service/EmailCodeService.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/service/EmailCodeService.java
@@ -88,7 +88,8 @@ public class EmailCodeService {
 
 		final String code = createConfirmationCode(30);
 		final String email = member.getEmail();
-		final String text = String.format(resetPasswordEmailUI, username, code, username, code, email, username);
+		final String text = String.format(resetPasswordEmailUI, username, username, code, username, username, code,
+			email, username);
 		emailService.sendHtmlTextEmail(username + ", recover your account's password.", text, email);
 
 		final ResetPasswordCode resetPasswordCode = ResetPasswordCode.builder()

--- a/src/main/java/cloneproject/Instagram/domain/member/service/JwtUserDetailsService.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/service/JwtUserDetailsService.java
@@ -32,11 +32,12 @@ public class JwtUserDetailsService implements UserDetailsService {
     }
 
     private UserDetails createUserDetails(Member member) {
-        GrantedAuthority grantedAuthority = new SimpleGrantedAuthority(member.getRole().toString());
+        final GrantedAuthority grantedAuthority = new SimpleGrantedAuthority(member.getRole().toString());
         // TOKEN, AUTHENTICATION 에 넣을 값 (ex. username, id)
         return new User(
                 String.valueOf(member.getId()),
                 member.getPassword(),
                 Collections.singleton(grantedAuthority));
     }
+
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/service/JwtUserDetailsService.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/service/JwtUserDetailsService.java
@@ -2,7 +2,6 @@ package cloneproject.Instagram.domain.member.service;
 
 import java.util.Collections;
 
-
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
@@ -20,8 +19,8 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class JwtUserDetailsService implements UserDetailsService{
-    
+public class JwtUserDetailsService implements UserDetailsService {
+
     private final MemberRepository memberRepository;
 
     @Override
@@ -32,13 +31,12 @@ public class JwtUserDetailsService implements UserDetailsService{
                 .orElseThrow(() -> new UsernameNotFoundException("일치하는 계정이 없습니다"));
     }
 
-    private UserDetails createUserDetails(Member member){
+    private UserDetails createUserDetails(Member member) {
         GrantedAuthority grantedAuthority = new SimpleGrantedAuthority(member.getRole().toString());
         // TOKEN, AUTHENTICATION 에 넣을 값 (ex. username, id)
         return new User(
-            String.valueOf(member.getId()),
-            member.getPassword(),
-            Collections.singleton(grantedAuthority)
-        );
+                String.valueOf(member.getId()),
+                member.getPassword(),
+                Collections.singleton(grantedAuthority));
     }
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/service/MemberAuthService.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/service/MemberAuthService.java
@@ -16,7 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 import cloneproject.Instagram.domain.member.dto.JwtDto;
 import cloneproject.Instagram.domain.member.dto.LoginRequest;
 import cloneproject.Instagram.domain.member.dto.LoginWithCodeRequest;
-import cloneproject.Instagram.domain.member.dto.LoginedDevicesDTO;
+import cloneproject.Instagram.domain.member.dto.LoginDevicesDTO;
 import cloneproject.Instagram.domain.member.dto.RegisterRequest;
 import cloneproject.Instagram.domain.member.dto.ResetPasswordRequest;
 import cloneproject.Instagram.domain.member.dto.UpdatePasswordRequest;
@@ -195,7 +195,7 @@ public class MemberAuthService {
 		}
 	}
 
-	public List<LoginedDevicesDTO> getLoginDevices() {
+	public List<LoginDevicesDTO> getLoginDevices() {
 		final Member member = authUtil.getLoginMember();
 		return refreshTokenService.getLoginDevices(member.getId());
 	}

--- a/src/main/java/cloneproject/Instagram/domain/member/service/MemberAuthService.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/service/MemberAuthService.java
@@ -1,5 +1,7 @@
 package cloneproject.Instagram.domain.member.service;
 
+import static cloneproject.Instagram.global.error.ErrorCode.*;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -21,8 +23,8 @@ import cloneproject.Instagram.domain.member.dto.UpdatePasswordRequest;
 import cloneproject.Instagram.domain.member.entity.Member;
 import cloneproject.Instagram.domain.member.entity.redis.RefreshToken;
 import cloneproject.Instagram.domain.member.exception.AccountMismatchException;
-import cloneproject.Instagram.domain.member.exception.PasswordResetFailException;
 import cloneproject.Instagram.domain.member.exception.InvalidJwtException;
+import cloneproject.Instagram.domain.member.exception.PasswordResetFailException;
 import cloneproject.Instagram.domain.member.repository.MemberRepository;
 import cloneproject.Instagram.domain.search.entity.SearchMember;
 import cloneproject.Instagram.domain.search.repository.SearchMemberRepository;
@@ -30,13 +32,11 @@ import cloneproject.Instagram.global.error.exception.EntityAlreadyExistException
 import cloneproject.Instagram.global.error.exception.EntityNotFoundException;
 import cloneproject.Instagram.global.util.AuthUtil;
 import cloneproject.Instagram.global.util.JwtUtil;
-import cloneproject.Instagram.infra.geoip.dto.GeoIP;
 import cloneproject.Instagram.infra.geoip.GeoIPLocationService;
+import cloneproject.Instagram.infra.geoip.dto.GeoIP;
 import io.jsonwebtoken.JwtException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
-import static cloneproject.Instagram.global.error.ErrorCode.*;
 
 @Slf4j
 @Service
@@ -55,10 +55,7 @@ public class MemberAuthService {
 
 	@Transactional(readOnly = true)
 	public boolean checkUsername(String username) {
-		if (memberRepository.existsByUsername(username)) {
-			return false;
-		}
-		return true;
+		return !memberRepository.existsByUsername(username);
 	}
 
 	@Transactional
@@ -66,18 +63,18 @@ public class MemberAuthService {
 		if (memberRepository.existsByUsername(registerRequest.getUsername())) {
 			throw new EntityAlreadyExistException(USERNAME_ALREADY_EXIST);
 		}
-		String username = registerRequest.getUsername();
+		final String username = registerRequest.getUsername();
 
 		if (!emailCodeService.checkEmailCode(username, registerRequest.getEmail(), registerRequest.getCode())) {
 			return false;
 		}
 
-		Member member = registerRequest.convert();
-		String encryptedPassword = bCryptPasswordEncoder.encode(member.getPassword());
+		final Member member = registerRequest.convert();
+		final String encryptedPassword = bCryptPasswordEncoder.encode(member.getPassword());
 		member.setEncryptedPassword(encryptedPassword);
 		memberRepository.save(member);
 
-		SearchMember searchMember = new SearchMember(member);
+		final SearchMember searchMember = new SearchMember(member);
 		searchMemberRepository.save(searchMember);
 
 		return true;
@@ -93,14 +90,16 @@ public class MemberAuthService {
 	@Transactional
 	public JwtDto login(LoginRequest loginRequest, String device, String ip) {
 		try {
-			UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
-					loginRequest.getUsername(), loginRequest.getPassword());
-			Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
-			JwtDto jwtDto = jwtUtil.generateTokenDto(authentication);
+			final UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
+				loginRequest.getUsername(), loginRequest.getPassword());
+			final Authentication authentication = authenticationManagerBuilder.getObject()
+				.authenticate(authenticationToken);
+			final JwtDto jwtDto = jwtUtil.generateTokenDto(authentication);
 
-			GeoIP geoIP = geoIPLocationService.getLocation(ip);
+			final GeoIP geoIP = geoIPLocationService.getLocation(ip);
 
-			refreshTokenService.addRefreshToken(Long.valueOf(authentication.getName()), jwtDto.getRefreshToken(), device, geoIP);
+			refreshTokenService.addRefreshToken(Long.valueOf(authentication.getName()), jwtDto.getRefreshToken(),
+				device, geoIP);
 			return jwtDto;
 		} catch (BadCredentialsException e) {
 			throw new AccountMismatchException();
@@ -108,7 +107,7 @@ public class MemberAuthService {
 	}
 
 	@Transactional
-	public Optional<JwtDto> reisuue(String refreshTokenString) {
+	public Optional<JwtDto> reissue(String refreshTokenString) {
 		if (!jwtUtil.validateRefeshJwt(refreshTokenString)) {
 			throw new InvalidJwtException();
 		}
@@ -118,26 +117,27 @@ public class MemberAuthService {
 		} catch (JwtException e) {
 			throw new InvalidJwtException();
 		}
-		Member member = authUtil.getLoginMember();
+		final Member member = authUtil.getLoginMember();
 
-		Optional<RefreshToken> refreshToken = refreshTokenService.findRefreshToken(member.getId(), refreshTokenString);
+		final Optional<RefreshToken> refreshToken = refreshTokenService.findRefreshToken(member.getId(),
+			refreshTokenString);
 		if (refreshToken.isEmpty()) {
 			return Optional.empty();
 		}
-		JwtDto jwtDto = jwtUtil.generateTokenDto(authentication);
+		final JwtDto jwtDto = jwtUtil.generateTokenDto(authentication);
 		refreshTokenService.updateRefreshToken(refreshToken.get(), jwtDto.getRefreshToken());
 		return Optional.of(jwtDto);
 	}
 
 	@Transactional
 	public void updatePassword(UpdatePasswordRequest updatePasswordRequest) {
-		Member member = authUtil.getLoginMember();
-		boolean oldPasswordCorrect = bCryptPasswordEncoder.matches(updatePasswordRequest.getOldPassword(),
-				member.getPassword());
+		final Member member = authUtil.getLoginMember();
+		final boolean oldPasswordCorrect = bCryptPasswordEncoder.matches(updatePasswordRequest.getOldPassword(),
+			member.getPassword());
 		if (!oldPasswordCorrect) {
 			throw new AccountMismatchException();
 		}
-		String encryptedPassword = bCryptPasswordEncoder.encode(updatePasswordRequest.getNewPassword());
+		final String encryptedPassword = bCryptPasswordEncoder.encode(updatePasswordRequest.getNewPassword());
 		member.setEncryptedPassword(encryptedPassword);
 		memberRepository.save(member);
 	}
@@ -149,33 +149,33 @@ public class MemberAuthService {
 
 	@Transactional
 	public JwtDto resetPassword(ResetPasswordRequest resetPasswordRequest, String device, String ip) {
-        Member member = memberRepository.findByUsername(resetPasswordRequest.getUsername())
-                                    .orElseThrow(() -> new EntityNotFoundException(MEMBER_NOT_FOUND));
+		final Member member = memberRepository.findByUsername(resetPasswordRequest.getUsername())
+			.orElseThrow(() -> new EntityNotFoundException(MEMBER_NOT_FOUND));
 		if (!emailCodeService.checkResetPasswordCode(resetPasswordRequest.getUsername(),
-				resetPasswordRequest.getCode())) {
+			resetPasswordRequest.getCode())) {
 			throw new PasswordResetFailException();
 		}
-		String encryptedPassword = bCryptPasswordEncoder.encode(resetPasswordRequest.getNewPassword());
+		final String encryptedPassword = bCryptPasswordEncoder.encode(resetPasswordRequest.getNewPassword());
 		member.setEncryptedPassword(encryptedPassword);
 		memberRepository.save(member);
-		JwtDto jwtDto = login(
-				new LoginRequest(resetPasswordRequest.getUsername(), resetPasswordRequest.getNewPassword()), device,
-				ip);
+		final JwtDto jwtDto = login(
+			new LoginRequest(resetPasswordRequest.getUsername(), resetPasswordRequest.getNewPassword()), device,
+			ip);
 		emailCodeService.deleteResetPasswordCode(resetPasswordRequest.getUsername());
 		return jwtDto;
 	}
 
 	@Transactional
 	public JwtDto loginWithCode(LoginWithCodeRequest loginRequest, String device, String ip) {
-        Member member = memberRepository.findByUsername(loginRequest.getUsername())
-                                    .orElseThrow(() -> new EntityNotFoundException(MEMBER_NOT_FOUND));
+		final Member member = memberRepository.findByUsername(loginRequest.getUsername())
+			.orElseThrow(() -> new EntityNotFoundException(MEMBER_NOT_FOUND));
 		if (!emailCodeService.checkResetPasswordCode(loginRequest.getUsername(), loginRequest.getCode())) {
 			throw new PasswordResetFailException();
 		}
-		JwtDto jwtDto = jwtUtil.generateTokenDto(jwtUtil.getAuthenticationWithMember(member.getId().toString()));
+		final JwtDto jwtDto = jwtUtil.generateTokenDto(jwtUtil.getAuthenticationWithMember(member.getId().toString()));
 		emailCodeService.deleteResetPasswordCode(loginRequest.getUsername());
 
-		GeoIP geoIP = geoIPLocationService.getLocation(ip);
+		final GeoIP geoIP = geoIPLocationService.getLocation(ip);
 
 		refreshTokenService.addRefreshToken(member.getId(), jwtDto.getRefreshToken(), device, geoIP);
 		return jwtDto;
@@ -190,18 +190,19 @@ public class MemberAuthService {
 	public void logout(String refreshToken) {
 		try {
 			refreshTokenService.deleteRefreshTokenWithValue(authUtil.getLoginMemberId(), refreshToken);
-		} catch (InvalidJwtException e) {
-			return;
+		} catch (InvalidJwtException ignored) {
+
 		}
 	}
 
-	public List<LoginedDevicesDTO> getLoginedDevices() {
-		Member member = authUtil.getLoginMember();
-		return refreshTokenService.getLoginedDevices(member.getId());
+	public List<LoginedDevicesDTO> getLoginDevices() {
+		final Member member = authUtil.getLoginMember();
+		return refreshTokenService.getLoginDevices(member.getId());
 	}
 
 	@Transactional
 	public void logoutDevice(String tokenId) {
 		refreshTokenService.deleteRefreshTokenWithId(authUtil.getLoginMemberId(), tokenId);
 	}
+
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/service/MemberPostService.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/service/MemberPostService.java
@@ -1,20 +1,26 @@
 package cloneproject.Instagram.domain.member.service;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 import cloneproject.Instagram.domain.feed.dto.MemberPostDTO;
+import cloneproject.Instagram.domain.feed.dto.PostImageDTO;
+import cloneproject.Instagram.domain.feed.repository.PostImageRepository;
 import cloneproject.Instagram.domain.member.entity.Member;
-import cloneproject.Instagram.domain.member.exception.MemberDoesNotExistException;
 import cloneproject.Instagram.domain.member.repository.BlockRepository;
 import cloneproject.Instagram.domain.member.repository.MemberRepository;
+import cloneproject.Instagram.global.error.exception.EntityNotFoundException;
 import cloneproject.Instagram.global.util.AuthUtil;
 import lombok.RequiredArgsConstructor;
+
+import static cloneproject.Instagram.global.error.ErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
@@ -23,21 +29,22 @@ public class MemberPostService {
 	private final AuthUtil authUtil;
 	private final MemberRepository memberRepository;
 	private final BlockRepository blockRepository;
+	private final PostImageRepository postImageRepository;
 
-	public Page<MemberPostDTO> getMemberPostDto(String username, int size, int page) {
+	public Page<MemberPostDTO> getMemberPostDTOs(String username, int size, int page) {
 		page = (page == 0 ? 0 : page - 1) + 5;
 		final Long loginMemberId = authUtil.getLoginMemberIdOrNull();
 
 		final Member member = memberRepository.findByUsername(username)
-				.orElseThrow(MemberDoesNotExistException::new);
+			.orElseThrow(() -> new EntityNotFoundException(MEMBER_NOT_FOUND));
 
-		if (blockRepository.existsByMemberIdAndBlockMemberId(loginMemberId, member.getId()) ||
-				blockRepository.existsByMemberIdAndBlockMemberId(member.getId(), loginMemberId)) {
-			return null;
+		if (blockRepository.isBlockingOrIsBlocked(loginMemberId, member.getId())) {
+			return Page.empty();
 		}
 
 		final Pageable pageable = PageRequest.of(page, size);
-		Page<MemberPostDTO> posts = memberRepository.getMemberPostDto(loginMemberId, username, pageable);
+		Page<MemberPostDTO> posts = memberRepository.getMemberPostDTOs(username, pageable);
+		setMemberPostImageDTOs(posts.getContent());
 		return posts;
 
 	}
@@ -46,47 +53,51 @@ public class MemberPostService {
 		final Long loginMemberId = authUtil.getLoginMemberIdOrNull();
 
 		final Member member = memberRepository.findByUsername(username)
-				.orElseThrow(MemberDoesNotExistException::new);
+			.orElseThrow(() -> new EntityNotFoundException(MEMBER_NOT_FOUND));
 
-		if (blockRepository.existsByMemberIdAndBlockMemberId(loginMemberId, member.getId()) ||
-				blockRepository.existsByMemberIdAndBlockMemberId(member.getId(), loginMemberId)) {
-			return null;
+		if (blockRepository.isBlockingOrIsBlocked(loginMemberId, member.getId())) {
+			return Collections.emptyList();
 		}
 
-		List<MemberPostDTO> posts = memberRepository.getRecent15PostDTOs(loginMemberId, username);
-		return posts;
+		final Pageable pageable = PageRequest.of(0, 15);
+		Page<MemberPostDTO> posts = memberRepository.getMemberPostDTOs(username, pageable);
+		setMemberPostImageDTOs(posts.getContent());
+		return posts.getContent();
 	}
 
-	public Page<MemberPostDTO> getMemberSavedPostDto(int size, int page) {
+	public Page<MemberPostDTO> getMemberSavedPostDTOs(int size, int page) {
 		page = (page == 0 ? 0 : page - 1) + 5;
 		final Long loginMemberId = authUtil.getLoginMemberId();
 
 		final Pageable pageable = PageRequest.of(page, size);
-		Page<MemberPostDTO> posts = memberRepository.getMemberSavedPostDto(loginMemberId, pageable);
+		Page<MemberPostDTO> posts = memberRepository.getMemberSavedPostDTOs(loginMemberId, pageable);
+		setMemberPostImageDTOs(posts.getContent());
 		return posts;
 	}
 
 	public List<MemberPostDTO> getRecent15SavedPostDTOs() {
 		final Long loginMemberId = authUtil.getLoginMemberId();
 
-		List<MemberPostDTO> posts = memberRepository.getRecent15SavedPostDTOs(loginMemberId);
-		return posts;
+		final Pageable pageable = PageRequest.of(0, 15);
+		Page<MemberPostDTO> posts = memberRepository.getMemberSavedPostDTOs(loginMemberId, pageable);
+		setMemberPostImageDTOs(posts.getContent());
+		return posts.getContent();
 	}
 
-	public Page<MemberPostDTO> getMemberTaggedPostDto(String username, int size, int page) {
+	public Page<MemberPostDTO> getMemberTaggedPostDTOs(String username, int size, int page) {
 		page = (page == 0 ? 0 : page - 1) + 5;
 		final Long loginMemberId = authUtil.getLoginMemberIdOrNull();
 
 		final Member member = memberRepository.findByUsername(username)
-				.orElseThrow(MemberDoesNotExistException::new);
+			.orElseThrow(() -> new EntityNotFoundException(MEMBER_NOT_FOUND));
 
-		if (blockRepository.existsByMemberIdAndBlockMemberId(loginMemberId, member.getId()) ||
-				blockRepository.existsByMemberIdAndBlockMemberId(member.getId(), loginMemberId)) {
-			return null;
+		if (blockRepository.isBlockingOrIsBlocked(loginMemberId, member.getId())) {
+			return Page.empty();
 		}
 
 		final Pageable pageable = PageRequest.of(page, size);
-		Page<MemberPostDTO> posts = memberRepository.getMemberTaggedPostDto(loginMemberId, username, pageable);
+		Page<MemberPostDTO> posts = memberRepository.getMemberTaggedPostDTOs(username, pageable);
+		setMemberPostImageDTOs(posts.getContent());
 		return posts;
 
 	}
@@ -95,15 +106,29 @@ public class MemberPostService {
 		final Long loginMemberId = authUtil.getLoginMemberIdOrNull();
 
 		final Member member = memberRepository.findByUsername(username)
-				.orElseThrow(MemberDoesNotExistException::new);
+			.orElseThrow(() -> new EntityNotFoundException(MEMBER_NOT_FOUND));
 
-		if (blockRepository.existsByMemberIdAndBlockMemberId(loginMemberId, member.getId()) ||
-				blockRepository.existsByMemberIdAndBlockMemberId(member.getId(), loginMemberId)) {
-			return null;
+		if (blockRepository.isBlockingOrIsBlocked(loginMemberId, member.getId())) {
+			return Collections.emptyList();
 		}
 
-		List<MemberPostDTO> posts = memberRepository.getRecent15TaggedPostDTOs(loginMemberId, username);
-		return posts;
+		final Pageable pageable = PageRequest.of(0, 15);
+		Page<MemberPostDTO> posts = memberRepository.getMemberTaggedPostDTOs(username, pageable);
+		setMemberPostImageDTOs(posts.getContent());
+		return posts.getContent();
+	}
+
+	private void setMemberPostImageDTOs(List<MemberPostDTO> memberPostDTOs) {
+		final List<Long> postIds = memberPostDTOs.stream()
+			.map(MemberPostDTO::getPostId)
+			.collect(Collectors.toList());
+
+		final List<PostImageDTO> postImageDTOs = postImageRepository.findAllPostImageDto(postIds);
+
+		final Map<Long, List<PostImageDTO>> postDTOMap = postImageDTOs.stream()
+			.collect(Collectors.groupingBy(PostImageDTO::getPostId));
+
+		memberPostDTOs.forEach(p -> p.setPostImageDTO(postDTOMap.get(p.getPostId()).get(0)));
 	}
 
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/service/MemberPostService.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/service/MemberPostService.java
@@ -1,6 +1,5 @@
 package cloneproject.Instagram.domain.member.service;
 
-
 import java.util.List;
 
 import org.springframework.data.domain.Page;
@@ -20,95 +19,91 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class MemberPostService {
-    
-    private final MemberRepository memberRepository;
-    private final BlockRepository blockRepository;
-    
-    public Page<MemberPostDTO> getMemberPostDto(String username, int size, int page) {
-        page = (page == 0 ? 0 : page - 1) + 5;
-        final Long loginedMemberId = AuthUtil.getLoginMemberIdOrNull();
 
-        final Member member = memberRepository.findByUsername(username)
-                                                .orElseThrow(MemberDoesNotExistException::new);
+	private final MemberRepository memberRepository;
+	private final BlockRepository blockRepository;
 
-        if(blockRepository.existsByMemberIdAndBlockMemberId(loginedMemberId, member.getId()) ||
-            blockRepository.existsByMemberIdAndBlockMemberId(member.getId(), loginedMemberId)){
-            return null;
-        }
+	public Page<MemberPostDTO> getMemberPostDto(String username, int size, int page) {
+		page = (page == 0 ? 0 : page - 1) + 5;
+		final Long loginedMemberId = AuthUtil.getLoginMemberIdOrNull();
 
-        final Pageable pageable = PageRequest.of(page, size);
-        Page<MemberPostDTO> posts = memberRepository.getMemberPostDto(loginedMemberId, username, pageable);
-        return posts;
+		final Member member = memberRepository.findByUsername(username)
+				.orElseThrow(MemberDoesNotExistException::new);
 
+		if (blockRepository.existsByMemberIdAndBlockMemberId(loginedMemberId, member.getId()) ||
+				blockRepository.existsByMemberIdAndBlockMemberId(member.getId(), loginedMemberId)) {
+			return null;
+		}
 
-    }
-    
-    public List<MemberPostDTO> getRecent15PostDTOs(String username) {
-        final Long loginedMemberId = AuthUtil.getLoginMemberIdOrNull();
+		final Pageable pageable = PageRequest.of(page, size);
+		Page<MemberPostDTO> posts = memberRepository.getMemberPostDto(loginedMemberId, username, pageable);
+		return posts;
 
-        final Member member = memberRepository.findByUsername(username)
-                                                .orElseThrow(MemberDoesNotExistException::new);
+	}
 
-        if(blockRepository.existsByMemberIdAndBlockMemberId(loginedMemberId, member.getId()) ||
-            blockRepository.existsByMemberIdAndBlockMemberId(member.getId(), loginedMemberId)){
-            return null;
-        }
-        
-        List<MemberPostDTO> posts = memberRepository.getRecent15PostDTOs(loginedMemberId, username);
-        return posts;
-    }
+	public List<MemberPostDTO> getRecent15PostDTOs(String username) {
+		final Long loginedMemberId = AuthUtil.getLoginMemberIdOrNull();
 
-    public Page<MemberPostDTO> getMemberSavedPostDto(int size, int page) {
-        page = (page == 0 ? 0 : page - 1)+5;
-        final String loginedMemberId = SecurityContextHolder.getContext().getAuthentication().getName();
+		final Member member = memberRepository.findByUsername(username)
+				.orElseThrow(MemberDoesNotExistException::new);
 
+		if (blockRepository.existsByMemberIdAndBlockMemberId(loginedMemberId, member.getId()) ||
+				blockRepository.existsByMemberIdAndBlockMemberId(member.getId(), loginedMemberId)) {
+			return null;
+		}
 
-        final Pageable pageable = PageRequest.of(page, size);
-        Page<MemberPostDTO> posts = memberRepository.getMemberSavedPostDto(Long.valueOf(loginedMemberId), pageable);
-        return posts;
+		List<MemberPostDTO> posts = memberRepository.getRecent15PostDTOs(loginedMemberId, username);
+		return posts;
+	}
 
+	public Page<MemberPostDTO> getMemberSavedPostDto(int size, int page) {
+		page = (page == 0 ? 0 : page - 1) + 5;
+		final String loginedMemberId = SecurityContextHolder.getContext().getAuthentication().getName();
 
-    }
-    
-    public List<MemberPostDTO> getRecent15SavedPostDTOs() {
-        final String loginedMemberId = SecurityContextHolder.getContext().getAuthentication().getName();
+		final Pageable pageable = PageRequest.of(page, size);
+		Page<MemberPostDTO> posts = memberRepository.getMemberSavedPostDto(Long.valueOf(loginedMemberId), pageable);
+		return posts;
 
-        List<MemberPostDTO> posts = memberRepository.getRecent15SavedPostDTOs(Long.valueOf(loginedMemberId));
-        return posts;
-    }
+	}
 
-    public Page<MemberPostDTO> getMemberTaggedPostDto(String username, int size, int page) {
-        page = (page == 0 ? 0 : page - 1)+5;
-        final Long loginedMemberId = AuthUtil.getLoginMemberIdOrNull();
+	public List<MemberPostDTO> getRecent15SavedPostDTOs() {
+		final String loginedMemberId = SecurityContextHolder.getContext().getAuthentication().getName();
 
-        final Member member = memberRepository.findByUsername(username)
-                                                .orElseThrow(MemberDoesNotExistException::new);
+		List<MemberPostDTO> posts = memberRepository.getRecent15SavedPostDTOs(Long.valueOf(loginedMemberId));
+		return posts;
+	}
 
-        if(blockRepository.existsByMemberIdAndBlockMemberId(loginedMemberId, member.getId()) ||
-            blockRepository.existsByMemberIdAndBlockMemberId(member.getId(), loginedMemberId)){
-            return null;
-        }
+	public Page<MemberPostDTO> getMemberTaggedPostDto(String username, int size, int page) {
+		page = (page == 0 ? 0 : page - 1) + 5;
+		final Long loginedMemberId = AuthUtil.getLoginMemberIdOrNull();
 
-        final Pageable pageable = PageRequest.of(page, size);
-        Page<MemberPostDTO> posts = memberRepository.getMemberTaggedPostDto(loginedMemberId, username, pageable);
-        return posts;
+		final Member member = memberRepository.findByUsername(username)
+				.orElseThrow(MemberDoesNotExistException::new);
 
+		if (blockRepository.existsByMemberIdAndBlockMemberId(loginedMemberId, member.getId()) ||
+				blockRepository.existsByMemberIdAndBlockMemberId(member.getId(), loginedMemberId)) {
+			return null;
+		}
 
-    }
-    
-    public List<MemberPostDTO> getRecent15TaggedPostDTOs(String username) {
-        final Long loginedMemberId = AuthUtil.getLoginMemberIdOrNull();
+		final Pageable pageable = PageRequest.of(page, size);
+		Page<MemberPostDTO> posts = memberRepository.getMemberTaggedPostDto(loginedMemberId, username, pageable);
+		return posts;
 
-        final Member member = memberRepository.findByUsername(username)
-                                                .orElseThrow(MemberDoesNotExistException::new);
+	}
 
-        if(blockRepository.existsByMemberIdAndBlockMemberId(loginedMemberId, member.getId()) ||
-            blockRepository.existsByMemberIdAndBlockMemberId(member.getId(), loginedMemberId)){
-            return null;
-        }
-        
-        List<MemberPostDTO> posts = memberRepository.getRecent15TaggedPostDTOs(loginedMemberId, username);
-        return posts;
-    }
-    
+	public List<MemberPostDTO> getRecent15TaggedPostDTOs(String username) {
+		final Long loginedMemberId = AuthUtil.getLoginMemberIdOrNull();
+
+		final Member member = memberRepository.findByUsername(username)
+				.orElseThrow(MemberDoesNotExistException::new);
+
+		if (blockRepository.existsByMemberIdAndBlockMemberId(loginedMemberId, member.getId()) ||
+				blockRepository.existsByMemberIdAndBlockMemberId(member.getId(), loginedMemberId)) {
+			return null;
+		}
+
+		List<MemberPostDTO> posts = memberRepository.getRecent15TaggedPostDTOs(loginedMemberId, username);
+		return posts;
+	}
+
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/service/MemberPostService.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/service/MemberPostService.java
@@ -26,84 +26,83 @@ public class MemberPostService {
 
 	public Page<MemberPostDTO> getMemberPostDto(String username, int size, int page) {
 		page = (page == 0 ? 0 : page - 1) + 5;
-		final Long loginedMemberId = authUtil.getLoginMemberIdOrNull();
+		final Long loginMemberId = authUtil.getLoginMemberIdOrNull();
 
 		final Member member = memberRepository.findByUsername(username)
 				.orElseThrow(MemberDoesNotExistException::new);
 
-		if (blockRepository.existsByMemberIdAndBlockMemberId(loginedMemberId, member.getId()) ||
-				blockRepository.existsByMemberIdAndBlockMemberId(member.getId(), loginedMemberId)) {
+		if (blockRepository.existsByMemberIdAndBlockMemberId(loginMemberId, member.getId()) ||
+				blockRepository.existsByMemberIdAndBlockMemberId(member.getId(), loginMemberId)) {
 			return null;
 		}
 
 		final Pageable pageable = PageRequest.of(page, size);
-		Page<MemberPostDTO> posts = memberRepository.getMemberPostDto(loginedMemberId, username, pageable);
+		Page<MemberPostDTO> posts = memberRepository.getMemberPostDto(loginMemberId, username, pageable);
 		return posts;
 
 	}
 
 	public List<MemberPostDTO> getRecent15PostDTOs(String username) {
-		final Long loginedMemberId = authUtil.getLoginMemberIdOrNull();
+		final Long loginMemberId = authUtil.getLoginMemberIdOrNull();
 
 		final Member member = memberRepository.findByUsername(username)
 				.orElseThrow(MemberDoesNotExistException::new);
 
-		if (blockRepository.existsByMemberIdAndBlockMemberId(loginedMemberId, member.getId()) ||
-				blockRepository.existsByMemberIdAndBlockMemberId(member.getId(), loginedMemberId)) {
+		if (blockRepository.existsByMemberIdAndBlockMemberId(loginMemberId, member.getId()) ||
+				blockRepository.existsByMemberIdAndBlockMemberId(member.getId(), loginMemberId)) {
 			return null;
 		}
 
-		List<MemberPostDTO> posts = memberRepository.getRecent15PostDTOs(loginedMemberId, username);
+		List<MemberPostDTO> posts = memberRepository.getRecent15PostDTOs(loginMemberId, username);
 		return posts;
 	}
 
 	public Page<MemberPostDTO> getMemberSavedPostDto(int size, int page) {
 		page = (page == 0 ? 0 : page - 1) + 5;
-		final String loginedMemberId = SecurityContextHolder.getContext().getAuthentication().getName();
+		final Long loginMemberId = authUtil.getLoginMemberId();
 
 		final Pageable pageable = PageRequest.of(page, size);
-		Page<MemberPostDTO> posts = memberRepository.getMemberSavedPostDto(Long.valueOf(loginedMemberId), pageable);
+		Page<MemberPostDTO> posts = memberRepository.getMemberSavedPostDto(loginMemberId, pageable);
 		return posts;
-
 	}
 
 	public List<MemberPostDTO> getRecent15SavedPostDTOs() {
-		final String loginedMemberId = SecurityContextHolder.getContext().getAuthentication().getName();
+		final Long loginMemberId = authUtil.getLoginMemberId();
 
-		List<MemberPostDTO> posts = memberRepository.getRecent15SavedPostDTOs(Long.valueOf(loginedMemberId));
+		List<MemberPostDTO> posts = memberRepository.getRecent15SavedPostDTOs(loginMemberId);
 		return posts;
 	}
 
 	public Page<MemberPostDTO> getMemberTaggedPostDto(String username, int size, int page) {
 		page = (page == 0 ? 0 : page - 1) + 5;
-		final Long loginedMemberId = authUtil.getLoginMemberIdOrNull();
+		final Long loginMemberId = authUtil.getLoginMemberIdOrNull();
 
 		final Member member = memberRepository.findByUsername(username)
 				.orElseThrow(MemberDoesNotExistException::new);
 
-		if (blockRepository.existsByMemberIdAndBlockMemberId(loginedMemberId, member.getId()) ||
-				blockRepository.existsByMemberIdAndBlockMemberId(member.getId(), loginedMemberId)) {
+		if (blockRepository.existsByMemberIdAndBlockMemberId(loginMemberId, member.getId()) ||
+				blockRepository.existsByMemberIdAndBlockMemberId(member.getId(), loginMemberId)) {
 			return null;
 		}
 
 		final Pageable pageable = PageRequest.of(page, size);
-		Page<MemberPostDTO> posts = memberRepository.getMemberTaggedPostDto(loginedMemberId, username, pageable);
+		Page<MemberPostDTO> posts = memberRepository.getMemberTaggedPostDto(loginMemberId, username, pageable);
 		return posts;
 
 	}
 
 	public List<MemberPostDTO> getRecent15TaggedPostDTOs(String username) {
-		final Long loginedMemberId = authUtil.getLoginMemberIdOrNull();
+		final Long loginMemberId = authUtil.getLoginMemberIdOrNull();
 
 		final Member member = memberRepository.findByUsername(username)
 				.orElseThrow(MemberDoesNotExistException::new);
 
-		if (blockRepository.existsByMemberIdAndBlockMemberId(loginedMemberId, member.getId()) ||
-				blockRepository.existsByMemberIdAndBlockMemberId(member.getId(), loginedMemberId)) {
+		if (blockRepository.existsByMemberIdAndBlockMemberId(loginMemberId, member.getId()) ||
+				blockRepository.existsByMemberIdAndBlockMemberId(member.getId(), loginMemberId)) {
 			return null;
 		}
 
-		List<MemberPostDTO> posts = memberRepository.getRecent15TaggedPostDTOs(loginedMemberId, username);
+		List<MemberPostDTO> posts = memberRepository.getRecent15TaggedPostDTOs(loginMemberId, username);
 		return posts;
 	}
 

--- a/src/main/java/cloneproject/Instagram/domain/member/service/MemberPostService.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/service/MemberPostService.java
@@ -20,12 +20,13 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class MemberPostService {
 
+	private final AuthUtil authUtil;
 	private final MemberRepository memberRepository;
 	private final BlockRepository blockRepository;
 
 	public Page<MemberPostDTO> getMemberPostDto(String username, int size, int page) {
 		page = (page == 0 ? 0 : page - 1) + 5;
-		final Long loginedMemberId = AuthUtil.getLoginMemberIdOrNull();
+		final Long loginedMemberId = authUtil.getLoginMemberIdOrNull();
 
 		final Member member = memberRepository.findByUsername(username)
 				.orElseThrow(MemberDoesNotExistException::new);
@@ -42,7 +43,7 @@ public class MemberPostService {
 	}
 
 	public List<MemberPostDTO> getRecent15PostDTOs(String username) {
-		final Long loginedMemberId = AuthUtil.getLoginMemberIdOrNull();
+		final Long loginedMemberId = authUtil.getLoginMemberIdOrNull();
 
 		final Member member = memberRepository.findByUsername(username)
 				.orElseThrow(MemberDoesNotExistException::new);
@@ -75,7 +76,7 @@ public class MemberPostService {
 
 	public Page<MemberPostDTO> getMemberTaggedPostDto(String username, int size, int page) {
 		page = (page == 0 ? 0 : page - 1) + 5;
-		final Long loginedMemberId = AuthUtil.getLoginMemberIdOrNull();
+		final Long loginedMemberId = authUtil.getLoginMemberIdOrNull();
 
 		final Member member = memberRepository.findByUsername(username)
 				.orElseThrow(MemberDoesNotExistException::new);
@@ -92,7 +93,7 @@ public class MemberPostService {
 	}
 
 	public List<MemberPostDTO> getRecent15TaggedPostDTOs(String username) {
-		final Long loginedMemberId = AuthUtil.getLoginMemberIdOrNull();
+		final Long loginedMemberId = authUtil.getLoginMemberIdOrNull();
 
 		final Member member = memberRepository.findByUsername(username)
 				.orElseThrow(MemberDoesNotExistException::new);

--- a/src/main/java/cloneproject/Instagram/domain/member/service/MemberPostService.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/service/MemberPostService.java
@@ -1,5 +1,7 @@
 package cloneproject.Instagram.domain.member.service;
 
+import static cloneproject.Instagram.global.error.ErrorCode.*;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -20,8 +22,6 @@ import cloneproject.Instagram.global.error.exception.EntityNotFoundException;
 import cloneproject.Instagram.global.util.AuthUtil;
 import lombok.RequiredArgsConstructor;
 
-import static cloneproject.Instagram.global.error.ErrorCode.*;
-
 @Service
 @RequiredArgsConstructor
 public class MemberPostService {
@@ -30,9 +30,10 @@ public class MemberPostService {
 	private final MemberRepository memberRepository;
 	private final BlockRepository blockRepository;
 	private final PostImageRepository postImageRepository;
+	private static final int FIRST_PAGE_SIZE = 15;
+	private static final int PAGE_OFFSET = 4;
 
 	public Page<MemberPostDTO> getMemberPostDTOs(String username, int size, int page) {
-		page = (page == 0 ? 0 : page - 1) + 5;
 		final Long loginMemberId = authUtil.getLoginMemberIdOrNull();
 
 		final Member member = memberRepository.findByUsername(username)
@@ -42,11 +43,10 @@ public class MemberPostService {
 			return Page.empty();
 		}
 
-		final Pageable pageable = PageRequest.of(page, size);
-		Page<MemberPostDTO> posts = memberRepository.getMemberPostDTOs(username, pageable);
+		final Pageable pageable = PageRequest.of(page + PAGE_OFFSET, size);
+		final Page<MemberPostDTO> posts = memberRepository.getMemberPostDTOs(username, pageable);
 		setMemberPostImageDTOs(posts.getContent());
 		return posts;
-
 	}
 
 	public List<MemberPostDTO> getRecent15PostDTOs(String username) {
@@ -59,18 +59,17 @@ public class MemberPostService {
 			return Collections.emptyList();
 		}
 
-		final Pageable pageable = PageRequest.of(0, 15);
-		Page<MemberPostDTO> posts = memberRepository.getMemberPostDTOs(username, pageable);
+		final Pageable pageable = PageRequest.of(0, FIRST_PAGE_SIZE);
+		final Page<MemberPostDTO> posts = memberRepository.getMemberPostDTOs(username, pageable);
 		setMemberPostImageDTOs(posts.getContent());
 		return posts.getContent();
 	}
 
 	public Page<MemberPostDTO> getMemberSavedPostDTOs(int size, int page) {
-		page = (page == 0 ? 0 : page - 1) + 5;
 		final Long loginMemberId = authUtil.getLoginMemberId();
 
-		final Pageable pageable = PageRequest.of(page, size);
-		Page<MemberPostDTO> posts = memberRepository.getMemberSavedPostDTOs(loginMemberId, pageable);
+		final Pageable pageable = PageRequest.of(page + PAGE_OFFSET, size);
+		final Page<MemberPostDTO> posts = memberRepository.getMemberSavedPostDTOs(loginMemberId, pageable);
 		setMemberPostImageDTOs(posts.getContent());
 		return posts;
 	}
@@ -78,14 +77,13 @@ public class MemberPostService {
 	public List<MemberPostDTO> getRecent15SavedPostDTOs() {
 		final Long loginMemberId = authUtil.getLoginMemberId();
 
-		final Pageable pageable = PageRequest.of(0, 15);
-		Page<MemberPostDTO> posts = memberRepository.getMemberSavedPostDTOs(loginMemberId, pageable);
+		final Pageable pageable = PageRequest.of(0, FIRST_PAGE_SIZE);
+		final Page<MemberPostDTO> posts = memberRepository.getMemberSavedPostDTOs(loginMemberId, pageable);
 		setMemberPostImageDTOs(posts.getContent());
 		return posts.getContent();
 	}
 
 	public Page<MemberPostDTO> getMemberTaggedPostDTOs(String username, int size, int page) {
-		page = (page == 0 ? 0 : page - 1) + 5;
 		final Long loginMemberId = authUtil.getLoginMemberIdOrNull();
 
 		final Member member = memberRepository.findByUsername(username)
@@ -95,11 +93,10 @@ public class MemberPostService {
 			return Page.empty();
 		}
 
-		final Pageable pageable = PageRequest.of(page, size);
-		Page<MemberPostDTO> posts = memberRepository.getMemberTaggedPostDTOs(username, pageable);
+		final Pageable pageable = PageRequest.of(page + PAGE_OFFSET, size);
+		final Page<MemberPostDTO> posts = memberRepository.getMemberTaggedPostDTOs(username, pageable);
 		setMemberPostImageDTOs(posts.getContent());
 		return posts;
-
 	}
 
 	public List<MemberPostDTO> getRecent15TaggedPostDTOs(String username) {
@@ -112,8 +109,8 @@ public class MemberPostService {
 			return Collections.emptyList();
 		}
 
-		final Pageable pageable = PageRequest.of(0, 15);
-		Page<MemberPostDTO> posts = memberRepository.getMemberTaggedPostDTOs(username, pageable);
+		final Pageable pageable = PageRequest.of(0, FIRST_PAGE_SIZE);
+		final Page<MemberPostDTO> posts = memberRepository.getMemberTaggedPostDTOs(username, pageable);
 		setMemberPostImageDTOs(posts.getContent());
 		return posts.getContent();
 	}

--- a/src/main/java/cloneproject/Instagram/domain/member/service/MemberService.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/service/MemberService.java
@@ -1,5 +1,12 @@
 package cloneproject.Instagram.domain.member.service;
 
+import static cloneproject.Instagram.global.error.ErrorCode.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -25,13 +32,6 @@ import cloneproject.Instagram.global.vo.Image;
 import cloneproject.Instagram.infra.aws.S3Uploader;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
-import static cloneproject.Instagram.global.error.ErrorCode.*;
 
 @Slf4j
 @Service
@@ -64,7 +64,7 @@ public class MemberService {
 		final Member member = memberRepository.findByUsername(username)
 			.orElseThrow(() -> new EntityNotFoundException(MEMBER_NOT_FOUND));
 
-		UserProfileResponse result = memberRepository.getUserProfile(memberId, member.getUsername());
+		final UserProfileResponse result = memberRepository.getUserProfile(memberId, member.getUsername());
 		result.setHasStory(memberStoryRedisRepository.findAllByMemberId(member.getId()).size() > 0);
 
 		return result;
@@ -77,7 +77,7 @@ public class MemberService {
 		final Member member = memberRepository.findByUsername(username)
 			.orElseThrow(() -> new EntityNotFoundException(MEMBER_NOT_FOUND));
 
-		MiniProfileResponse result = memberRepository.getMiniProfile(memberId, member.getUsername());
+		final MiniProfileResponse result = memberRepository.getMiniProfile(memberId, member.getUsername());
 		result.setHasStory(memberStoryRedisRepository.findAllByMemberId(member.getId()).size() > 0);
 		setMemberPostImages(result, member.getId());
 		return result;
@@ -93,7 +93,7 @@ public class MemberService {
 		final Map<Long, List<PostImageDTO>> postDTOMap = postImages.stream()
 			.collect(Collectors.groupingBy(PostImageDTO::getPostId));
 
-		List<MiniProfilePostDTO> results = new ArrayList<>();
+		final List<MiniProfilePostDTO> results = new ArrayList<>();
 		postDTOMap.forEach((id, p) -> results.add(
 			MiniProfilePostDTO.builder()
 				.postId(id)
@@ -105,28 +105,28 @@ public class MemberService {
 
 	@Transactional
 	public void uploadMemberImage(MultipartFile uploadedImage) {
-		Member member = authUtil.getLoginMember();
+		final Member member = authUtil.getLoginMember();
 
 		// 기존 사진 삭제
-		Image originalImage = member.getImage();
+		final Image originalImage = member.getImage();
 		s3Uploader.deleteImage("member", originalImage);
 
-		Image image = s3Uploader.uploadImage(uploadedImage, "member");
+		final Image image = s3Uploader.uploadImage(uploadedImage, "member");
 		member.uploadImage(image);
 		memberRepository.save(member);
 	}
 
 	@Transactional
 	public void deleteMemberImage() {
-		Member member = authUtil.getLoginMember();
-		Image image = member.getImage();
+		final Member member = authUtil.getLoginMember();
+		final Image image = member.getImage();
 		s3Uploader.deleteImage("member", image);
 		member.deleteImage();
 		memberRepository.save(member);
 	}
 
 	public EditProfileResponse getEditProfile() {
-		Member member = authUtil.getLoginMember();
+		final Member member = authUtil.getLoginMember();
 		return EditProfileResponse.builder()
 			.memberUsername(member.getUsername())
 			.memberName(member.getName())
@@ -141,7 +141,7 @@ public class MemberService {
 
 	// TODO 변경시 이메일 인증 로직은?
 	public void editProfile(EditProfileRequest editProfileRequest) {
-		Member member = authUtil.getLoginMember();
+		final Member member = authUtil.getLoginMember();
 
 		if (memberRepository.existsByUsername(editProfileRequest.getMemberUsername())
 			&& !member.getUsername().equals(editProfileRequest.getMemberUsername())) {
@@ -157,4 +157,5 @@ public class MemberService {
 		member.updateGender(Gender.valueOf(editProfileRequest.getMemberGender()));
 		memberRepository.save(member);
 	}
+
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/service/MemberService.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/service/MemberService.java
@@ -4,6 +4,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import cloneproject.Instagram.domain.feed.dto.MiniProfilePostDTO;
+import cloneproject.Instagram.domain.feed.dto.PostImageDTO;
+import cloneproject.Instagram.domain.feed.entity.Post;
+import cloneproject.Instagram.domain.feed.repository.PostImageRepository;
+import cloneproject.Instagram.domain.feed.repository.PostRepository;
 import cloneproject.Instagram.domain.member.dto.EditProfileRequest;
 import cloneproject.Instagram.domain.member.dto.EditProfileResponse;
 import cloneproject.Instagram.domain.member.dto.MenuMemberDTO;
@@ -13,12 +18,18 @@ import cloneproject.Instagram.domain.member.entity.Gender;
 import cloneproject.Instagram.domain.member.entity.Member;
 import cloneproject.Instagram.domain.member.exception.UsernameAlreadyExistException;
 import cloneproject.Instagram.domain.member.repository.MemberRepository;
+import cloneproject.Instagram.domain.story.repository.MemberStoryRedisRepository;
 import cloneproject.Instagram.global.error.exception.EntityNotFoundException;
 import cloneproject.Instagram.global.util.AuthUtil;
 import cloneproject.Instagram.global.vo.Image;
 import cloneproject.Instagram.infra.aws.S3Uploader;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import static cloneproject.Instagram.global.error.ErrorCode.*;
 
@@ -30,17 +41,20 @@ public class MemberService {
 	private final AuthUtil authUtil;
 	private final MemberRepository memberRepository;
 	private final S3Uploader s3Uploader;
+	private final MemberStoryRedisRepository memberStoryRedisRepository;
+	private final PostRepository postRepository;
+	private final PostImageRepository postImageRepository;
 
 	@Transactional(readOnly = true)
 	public MenuMemberDTO getMenuMemberProfile() {
 		final Member member = authUtil.getLoginMember();
 
 		return MenuMemberDTO.builder()
-				.memberId(member.getId())
-				.memberUsername(member.getUsername())
-				.memberName(member.getName())
-				.memberImageUrl(member.getImage().getImageUrl())
-				.build();
+			.memberId(member.getId())
+			.memberUsername(member.getUsername())
+			.memberName(member.getName())
+			.memberImageUrl(member.getImage().getImageUrl())
+			.build();
 	}
 
 	@Transactional(readOnly = true)
@@ -48,9 +62,10 @@ public class MemberService {
 		final Long memberId = authUtil.getLoginMemberIdOrNull();
 
 		final Member member = memberRepository.findByUsername(username)
-				.orElseThrow(() -> new EntityNotFoundException(MEMBER_NOT_FOUND));
+			.orElseThrow(() -> new EntityNotFoundException(MEMBER_NOT_FOUND));
 
 		UserProfileResponse result = memberRepository.getUserProfile(memberId, member.getUsername());
+		result.setHasStory(memberStoryRedisRepository.findAllByMemberId(member.getId()).size() > 0);
 
 		return result;
 	}
@@ -60,11 +75,32 @@ public class MemberService {
 		final Long memberId = authUtil.getLoginMemberId();
 
 		final Member member = memberRepository.findByUsername(username)
-				.orElseThrow(() -> new EntityNotFoundException(MEMBER_NOT_FOUND));
+			.orElseThrow(() -> new EntityNotFoundException(MEMBER_NOT_FOUND));
 
 		MiniProfileResponse result = memberRepository.getMiniProfile(memberId, member.getUsername());
-
+		result.setHasStory(memberStoryRedisRepository.findAllByMemberId(member.getId()).size() > 0);
+		setMemberPostImages(result, member.getId());
 		return result;
+	}
+
+	private void setMemberPostImages(MiniProfileResponse miniProfileResponse, Long memberId) {
+		final List<Post> posts = postRepository.findTop3ByMemberIdOrderByIdDesc(memberId);
+		final List<Long> postIds = posts.stream()
+			.map(Post::getId)
+			.collect(Collectors.toList());
+		final List<PostImageDTO> postImages = postImageRepository.findAllPostImageDto(postIds);
+
+		final Map<Long, List<PostImageDTO>> postDTOMap = postImages.stream()
+			.collect(Collectors.groupingBy(PostImageDTO::getPostId));
+
+		List<MiniProfilePostDTO> results = new ArrayList<>();
+		postDTOMap.forEach((id, p) -> results.add(
+			MiniProfilePostDTO.builder()
+				.postId(id)
+				.postImageUrl(p.get(0).getPostImageUrl())
+				.build()));
+
+		miniProfileResponse.setMemberPosts(results);
 	}
 
 	@Transactional
@@ -92,15 +128,15 @@ public class MemberService {
 	public EditProfileResponse getEditProfile() {
 		Member member = authUtil.getLoginMember();
 		return EditProfileResponse.builder()
-				.memberUsername(member.getUsername())
-				.memberName(member.getName())
-				.memberImageUrl(member.getImage().getImageUrl())
-				.memberGender(member.getGender().toString())
-				.memberEmail(member.getEmail())
-				.memberIntroduce(member.getIntroduce())
-				.memberWebsite(member.getWebsite())
-				.memberPhone(member.getPhone())
-				.build();
+			.memberUsername(member.getUsername())
+			.memberName(member.getName())
+			.memberImageUrl(member.getImage().getImageUrl())
+			.memberGender(member.getGender().toString())
+			.memberEmail(member.getEmail())
+			.memberIntroduce(member.getIntroduce())
+			.memberWebsite(member.getWebsite())
+			.memberPhone(member.getPhone())
+			.build();
 	}
 
 	// TODO 변경시 이메일 인증 로직은?
@@ -108,7 +144,7 @@ public class MemberService {
 		Member member = authUtil.getLoginMember();
 
 		if (memberRepository.existsByUsername(editProfileRequest.getMemberUsername())
-				&& !member.getUsername().equals(editProfileRequest.getMemberUsername())) {
+			&& !member.getUsername().equals(editProfileRequest.getMemberUsername())) {
 			throw new UsernameAlreadyExistException();
 		}
 

--- a/src/main/java/cloneproject/Instagram/domain/member/service/MemberService.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/service/MemberService.java
@@ -26,113 +26,110 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class MemberService {
 
+	private final MemberRepository memberRepository;
 
-    private final MemberRepository memberRepository;
-    
-    private final S3Uploader s3Uploader;
+	private final S3Uploader s3Uploader;
 
-    @Transactional(readOnly = true)
-    public MenuMemberDTO getMenuMemberProfile(){
-        final String memberId = SecurityContextHolder.getContext().getAuthentication().getName();
+	@Transactional(readOnly = true)
+	public MenuMemberDTO getMenuMemberProfile() {
+		final String memberId = SecurityContextHolder.getContext().getAuthentication().getName();
 
-        final Member member = memberRepository.findById(Long.valueOf(memberId))
-                                .orElseThrow(MemberDoesNotExistException::new);
-        
-        return MenuMemberDTO.builder()
-                            .memberId(member.getId())
-                            .memberUsername(member.getUsername())
-                            .memberName(member.getName())
-                            .memberImageUrl(member.getImage().getImageUrl())
-                            .build();
-        
-    }
+		final Member member = memberRepository.findById(Long.valueOf(memberId))
+				.orElseThrow(MemberDoesNotExistException::new);
 
-    @Transactional(readOnly = true)
-    public UserProfileResponse getUserProfile(String username){
-        final Long memberId = AuthUtil.getLoginMemberIdOrNull();
-        
-        final Member member = memberRepository.findByUsername(username)
-                                .orElseThrow(MemberDoesNotExistException::new);
+		return MenuMemberDTO.builder()
+				.memberId(member.getId())
+				.memberUsername(member.getUsername())
+				.memberName(member.getName())
+				.memberImageUrl(member.getImage().getImageUrl())
+				.build();
 
-        
-        UserProfileResponse result = memberRepository.getUserProfile(memberId, member.getUsername());
-        
-        return result;
-    }
+	}
 
-    @Transactional(readOnly = true)
-    public MiniProfileResponse getMiniProfile(String username){
-        final String memberId = SecurityContextHolder.getContext().getAuthentication().getName();
+	@Transactional(readOnly = true)
+	public UserProfileResponse getUserProfile(String username) {
+		final Long memberId = AuthUtil.getLoginMemberIdOrNull();
 
-        final Member member = memberRepository.findByUsername(username)
-                                .orElseThrow(MemberDoesNotExistException::new);
-        
-        MiniProfileResponse result = memberRepository.getMiniProfile(Long.valueOf(memberId), member.getUsername());
+		final Member member = memberRepository.findByUsername(username)
+				.orElseThrow(MemberDoesNotExistException::new);
 
-        return result;
-    }
+		UserProfileResponse result = memberRepository.getUserProfile(memberId, member.getUsername());
 
-    @Transactional
-    public void uploadMemberImage(MultipartFile uploadedImage){
-        final String memberId = SecurityContextHolder.getContext().getAuthentication().getName();
-        Member member = memberRepository.findById(Long.valueOf(memberId))
-                                    .orElseThrow(MemberDoesNotExistException::new);
+		return result;
+	}
 
-        // 기존 사진 삭제
-        Image originalImage = member.getImage();
-        s3Uploader.deleteImage("member", originalImage);
+	@Transactional(readOnly = true)
+	public MiniProfileResponse getMiniProfile(String username) {
+		final String memberId = SecurityContextHolder.getContext().getAuthentication().getName();
 
-        Image image = s3Uploader.uploadImage(uploadedImage, "member");
-        member.uploadImage(image);
-        memberRepository.save(member);
-    }
+		final Member member = memberRepository.findByUsername(username)
+				.orElseThrow(MemberDoesNotExistException::new);
 
-    @Transactional
-    public void deleteMemberImage(){
-        final String memberId = SecurityContextHolder.getContext().getAuthentication().getName();
-        Member member = memberRepository.findById(Long.valueOf(memberId))
-                                    .orElseThrow(MemberDoesNotExistException::new);
-        Image image = member.getImage();
-        s3Uploader.deleteImage("member", image);
-        member.deleteImage();
-        memberRepository.save(member);
-    }
+		MiniProfileResponse result = memberRepository.getMiniProfile(Long.valueOf(memberId), member.getUsername());
 
-    public EditProfileResponse getEditProfile(){
-        final String memberId = SecurityContextHolder.getContext().getAuthentication().getName();
-        Member member = memberRepository.findById(Long.valueOf(memberId))
-                                .orElseThrow(MemberDoesNotExistException::new);
-        return EditProfileResponse.builder()
-                                .memberUsername(member.getUsername())
-                                .memberName(member.getName())
-                                .memberImageUrl(member.getImage().getImageUrl())
-                                .memberGender(member.getGender().toString())
-                                .memberEmail(member.getEmail())
-                                .memberIntroduce(member.getIntroduce())
-                                .memberWebsite(member.getWebsite())
-                                .memberPhone(member.getPhone())
-                                .build();
-    }
+		return result;
+	}
 
-    // TODO 변경시 이메일 인증 로직은?
-    public void editProfile(EditProfileRequest editProfileRequest){
-        final String memberId = SecurityContextHolder.getContext().getAuthentication().getName();
-        Member member = memberRepository.findById(Long.valueOf(memberId))
-                                .orElseThrow(MemberDoesNotExistException::new);
-        
-        if(memberRepository.existsByUsername(editProfileRequest.getMemberUsername())
-                        && !member.getUsername().equals(editProfileRequest.getMemberUsername())){
-            throw new UsernameAlreadyExistException();
-        }
-        
-        member.updateUsername(editProfileRequest.getMemberUsername());
-        member.updateName(editProfileRequest.getMemberName());
-        member.updateEmail(editProfileRequest.getMemberEmail());
-        member.updateIntroduce(editProfileRequest.getMemberIntroduce());
-        member.updateWebsite(editProfileRequest.getMemberWebsite());
-        member.updatePhone(editProfileRequest.getMemberPhone());
-        member.updateGender(Gender.valueOf(editProfileRequest.getMemberGender()));
-        memberRepository.save(member);
-    }
-    
+	@Transactional
+	public void uploadMemberImage(MultipartFile uploadedImage) {
+		final String memberId = SecurityContextHolder.getContext().getAuthentication().getName();
+		Member member = memberRepository.findById(Long.valueOf(memberId))
+				.orElseThrow(MemberDoesNotExistException::new);
+
+		// 기존 사진 삭제
+		Image originalImage = member.getImage();
+		s3Uploader.deleteImage("member", originalImage);
+
+		Image image = s3Uploader.uploadImage(uploadedImage, "member");
+		member.uploadImage(image);
+		memberRepository.save(member);
+	}
+
+	@Transactional
+	public void deleteMemberImage() {
+		final String memberId = SecurityContextHolder.getContext().getAuthentication().getName();
+		Member member = memberRepository.findById(Long.valueOf(memberId))
+				.orElseThrow(MemberDoesNotExistException::new);
+		Image image = member.getImage();
+		s3Uploader.deleteImage("member", image);
+		member.deleteImage();
+		memberRepository.save(member);
+	}
+
+	public EditProfileResponse getEditProfile() {
+		final String memberId = SecurityContextHolder.getContext().getAuthentication().getName();
+		Member member = memberRepository.findById(Long.valueOf(memberId))
+				.orElseThrow(MemberDoesNotExistException::new);
+		return EditProfileResponse.builder()
+				.memberUsername(member.getUsername())
+				.memberName(member.getName())
+				.memberImageUrl(member.getImage().getImageUrl())
+				.memberGender(member.getGender().toString())
+				.memberEmail(member.getEmail())
+				.memberIntroduce(member.getIntroduce())
+				.memberWebsite(member.getWebsite())
+				.memberPhone(member.getPhone())
+				.build();
+	}
+
+	// TODO 변경시 이메일 인증 로직은?
+	public void editProfile(EditProfileRequest editProfileRequest) {
+		final String memberId = SecurityContextHolder.getContext().getAuthentication().getName();
+		Member member = memberRepository.findById(Long.valueOf(memberId))
+				.orElseThrow(MemberDoesNotExistException::new);
+
+		if (memberRepository.existsByUsername(editProfileRequest.getMemberUsername())
+				&& !member.getUsername().equals(editProfileRequest.getMemberUsername())) {
+			throw new UsernameAlreadyExistException();
+		}
+
+		member.updateUsername(editProfileRequest.getMemberUsername());
+		member.updateName(editProfileRequest.getMemberName());
+		member.updateEmail(editProfileRequest.getMemberEmail());
+		member.updateIntroduce(editProfileRequest.getMemberIntroduce());
+		member.updateWebsite(editProfileRequest.getMemberWebsite());
+		member.updatePhone(editProfileRequest.getMemberPhone());
+		member.updateGender(Gender.valueOf(editProfileRequest.getMemberGender()));
+		memberRepository.save(member);
+	}
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/service/MemberService.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/service/MemberService.java
@@ -26,8 +26,8 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class MemberService {
 
+	private final AuthUtil authUtil;
 	private final MemberRepository memberRepository;
-
 	private final S3Uploader s3Uploader;
 
 	@Transactional(readOnly = true)
@@ -48,7 +48,7 @@ public class MemberService {
 
 	@Transactional(readOnly = true)
 	public UserProfileResponse getUserProfile(String username) {
-		final Long memberId = AuthUtil.getLoginMemberIdOrNull();
+		final Long memberId = authUtil.getLoginMemberIdOrNull();
 
 		final Member member = memberRepository.findByUsername(username)
 				.orElseThrow(MemberDoesNotExistException::new);

--- a/src/main/java/cloneproject/Instagram/domain/member/service/RefreshTokenService.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/service/RefreshTokenService.java
@@ -32,7 +32,7 @@ public class RefreshTokenService {
 
 	@Transactional
 	public void addRefreshToken(Long memberId, String tokenValue, String device, GeoIP geoIP) {
-		List<RefreshToken> refreshTokens = refreshTokenRedisRepository.findByMemberId(memberId)
+		final List<RefreshToken> refreshTokens = refreshTokenRedisRepository.findByMemberId(memberId)
 				.stream()
 				.sorted(Comparator.comparing(RefreshToken::getCreatedAt))
 				.collect(Collectors.toList());
@@ -42,7 +42,7 @@ public class RefreshTokenService {
 			refreshTokens.remove(i);
 		}
 
-		RefreshToken refreshToken = RefreshToken.builder()
+		final RefreshToken refreshToken = RefreshToken.builder()
 				.memberId(memberId)
 				.value(tokenValue)
 				.device(device)
@@ -59,7 +59,7 @@ public class RefreshTokenService {
 
 	@Transactional
 	public void updateRefreshToken(RefreshToken refreshToken, String newToken) {
-		RefreshToken newRefreshToken = RefreshToken.builder()
+		final RefreshToken newRefreshToken = RefreshToken.builder()
 				.memberId(refreshToken.getMemberId())
 				.value(newToken)
 				.device(refreshToken.getDevice())
@@ -71,28 +71,27 @@ public class RefreshTokenService {
 
 	@Transactional
 	public void deleteRefreshTokenWithValue(Long memberId, String value) {
-		RefreshToken refreshToken = refreshTokenRedisRepository.findByMemberIdAndValue(memberId, value)
+		final RefreshToken refreshToken = refreshTokenRedisRepository.findByMemberIdAndValue(memberId, value)
 				.orElseThrow(InvalidJwtException::new);
 		refreshTokenRedisRepository.delete(refreshToken);
 	}
 
 	@Transactional
 	public void deleteRefreshTokenWithId(Long memberId, String id) {
-		RefreshToken refreshToken = refreshTokenRedisRepository.findByMemberIdAndId(memberId, id)
+		final RefreshToken refreshToken = refreshTokenRedisRepository.findByMemberIdAndId(memberId, id)
 				.orElseThrow(InvalidJwtException::new);
 		refreshTokenRedisRepository.delete(refreshToken);
 	}
 
 	@Transactional(readOnly = true)
-	public List<LoginedDevicesDTO> getLoginedDevices(Long memberId) {
-		List<RefreshToken> refreshTokens = refreshTokenRedisRepository.findByMemberId(memberId)
+	public List<LoginedDevicesDTO> getLoginDevices(Long memberId) {
+		final List<RefreshToken> refreshTokens = refreshTokenRedisRepository.findByMemberId(memberId)
 				.stream()
 				.sorted(Comparator.comparing(RefreshToken::getCreatedAt).reversed())
 				.collect(Collectors.toList());
-		List<LoginedDevicesDTO> loginedDevicesDTOs = refreshTokens.stream()
+		return refreshTokens.stream()
 				.map(this::convertRefreshTokenToLoginedDevicesDTO)
 				.collect(Collectors.toList());
-		return loginedDevicesDTOs;
 	}
 
 	private LoginedDevicesDTO convertRefreshTokenToLoginedDevicesDTO(RefreshToken refreshToken) {
@@ -102,4 +101,5 @@ public class RefreshTokenService {
 				.location(refreshToken.getGeoIP())
 				.build();
 	}
+
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/service/RefreshTokenService.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/service/RefreshTokenService.java
@@ -9,7 +9,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import cloneproject.Instagram.domain.member.dto.LoginedDevicesDTO;
+import cloneproject.Instagram.domain.member.dto.LoginDevicesDTO;
 import cloneproject.Instagram.domain.member.entity.redis.RefreshToken;
 import cloneproject.Instagram.domain.member.exception.InvalidJwtException;
 import cloneproject.Instagram.domain.member.repository.redis.RefreshTokenRedisRepository;
@@ -84,7 +84,7 @@ public class RefreshTokenService {
 	}
 
 	@Transactional(readOnly = true)
-	public List<LoginedDevicesDTO> getLoginDevices(Long memberId) {
+	public List<LoginDevicesDTO> getLoginDevices(Long memberId) {
 		final List<RefreshToken> refreshTokens = refreshTokenRedisRepository.findByMemberId(memberId)
 				.stream()
 				.sorted(Comparator.comparing(RefreshToken::getCreatedAt).reversed())
@@ -94,8 +94,8 @@ public class RefreshTokenService {
 				.collect(Collectors.toList());
 	}
 
-	private LoginedDevicesDTO convertRefreshTokenToLoginedDevicesDTO(RefreshToken refreshToken) {
-		return LoginedDevicesDTO.builder()
+	private LoginDevicesDTO convertRefreshTokenToLoginedDevicesDTO(RefreshToken refreshToken) {
+		return LoginDevicesDTO.builder()
 				.tokenId(refreshToken.getId())
 				.device(refreshToken.getDevice())
 				.location(refreshToken.getGeoIP())

--- a/src/main/java/cloneproject/Instagram/domain/story/service/StoryService.java
+++ b/src/main/java/cloneproject/Instagram/domain/story/service/StoryService.java
@@ -71,7 +71,7 @@ public class StoryService {
                 .collect(Collectors.groupingBy(StoryContentRequest::getId));
         validateStoryUploadRequest(storyImages, storyContentMap);
 
-        final Long memberId = AuthUtil.getLoginMemberIdOrNull();
+        final Long memberId = authUtil.getLoginMemberIdOrNull();
         final Member member = memberRepository.findById(memberId).orElseThrow(MemberDoesNotExistException::new);
 
         final Set<String> usernames = new HashSet<>();
@@ -85,7 +85,8 @@ public class StoryService {
                 continue;
             final List<StoryContentRequest> storyContents = storyContentMap.get(i + 1);
             for (StoryContentRequest storyContent : storyContents) {
-                final List<String> mentionedUsernames = stringExtractUtil.extractMentions(storyContent.getContent(), List.of(member.getUsername()));
+                final List<String> mentionedUsernames = stringExtractUtil.extractMentions(storyContent.getContent(),
+                        List.of(member.getUsername()));
                 usernames.addAll(mentionedUsernames);
             }
 
@@ -137,7 +138,8 @@ public class StoryService {
                         joinRoomRepository.save(new JoinRoom(room, privateRoomMember, message));
                 }
 
-                final MessageResponse response = new MessageResponse(MessageAction.MESSAGE_GET, new MessageDTO(message));
+                final MessageResponse response = new MessageResponse(MessageAction.MESSAGE_GET,
+                        new MessageDTO(message));
                 messagingTemplate.convertAndSend("/sub/" + mentionedMember.getUsername(), response);
             });
 
@@ -150,7 +152,8 @@ public class StoryService {
         return new StatusResponse(true);
     }
 
-    private void validateStoryUploadRequest(List<MultipartFile> storyImages, Map<Integer, List<StoryContentRequest>> storyContentMap) {
+    private void validateStoryUploadRequest(List<MultipartFile> storyImages,
+            Map<Integer, List<StoryContentRequest>> storyContentMap) {
         final List<ErrorResponse.FieldError> errors = new ArrayList<>();
         if (storyImages.isEmpty()) {
             errors.add(new ErrorResponse.FieldError("storyImages", "empty", INVALID_STORY_IMAGE.getMessage()));
@@ -159,7 +162,8 @@ public class StoryService {
 
         storyContentMap.keySet().forEach(id -> {
             if (id > storyImages.size() || id < 1) {
-                errors.add(new ErrorResponse.FieldError("storyContents.id", id.toString(), INVALID_STORY_IMAGE_INDEX.getMessage()));
+                errors.add(new ErrorResponse.FieldError("storyContents.id", id.toString(),
+                        INVALID_STORY_IMAGE_INDEX.getMessage()));
                 throw new InvalidInputException(errors);
             }
         });

--- a/src/main/java/cloneproject/Instagram/global/error/ErrorCode.java
+++ b/src/main/java/cloneproject/Instagram/global/error/ErrorCode.java
@@ -14,83 +14,84 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorCode {
 
-    // Global
-    INTERNAL_SERVER_ERROR(500, "G001", "내부 서버 오류입니다."),
-    METHOD_NOT_ALLOWED(405, "G002", "허용되지 않은 HTTP method입니다."),
-    INPUT_VALUE_INVALID(400, "G003", "유효하지 않은 입력입니다."),
-    INPUT_TYPE_INVALID(400, "G004", "입력 타입이 유효하지 않습니다."),
-    HTTP_MESSAGE_NOT_READABLE(400, "G005", "request message body가 없거나, 값 타입이 올바르지 않습니다."),
-    HTTP_HEADER_INVALID(400, "G006", "request header가 유효하지 않습니다."),
-    IMAGE_TYPE_NOT_SUPPORTED(400, "G007", "지원하지 않는 이미지 타입입니다."),
-    FILE_CANT_CONVERT(500, "G008", "변환할 수 없는 파일입니다."),
+	// Global
+	INTERNAL_SERVER_ERROR(500, "G001", "내부 서버 오류입니다."),
+	METHOD_NOT_ALLOWED(405, "G002", "허용되지 않은 HTTP method입니다."),
+	INPUT_VALUE_INVALID(400, "G003", "유효하지 않은 입력입니다."),
+	INPUT_TYPE_INVALID(400, "G004", "입력 타입이 유효하지 않습니다."),
+	HTTP_MESSAGE_NOT_READABLE(400, "G005", "request message body가 없거나, 값 타입이 올바르지 않습니다."),
+	HTTP_HEADER_INVALID(400, "G006", "request header가 유효하지 않습니다."),
+	IMAGE_TYPE_NOT_SUPPORTED(400, "G007", "지원하지 않는 이미지 타입입니다."),
+	FILE_CANT_CONVERT(500, "G008", "변환할 수 없는 파일입니다."),
 
-    // Member
-    MEMBER_NOT_FOUND(400, "M001", "존재 하지 않는 유저입니다."),
-    USERNAME_ALREADY_EXIST(400, "M002", "이미 존재하는 사용자 이름입니다."),
-    NEED_TO_LOGIN(401, "M003", "로그인이 필요한 화면입니다."),
-    NO_AUTHORITY(403, "M004", "권한이 없습니다."),
-    ACCOUNT_MISMATCH(401, "M005", "계정 정보가 일치하지 않습니다."),
-    EMAIL_NOT_CONFIRMED(400, "M007", "인증 이메일 전송을 먼저 해야합니다."),
-    PASSWORD_RESET_FAIL(400, "M008", "잘못되거나 만료된 코드입니다"),
-    ALREADY_BLOCK(400, "M009", "이미 차단한 유저입니다."),
-    CANT_UNBLOCK(400, "M010", "차단하지 않은 유저는 차단해제 할 수 없습니다."),
-    CANT_BLOCK_MYSELF(400, "M011", "자기 자신을 차단 할 수 없습니다."),
-    CANT_UNBLOCK_MYSELF(400, "M012", "자기 자신을 차단해제 할 수 없습니다."),
+	// Member
+	MEMBER_NOT_FOUND(400, "M001", "존재 하지 않는 유저입니다."),
+	USERNAME_ALREADY_EXIST(400, "M002", "이미 존재하는 사용자 이름입니다."),
+	NEED_TO_LOGIN(401, "M003", "로그인이 필요한 화면입니다."),
+	NO_AUTHORITY(403, "M004", "권한이 없습니다."),
+	ACCOUNT_MISMATCH(401, "M005", "계정 정보가 일치하지 않습니다."),
+	EMAIL_NOT_CONFIRMED(400, "M007", "인증 이메일 전송을 먼저 해야합니다."),
+	PASSWORD_RESET_FAIL(400, "M008", "잘못되거나 만료된 코드입니다"),
+	ALREADY_BLOCK(400, "M009", "이미 차단한 유저입니다."),
+	CANT_UNBLOCK(400, "M010", "차단하지 않은 유저는 차단해제 할 수 없습니다."),
+	CANT_BLOCK_MYSELF(400, "M011", "자기 자신을 차단 할 수 없습니다."),
+	CANT_UNBLOCK_MYSELF(400, "M012", "자기 자신을 차단해제 할 수 없습니다."),
+	PASSWORD_ALREADY_EXIST(400, "M013", "기존 비밀번호와 동일하게 변경할 수 없습니다."),
 
-    // Follow
-    ALREADY_FOLLOW(400, "F001", "이미 팔로우한 유저입니다."),
-    CANT_UNFOLLOW(400, "F002", "팔로우하지 않은 유저는 언팔로우 할 수 없습니다."),
-    CANT_FOLLOW_MYSELF(400, "F003", "자기 자신을 팔로우 할 수 없습니다."),
-    CANT_UNFOLLOW_MYSELF(400, "F004", "자기 자신을 언팔로우 할 수 없습니다."),
-    CANT_DELETE_FOLLOWER(400, "F005", "팔로워 삭제할 수 없는 대상입니다."),
+	// Follow
+	ALREADY_FOLLOW(400, "F001", "이미 팔로우한 유저입니다."),
+	CANT_UNFOLLOW(400, "F002", "팔로우하지 않은 유저는 언팔로우 할 수 없습니다."),
+	CANT_FOLLOW_MYSELF(400, "F003", "자기 자신을 팔로우 할 수 없습니다."),
+	CANT_UNFOLLOW_MYSELF(400, "F004", "자기 자신을 언팔로우 할 수 없습니다."),
+	CANT_DELETE_FOLLOWER(400, "F005", "팔로워 삭제할 수 없는 대상입니다."),
 
-    // Jwt
-    INVALID_JWT(401, "J001", "유효하지 않은 토큰입니다."),
-    EXPIRED_ACCESS_TOKEN(401, "J002", "만료된 ACCESS 토큰입니다. REISSUE 해주십시오."),
-    EXPIRED_REFRESH_TOKEN(401, "J003", "만료된 REFRESH 토큰입니다. 재로그인 해주십시오."),
+	// Jwt
+	INVALID_JWT(401, "J001", "유효하지 않은 토큰입니다."),
+	EXPIRED_ACCESS_TOKEN(401, "J002", "만료된 ACCESS 토큰입니다. REISSUE 해주십시오."),
+	EXPIRED_REFRESH_TOKEN(401, "J003", "만료된 REFRESH 토큰입니다. 재로그인 해주십시오."),
 
-    // Feed
-    POST_NOT_FOUND(400, "F001", "존재하지 않는 게시물입니다."),
-    POST_CANT_DELETE(400, "F002", "게시물 게시자만 삭제할 수 있습니다."),
-    POST_LIKE_NOT_FOUND(400, "F003", "해당 게시물에 좋아요를 누르지 않은 회원입니다."),
-    POST_LIKE_ALREADY_EXIST(400, "F004", "해당 게시물에 이미 좋아요를 누른 회원입니다."),
-    POST_IMAGES_AND_ALT_TEXTS_MISMATCH(400, "F005", "게시물 이미지 개수와 대체 텍스트 개수는 동일해야 합니다."),
-    BOOKMARK_ALREADY_EXIST(400, "F006", "이미 해당 게시물을 저장하였습니다."),
-    BOOKMARK_NOT_FOUND(400, "F007", "아직 해당 게시물을 저장하지 않았습니다."),
-    COMMENT_NOT_FOUND(400, "F008", "존재하지 않는 댓글입니다."),
-    COMMENT_CANT_DELETE(400, "F009", "타인이 작성한 댓글은 삭제할 수 없습니다."),
-    COMMENT_LIKE_ALREADY_EXIST(400, "F010", "해당 댓글에 이미 좋아요를 누른 회원입니다."),
-    COMMENT_LIKE_NOT_FOUND(400, "F011", "해당 댓글에 좋아요를 누르지 않은 회원입니다."),
-    COMMENT_CANT_UPLOAD(400, "F012", "댓글 기능이 해제된 게시물에는 댓글을 작성할 수 없습니다."),
-    REPLY_CANT_UPLOAD(400, "F013", "최상위 댓글에만 답글을 업로드할 수 있습니다."),
+	// Feed
+	POST_NOT_FOUND(400, "F001", "존재하지 않는 게시물입니다."),
+	POST_CANT_DELETE(400, "F002", "게시물 게시자만 삭제할 수 있습니다."),
+	POST_LIKE_NOT_FOUND(400, "F003", "해당 게시물에 좋아요를 누르지 않은 회원입니다."),
+	POST_LIKE_ALREADY_EXIST(400, "F004", "해당 게시물에 이미 좋아요를 누른 회원입니다."),
+	POST_IMAGES_AND_ALT_TEXTS_MISMATCH(400, "F005", "게시물 이미지 개수와 대체 텍스트 개수는 동일해야 합니다."),
+	BOOKMARK_ALREADY_EXIST(400, "F006", "이미 해당 게시물을 저장하였습니다."),
+	BOOKMARK_NOT_FOUND(400, "F007", "아직 해당 게시물을 저장하지 않았습니다."),
+	COMMENT_NOT_FOUND(400, "F008", "존재하지 않는 댓글입니다."),
+	COMMENT_CANT_DELETE(400, "F009", "타인이 작성한 댓글은 삭제할 수 없습니다."),
+	COMMENT_LIKE_ALREADY_EXIST(400, "F010", "해당 댓글에 이미 좋아요를 누른 회원입니다."),
+	COMMENT_LIKE_NOT_FOUND(400, "F011", "해당 댓글에 좋아요를 누르지 않은 회원입니다."),
+	COMMENT_CANT_UPLOAD(400, "F012", "댓글 기능이 해제된 게시물에는 댓글을 작성할 수 없습니다."),
+	REPLY_CANT_UPLOAD(400, "F013", "최상위 댓글에만 답글을 업로드할 수 있습니다."),
 
-    // Chat
-    CHAT_ROOM_NOT_FOUND(400, "C001", "존재하지 않는 채팅방입니다."),
-    JOIN_ROOM_NOT_FOUND(400, "C002", "해당 채팅방에 참여하지 않은 회원입니다."),
-    MESSAGE_IMAGE_INVALID(400, "C003", "메시지로 전송할 이미지는 필수입니다."),
-    MESSAGE_NOT_FOUND(400, "C004", "존재하지 않는 메시지입니다."),
-    MESSAGE_SENDER_MISMATCH(400, "C005", "해당 메시지를 전송한 회원이 아닙니다."),
-    MESSAGE_LIKE_ALREADY_EXIST(400, "C006", "해당 메시지를 이미 좋아요한 회원입니다."),
-    MESSAGE_LIKE_NOT_FOUND(400, "C007", "해당 메시지를 좋아요하지 않은 회원입니다."),
+	// Chat
+	CHAT_ROOM_NOT_FOUND(400, "C001", "존재하지 않는 채팅방입니다."),
+	JOIN_ROOM_NOT_FOUND(400, "C002", "해당 채팅방에 참여하지 않은 회원입니다."),
+	MESSAGE_IMAGE_INVALID(400, "C003", "메시지로 전송할 이미지는 필수입니다."),
+	MESSAGE_NOT_FOUND(400, "C004", "존재하지 않는 메시지입니다."),
+	MESSAGE_SENDER_MISMATCH(400, "C005", "해당 메시지를 전송한 회원이 아닙니다."),
+	MESSAGE_LIKE_ALREADY_EXIST(400, "C006", "해당 메시지를 이미 좋아요한 회원입니다."),
+	MESSAGE_LIKE_NOT_FOUND(400, "C007", "해당 메시지를 좋아요하지 않은 회원입니다."),
 
-    // Alarm
-    MISMATCHED_ALARM_TYPE(400, "A001", "알람 형식이 올바르지 않습니다."),
+	// Alarm
+	MISMATCHED_ALARM_TYPE(400, "A001", "알람 형식이 올바르지 않습니다."),
 
-    // Email
-    CANT_SEND_EMAIL(500, "E001", "이메일 전송 중 오류가 발생했습니다."),
+	// Email
+	CANT_SEND_EMAIL(500, "E001", "이메일 전송 중 오류가 발생했습니다."),
 
-    // HashTag
-    HASHTAG_NOT_FOUND(400, "H001", "존재하지 않는 해시태그 입니다"),
-    CANT_FOLLOW_HASHTAG(400, "H002", "해시태그 팔로우 실패"),
-    CANT_UNFOLLOW_HASHTAG(400, "H003", "해시태그 언팔로우 실패"),
+	// HashTag
+	HASHTAG_NOT_FOUND(400, "H001", "존재하지 않는 해시태그 입니다"),
+	CANT_FOLLOW_HASHTAG(400, "H002", "해시태그 팔로우 실패"),
+	CANT_UNFOLLOW_HASHTAG(400, "H003", "해시태그 언팔로우 실패"),
 
-    // Story
-    INVALID_STORY_IMAGE(400, "S001", "스토리 이미지는 필수입니다."),
-    INVALID_STORY_IMAGE_INDEX(400, "S002", "스토리 이미지 인덱스가 올바르지 않습니다."),
-    MEMBER_STORY_NOT_FOUND(400, "S003", "해당 회원은 24시간 이내에 스토리를 업로드하지 않았습니다."),
-    ;
+	// Story
+	INVALID_STORY_IMAGE(400, "S001", "스토리 이미지는 필수입니다."),
+	INVALID_STORY_IMAGE_INDEX(400, "S002", "스토리 이미지 인덱스가 올바르지 않습니다."),
+	MEMBER_STORY_NOT_FOUND(400, "S003", "해당 회원은 24시간 이내에 스토리를 업로드하지 않았습니다."),
+	;
 
-    private int status;
-    private final String code;
-    private final String message;
+	private int status;
+	private final String code;
+	private final String message;
 }

--- a/src/main/java/cloneproject/Instagram/global/util/AuthUtil.java
+++ b/src/main/java/cloneproject/Instagram/global/util/AuthUtil.java
@@ -13,7 +13,7 @@ public class AuthUtil {
 
 	private final MemberRepository memberRepository;
 
-	public static Long getLoginMemberIdOrNull() {
+	public Long getLoginMemberIdOrNull() {
 		try {
 			final String memberId = SecurityContextHolder.getContext().getAuthentication().getName();
 			return Long.valueOf(memberId);

--- a/src/main/java/cloneproject/Instagram/infra/aws/S3Uploader.java
+++ b/src/main/java/cloneproject/Instagram/infra/aws/S3Uploader.java
@@ -30,9 +30,9 @@ public class S3Uploader {
 	public String bucket;
 
 	public String upload(MultipartFile multipartFile, String dirName, String UUID, String name, String type)
-			throws IOException {
+		throws IOException {
 		File uploadFile = convert(multipartFile)
-				.orElseThrow(CantConvertFileException::new);
+			.orElseThrow(CantConvertFileException::new);
 
 		return upload(uploadFile, dirName, UUID, name, type);
 	}
@@ -41,7 +41,7 @@ public class S3Uploader {
 		try {
 			final Image image = ImageUtil.convertMultipartToImage(multipartFile);
 			final String url = upload(multipartFile, dirName, image.getImageUUID(),
-					image.getImageName(), image.getImageType().toString());
+				image.getImageName(), image.getImageType().toString());
 			image.setUrl(url);
 			return image;
 		} catch (IOException e) {
@@ -59,7 +59,7 @@ public class S3Uploader {
 			return;
 		}
 		String filename = dirName + "/" + image.getImageUUID() + "_" + image.getImageName()
-				+ "." + image.getImageType().toString();
+			+ "." + image.getImageType().toString();
 		deleteS3(filename);
 	}
 
@@ -72,7 +72,7 @@ public class S3Uploader {
 
 	private String putS3(File uploadFile, String fileName) {
 		amazonS3Client.putObject(
-				new PutObjectRequest(bucket, fileName, uploadFile).withCannedAcl(CannedAccessControlList.PublicRead));
+			new PutObjectRequest(bucket, fileName, uploadFile).withCannedAcl(CannedAccessControlList.PublicRead));
 		return amazonS3Client.getUrl(bucket, fileName).toString();
 	}
 
@@ -91,7 +91,7 @@ public class S3Uploader {
 	private Optional<File> convert(MultipartFile file) throws IOException {
 		File convertFile = new File(System.getProperty("user.dir") + "\\upload\\" + file.getOriginalFilename());
 		if (convertFile.createNewFile()) { // 바로 위에서 지정한 경로에 File이 생성됨 (경로가 잘못되었다면 생성 불가능)
-			try (FileOutputStream fos = new FileOutputStream(convertFile)) { 
+			try (FileOutputStream fos = new FileOutputStream(convertFile)) {
 				// FileOutputStream 데이터를 파일에 바이트 스트림으로 저장하기 위함
 				fos.write(file.getBytes());
 			}

--- a/src/main/resources/resetPasswordEmailUI.html
+++ b/src/main/resources/resetPasswordEmailUI.html
@@ -194,7 +194,7 @@
                                             <!-- 아래 href 속성값: 코드를 통한 로그인 연결링크 -->
                                             <!-- 임의로 accounts/login?username=dlwlrma&code= 로 설정해뒀습니다. 편하신대로 변경하시고, 말씀해주세요.-->
                                             <a
-                                              href="http://ec2-3-36-185-121.ap-northeast-2.compute.amazonaws.com/accounts/login?{username=dlwlrma&code=%s}"
+                                              href="http://ec2-3-36-185-121.ap-northeast-2.compute.amazonaws.com/accounts/login?username=%s&code=%s"
                                               style="
                                                 color: #3b5998;
                                                 text-decoration: none;
@@ -315,7 +315,7 @@
                                                                     <!-- 실제 인스타그램 라우터와 동일하게 accouts/password/reset/confirm/? 로 설정해두었습니다. -->
 
                                                                     <a
-                                                                      href="http://ec2-3-36-185-121.ap-northeast-2.compute.amazonaws.com/accounts/password/reset/confirm/?{username=dlwlrma&code=%s}"
+                                                                      href="http://ec2-3-36-185-121.ap-northeast-2.compute.amazonaws.com/accounts/password/reset/confirm/?username=%s&code=%s"
                                                                       style="
                                                                         color: #3b5998;
                                                                         text-decoration: none;


### PR DESCRIPTION
<!--
✅ Resolve: #이슈번호 형태로 입력해 주세요.
ex) Resolve: #123
-->
## 📌Linked Issues
- Resolve: #159 

<!--
✅ 변경 사항을 자세히 알려주세요. (why -> what -> how)
-->
## ✏Change Details
### member 도메인에 컨벤션 적용
- 지난번 유저 인증을 제외한 부분에 컨벤션 적용
### AuthUtil의 메서드 일부 수정
- static으로 지정 되어있던 `getLoginMemberIdOrNull` 메서드를 일반 메서드로 변경
- 이에 따라 연관된 API 수정
### Member 도메인 리팩토링
- member 도메인에 AuthUtil을 적용해 중복 코드 제거
- MemberNotFoundException을 EntityNotFoundException으로 변경
- querydsl 관련 리팩토링
  - 중복되는 서브쿼리를 메서드로 분리
  - 의미 없는 매개변수(loginUserId) 삭제
  - loginedUserId를 loginUserId로 변경
  - 차단함/차단당함 여부를 Querydsl로 구현 => 기존 2개의 쿼리를 1개의 쿼리로 줄임
  - MemberPost와 관련된 유사한 기능의 메서드를 하나로 통합(e.g. getRecent15MemberPostDTOs와 getMemberPostDTOs를 통합)
  - 하나의 메서드가 하나의 기능만 하도록 분리
  - 차단여부를 확인하는 메서드(checkBlock)를 제거 => 이제 다른 메서드 실행시 자동적으로 수행됨 
- DTO 수정
  - MemberPostDTO내 postImageUrl(String)을 PostImageDTO로 변경
- 유저 관련 서비스 리팩토링
  - MemberPostService에서 null이 아닌 []을 반환하도록 수정
  - MemberPostService내 중복코드를 setMemberPostImageDTOs로 분리
  - setHasStory를 repository가 아닌 서비스 층에서 사용하도록 변경

<!--
✅ 추가로 전달할 내용이 있다면 적어주세요.
-->
## 💬Comment
- Empty Page, MemberPostDTO의 content 변경은 배포후 프론트분들께 전달하겠습니다.
- 저도 IntelliJ로 넘어 왔습니다.. 😳 Eclipse 기반 formatter가 좀 더 엄격한 느낌이 있어 vscode로 foramtting하면 마음에 안드는 개행이 생기더라구요..
<!--
✅ 참고한 사이트가 있다면 공유해주세요.
-->
## 📑References

## ✅Check List
- [x] 추가한 기능에 대한 테스트는 모두 완료하셨나요?
- [x] 코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?
