### PR TITLE
검색 도메인 리팩토링, 최근 검색 기록 구현

### DIFF
--- a/src/main/java/cloneproject/Instagram/domain/follow/repository/querydsl/FollowRepositoryQuerydsl.java
+++ b/src/main/java/cloneproject/Instagram/domain/follow/repository/querydsl/FollowRepositoryQuerydsl.java
@@ -1,11 +1,17 @@
 package cloneproject.Instagram.domain.follow.repository.querydsl;
 
 import java.util.List;
+import java.util.Map;
 
+import cloneproject.Instagram.domain.follow.dto.FollowDTO;
 import cloneproject.Instagram.domain.follow.dto.FollowerDTO;
 
 public interface FollowRepositoryQuerydsl {
-    
-    List<FollowerDTO> getFollowings(Long loginedMemberId, Long memberId);
-    List<FollowerDTO> getFollowers(Long loginedMemberId, Long memberId);
+
+	List<FollowerDTO> getFollowings(Long loginedMemberId, Long memberId);
+
+	List<FollowerDTO> getFollowers(Long loginedMemberId, Long memberId);
+
+	Map<String, List<FollowDTO>> getFollowingMemberFollowMap(Long loginId, List<String> usernames);
+
 }

--- a/src/main/java/cloneproject/Instagram/domain/follow/repository/querydsl/FollowRepositoryQuerydslImpl.java
+++ b/src/main/java/cloneproject/Instagram/domain/follow/repository/querydsl/FollowRepositoryQuerydslImpl.java
@@ -1,91 +1,114 @@
 package cloneproject.Instagram.domain.follow.repository.querydsl;
 
-import java.util.List;
+import static cloneproject.Instagram.domain.follow.entity.QFollow.*;
+import static cloneproject.Instagram.domain.member.entity.QMember.*;
 
-import cloneproject.Instagram.domain.follow.dto.FollowerDTO;
-import cloneproject.Instagram.domain.member.dto.MemberDTO;
-import cloneproject.Instagram.domain.story.repository.MemberStoryRedisRepository;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
+import cloneproject.Instagram.domain.follow.dto.FollowDTO;
+import cloneproject.Instagram.domain.follow.dto.FollowerDTO;
+import cloneproject.Instagram.domain.follow.dto.QFollowDTO;
 import cloneproject.Instagram.domain.follow.dto.QFollowerDTO;
+import cloneproject.Instagram.domain.member.dto.MemberDTO;
+import cloneproject.Instagram.domain.story.repository.MemberStoryRedisRepository;
 import lombok.RequiredArgsConstructor;
 
-import static cloneproject.Instagram.domain.follow.entity.QFollow.follow;
-import static cloneproject.Instagram.domain.member.entity.QMember.member;
-
 @RequiredArgsConstructor
-public class FollowRepositoryQuerydslImpl implements FollowRepositoryQuerydsl{
+public class FollowRepositoryQuerydslImpl implements FollowRepositoryQuerydsl {
 
-    private final JPAQueryFactory queryFactory;
-    private final MemberStoryRedisRepository memberStoryRedisRepository;
+	private final JPAQueryFactory queryFactory;
+	private final MemberStoryRedisRepository memberStoryRedisRepository;
 
-    @Override
-    public List<FollowerDTO> getFollowings(Long loginedMemberId, Long memberId){
+	@Override
+	public List<FollowerDTO> getFollowings(Long loginedMemberId, Long memberId) {
 
-        final List<FollowerDTO> followerDTOs = queryFactory
-                    .select(new QFollowerDTO(
-                        member,
-                        JPAExpressions
-                            .selectFrom(follow)
-                            .where(follow.member.id.eq(loginedMemberId).and(follow.followMember.eq(member)))
-                            .exists(),
-                        JPAExpressions
-                            .selectFrom(follow)
-                            .where(follow.member.eq(member).and(follow.followMember.id.eq(loginedMemberId)))
-                            .exists(),
-                        member.id.eq(loginedMemberId)
-                    ))
-                    .from(member)
-                    .where(member.id.in(JPAExpressions
-                                        .select(follow.followMember.id)
-                                        .from(follow)
-                                        .where(follow.member.id.eq(memberId))
-                    ))
-                    .fetch();
+		final List<FollowerDTO> followerDTOs = queryFactory
+			.select(new QFollowerDTO(
+				member,
+				JPAExpressions
+					.selectFrom(follow)
+					.where(follow.member.id.eq(loginedMemberId).and(follow.followMember.eq(member)))
+					.exists(),
+				JPAExpressions
+					.selectFrom(follow)
+					.where(follow.member.eq(member).and(follow.followMember.id.eq(loginedMemberId)))
+					.exists(),
+				member.id.eq(loginedMemberId)
+			))
+			.from(member)
+			.where(member.id.in(JPAExpressions
+				.select(follow.followMember.id)
+				.from(follow)
+				.where(follow.member.id.eq(memberId))
+			))
+			.fetch();
 
-        followerDTOs.forEach(follower -> {
-            final MemberDTO member = follower.getMember();
-            final boolean hasStory = memberStoryRedisRepository.findAllByMemberId(member.getId()).size() > 0;
-            member.setHasStory(hasStory);
-        });
+		followerDTOs.forEach(follower -> {
+			final MemberDTO member = follower.getMember();
+			final boolean hasStory = memberStoryRedisRepository.findAllByMemberId(member.getId()).size() > 0;
+			member.setHasStory(hasStory);
+		});
 
-        return followerDTOs;
-    }
+		return followerDTOs;
+	}
 
-    @Override
-    public List<FollowerDTO> getFollowers(Long loginedMemberId, Long memberId){
+	@Override
+	public List<FollowerDTO> getFollowers(Long loginedMemberId, Long memberId) {
 
-        final List<FollowerDTO> followerDTOs = queryFactory
-                    .select(new QFollowerDTO(
-                        member,
-                        JPAExpressions
-                            .selectFrom(follow)
-                            .where(follow.member.id.eq(loginedMemberId).and(follow.followMember.eq(member)))
-                            .exists(),
-                        JPAExpressions
-                            .selectFrom(follow)
-                            .where(follow.member.eq(member).and(follow.followMember.id.eq(loginedMemberId)))
-                            .exists(),
-                        member.id.eq(loginedMemberId)
-                    ))
-                    .from(member)
-                    .where(member.id.in(JPAExpressions
-                                        .select(follow.member.id)
-                                        .from(follow)
-                                        .where(follow.followMember.id.eq(memberId))
-                    ))
-                    .fetch();
+		final List<FollowerDTO> followerDTOs = queryFactory
+			.select(new QFollowerDTO(
+				member,
+				JPAExpressions
+					.selectFrom(follow)
+					.where(follow.member.id.eq(loginedMemberId).and(follow.followMember.eq(member)))
+					.exists(),
+				JPAExpressions
+					.selectFrom(follow)
+					.where(follow.member.eq(member).and(follow.followMember.id.eq(loginedMemberId)))
+					.exists(),
+				member.id.eq(loginedMemberId)
+			))
+			.from(member)
+			.where(member.id.in(JPAExpressions
+				.select(follow.member.id)
+				.from(follow)
+				.where(follow.followMember.id.eq(memberId))
+			))
+			.fetch();
 
-        followerDTOs.forEach(follower -> {
-            final MemberDTO member = follower.getMember();
-            final boolean hasStory = memberStoryRedisRepository.findAllByMemberId(member.getId()).size() > 0;
-            member.setHasStory(hasStory);
-        });
+		followerDTOs.forEach(follower -> {
+			final MemberDTO member = follower.getMember();
+			final boolean hasStory = memberStoryRedisRepository.findAllByMemberId(member.getId()).size() > 0;
+			member.setHasStory(hasStory);
+		});
 
-        return followerDTOs;
+		return followerDTOs;
 
-    }
+	}
+
+	@Override
+	public Map<String, List<FollowDTO>> getFollowingMemberFollowMap(Long loginId, List<String> usernames) {
+		final List<FollowDTO> follows = queryFactory
+			.select(new QFollowDTO(
+				follow.member.username,
+				follow.followMember.username
+			))
+			.from(follow)
+			.where(follow.followMember.username.in(usernames)
+				.and(follow.member.id.in(
+					JPAExpressions
+						.select(follow.followMember.id)
+						.from(follow)
+						.where(follow.member.id.eq(loginId))
+				)))
+			.fetch();
+		return follows.stream()
+			.collect(Collectors.groupingBy(FollowDTO::getFollowMemberUsername));
+	}
 
 }

--- a/src/main/java/cloneproject/Instagram/domain/follow/repository/querydsl/FollowRepositoryQuerydslImpl.java
+++ b/src/main/java/cloneproject/Instagram/domain/follow/repository/querydsl/FollowRepositoryQuerydslImpl.java
@@ -26,7 +26,6 @@ public class FollowRepositoryQuerydslImpl implements FollowRepositoryQuerydsl {
 
 	@Override
 	public List<FollowerDTO> getFollowings(Long loginedMemberId, Long memberId) {
-
 		final List<FollowerDTO> followerDTOs = queryFactory
 			.select(new QFollowerDTO(
 				member,
@@ -59,7 +58,6 @@ public class FollowRepositoryQuerydslImpl implements FollowRepositoryQuerydsl {
 
 	@Override
 	public List<FollowerDTO> getFollowers(Long loginedMemberId, Long memberId) {
-
 		final List<FollowerDTO> followerDTOs = queryFactory
 			.select(new QFollowerDTO(
 				member,
@@ -88,7 +86,6 @@ public class FollowRepositoryQuerydslImpl implements FollowRepositoryQuerydsl {
 		});
 
 		return followerDTOs;
-
 	}
 
 	@Override

--- a/src/main/java/cloneproject/Instagram/domain/search/controller/SearchController.java
+++ b/src/main/java/cloneproject/Instagram/domain/search/controller/SearchController.java
@@ -1,5 +1,7 @@
 package cloneproject.Instagram.domain.search.controller;
 
+import static cloneproject.Instagram.global.result.ResultCode.*;
+
 import java.util.List;
 
 import javax.validation.constraints.Min;
@@ -10,12 +12,12 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import cloneproject.Instagram.domain.search.dto.SearchDTO;
 import cloneproject.Instagram.domain.search.service.SearchService;
-import cloneproject.Instagram.global.result.ResultCode;
 import cloneproject.Instagram.global.result.ResultResponse;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
@@ -29,17 +31,18 @@ import lombok.extern.slf4j.Slf4j;
 @Api(tags = "검색 API")
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/topsearch")
 public class SearchController {
 
 	private final SearchService searchService;
 
 	@ApiOperation(value = "검색")
 	@ApiImplicitParam(name = "text", value = "검색내용", required = true, example = "dlwl")
-	@GetMapping(value = "/topsearch")
+	@GetMapping(value = "/")
 	public ResponseEntity<ResultResponse> searchText(@RequestParam String text) {
-		List<SearchDTO> searchDTOs = searchService.searchByText(text);
+		final List<SearchDTO> searchDTOs = searchService.searchByText(text);
 
-		return ResponseEntity.ok(ResultResponse.of(ResultCode.SEARCH_SUCCESS, searchDTOs));
+		return ResponseEntity.ok(ResultResponse.of(SEARCH_SUCCESS, searchDTOs));
 	}
 
 	@ApiOperation(value = "검색 조회수 증가, 최근 검색 기록 업데이트")
@@ -47,28 +50,28 @@ public class SearchController {
 		@ApiImplicitParam(name = "entityName", value = "조회수 증가시킬 식별 name", required = true, example = "dlwlrma"),
 		@ApiImplicitParam(name = "entityType", value = "조회수 증가시킬 type", required = true, example = "MEMBER")
 	})
-	@PostMapping(value = "/topsearch/mark")
+	@PostMapping(value = "/mark")
 	public ResponseEntity<ResultResponse> markSearchedEntity(@RequestParam String entityName,
 		@RequestParam String entityType) {
 		searchService.markSearchedEntity(entityName, entityType);
 
-		return ResponseEntity.ok(ResultResponse.of(ResultCode.MARK_SEARCHED_ENTITY_SUCCESS));
+		return ResponseEntity.ok(ResultResponse.of(MARK_SEARCHED_ENTITY_SUCCESS));
 	}
 
 	@ApiOperation(value = "최근 검색 기록(15개 조회)")
-	@GetMapping(value = "/topsearch/recent/top")
+	@GetMapping(value = "/recent/top")
 	public ResponseEntity<ResultResponse> getTop15RecentSearch() {
-		Page<SearchDTO> searchDTOs = searchService.getTop15RecentSearches();
+		final Page<SearchDTO> searchDTOs = searchService.getTop15RecentSearches();
 
-		return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_TOP_15_RECENT_SEARCH_SUCCESS, searchDTOs));
+		return ResponseEntity.ok(ResultResponse.of(GET_TOP_15_RECENT_SEARCH_SUCCESS, searchDTOs));
 	}
 
 	@ApiOperation(value = "최근 검색 기록 무한스크롤")
-	@GetMapping(value = "/topsearch/recent")
+	@GetMapping(value = "/recent")
 	public ResponseEntity<ResultResponse> getRecentSearch(@Min(1) @RequestParam int page) {
-		Page<SearchDTO> searchDTOs = searchService.getRecentSearches(page);
+		final Page<SearchDTO> searchDTOs = searchService.getRecentSearches(page);
 
-		return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_RECENT_SEARCH_SUCCESS, searchDTOs));
+		return ResponseEntity.ok(ResultResponse.of(GET_RECENT_SEARCH_SUCCESS, searchDTOs));
 	}
 
 	@ApiOperation(value = "최근 검색 기록 삭제")
@@ -76,20 +79,20 @@ public class SearchController {
 		@ApiImplicitParam(name = "entityName", value = "삭제할 식별 name", required = true, example = "dlwlrma"),
 		@ApiImplicitParam(name = "entityType", value = "삭제할 type", required = true, example = "MEMBER")
 	})
-	@DeleteMapping(value = "/topsearch/recent")
+	@DeleteMapping(value = "/recent")
 	public ResponseEntity<ResultResponse> deleteRecentSearch(@RequestParam String entityName,
 		@RequestParam String entityType) {
 		searchService.deleteRecentSearch(entityName, entityType);
 
-		return ResponseEntity.ok(ResultResponse.of(ResultCode.DELETE_RECENT_SEARCH_SUCCESS));
+		return ResponseEntity.ok(ResultResponse.of(DELETE_RECENT_SEARCH_SUCCESS));
 	}
 
 	@ApiOperation(value = "최근 검색 기록 모두 삭제")
-	@DeleteMapping(value = "/topsearch/recent/all")
+	@DeleteMapping(value = "/recent/all")
 	public ResponseEntity<ResultResponse> deleteAllRecentSearch() {
 		searchService.deleteAllRecentSearch();
 
-		return ResponseEntity.ok(ResultResponse.of(ResultCode.DELETE_ALL_RECENT_SEARCH_SUCCESS));
+		return ResponseEntity.ok(ResultResponse.of(DELETE_ALL_RECENT_SEARCH_SUCCESS));
 	}
 
 }

--- a/src/main/java/cloneproject/Instagram/domain/search/dto/SearchDTO.java
+++ b/src/main/java/cloneproject/Instagram/domain/search/dto/SearchDTO.java
@@ -1,7 +1,5 @@
 package cloneproject.Instagram.domain.search.dto;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -13,10 +11,7 @@ import lombok.Setter;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 public abstract class SearchDTO {
-    
-    private String dtype;
 
-    @JsonIgnore
-    private Long count;
+	private String dtype;
 
 }

--- a/src/main/java/cloneproject/Instagram/domain/search/dto/SearchHashtagDTO.java
+++ b/src/main/java/cloneproject/Instagram/domain/search/dto/SearchHashtagDTO.java
@@ -1,5 +1,7 @@
 package cloneproject.Instagram.domain.search.dto;
 
+import java.time.LocalDateTime;
+
 import com.querydsl.core.annotations.QueryProjection;
 
 import cloneproject.Instagram.domain.hashtag.entity.Hashtag;
@@ -17,8 +19,8 @@ public class SearchHashtagDTO extends SearchDTO{
     private Integer postCount;
 
     @QueryProjection
-    public SearchHashtagDTO(String dtype, Long count, Hashtag hashtag){
-        super(dtype, count);
+    public SearchHashtagDTO(String dtype, Hashtag hashtag){
+        super(dtype);
         this.name = hashtag.getName();
         this.postCount = hashtag.getCount();
     }

--- a/src/main/java/cloneproject/Instagram/domain/search/dto/SearchMemberDTO.java
+++ b/src/main/java/cloneproject/Instagram/domain/search/dto/SearchMemberDTO.java
@@ -1,5 +1,6 @@
 package cloneproject.Instagram.domain.search.dto;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import com.querydsl.core.annotations.QueryProjection;
@@ -23,13 +24,14 @@ public class SearchMemberDTO extends SearchDTO{
     private List<FollowDTO> followingMemberFollow;
 
     @QueryProjection
-    public SearchMemberDTO(String dtype, Long count, Member member, boolean isFollowing, boolean isFollower){
-        super(dtype, count);
+    public SearchMemberDTO(String dtype, Member member, boolean isFollowing, boolean isFollower){
+        super(dtype);
         this.memberDTO = new MemberDTO(member);
         this.isFollowing = isFollowing;
         this.isFollower = isFollower;
         // this.followingMemberFollow = followingMemberFollow;
     }
+
     public void setFollowingMemberFollow(List<FollowDTO> followingMemberFollow) {
         this.followingMemberFollow = followingMemberFollow;
     }

--- a/src/main/java/cloneproject/Instagram/domain/search/entity/RecentSearch.java
+++ b/src/main/java/cloneproject/Instagram/domain/search/entity/RecentSearch.java
@@ -45,8 +45,8 @@ public class RecentSearch {
 	@JoinColumn(name = "search_id")
 	private Search search;
 
-	@Column(name = "recent_search_last_searched_at")
-	private LocalDateTime lastSearchedAt;
+	@Column(name = "recent_search_last_searched_date")
+	private LocalDateTime lastSearchedDate;
 
 	@Builder
 	public RecentSearch(Member member, Search search) {
@@ -54,8 +54,8 @@ public class RecentSearch {
 		this.search = search;
 	}
 
-	public void updateLastSearchedAt() {
-		this.lastSearchedAt = LocalDateTime.now();
+	public void updateLastSearchedDate() {
+		this.lastSearchedDate = LocalDateTime.now();
 	}
 
 }

--- a/src/main/java/cloneproject/Instagram/domain/search/entity/RecentSearch.java
+++ b/src/main/java/cloneproject/Instagram/domain/search/entity/RecentSearch.java
@@ -1,0 +1,61 @@
+package cloneproject.Instagram.domain.search.entity;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.IdClass;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+import cloneproject.Instagram.domain.member.entity.Member;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "recent_searches")
+@IdClass(RecentSearch.RecentSearchId.class)
+public class RecentSearch {
+
+	@NoArgsConstructor(access = AccessLevel.PROTECTED)
+	@AllArgsConstructor(access = AccessLevel.PROTECTED)
+	static class RecentSearchId implements Serializable {
+
+		private Long member;
+		private Long search;
+
+	}
+
+	@Id
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id")
+	private Member member;
+
+	@Id
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "search_id")
+	private Search search;
+
+	@Column(name = "recent_search_last_searched_at")
+	private LocalDateTime lastSearchedAt;
+
+	@Builder
+	public RecentSearch(Member member, Search search) {
+		this.member = member;
+		this.search = search;
+	}
+
+	public void updateLastSearchedAt() {
+		this.lastSearchedAt = LocalDateTime.now();
+	}
+
+}

--- a/src/main/java/cloneproject/Instagram/domain/search/entity/Search.java
+++ b/src/main/java/cloneproject/Instagram/domain/search/entity/Search.java
@@ -1,8 +1,18 @@
 package cloneproject.Instagram.domain.search.entity;
 
-import lombok.Getter;
+import javax.persistence.Column;
+import javax.persistence.DiscriminatorColumn;
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.Table;
+import javax.persistence.Transient;
 
-import javax.persistence.*;
+import lombok.Getter;
 
 @Getter
 @Entity
@@ -11,28 +21,28 @@ import javax.persistence.*;
 @Table(name = "searches")
 public class Search {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "search_id")
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "search_id")
+	private Long id;
 
-    @Column(name = "search_count")
-    private Long count;
+	@Column(name = "search_count")
+	private Long count;
 
-    @Column(insertable = false, updatable = false)
-    private String dtype;
+	@Column(insertable = false, updatable = false)
+	private String dtype;
 
-    protected Search(){
-        this.count = 0L;
-    }
+	protected Search() {
+		this.count = 0L;
+	}
 
-    public void upCount(){
-        this.count++;
-    }
+	public void upCount() {
+		this.count++;
+	}
 
-    @Transient
-    public void setDtype() {
-        this.dtype = getClass().getAnnotation(DiscriminatorValue.class).value();
-    }
+	@Transient
+	public void setDtype() {
+		this.dtype = getClass().getAnnotation(DiscriminatorValue.class).value();
+	}
 
 }

--- a/src/main/java/cloneproject/Instagram/domain/search/entity/SearchHashtag.java
+++ b/src/main/java/cloneproject/Instagram/domain/search/entity/SearchHashtag.java
@@ -17,15 +17,15 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @DiscriminatorValue("HASHTAG")
 @Table(name = "search_hashtags")
-public class SearchHashtag extends Search{
-    
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "hashtag_id")
-    private Hashtag hashtag;
+public class SearchHashtag extends Search {
 
-    public SearchHashtag(Hashtag hashtag) {
-        super();
-        this.hashtag = hashtag;
-    }
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "hashtag_id")
+	private Hashtag hashtag;
+
+	public SearchHashtag(Hashtag hashtag) {
+		super();
+		this.hashtag = hashtag;
+	}
 
 }

--- a/src/main/java/cloneproject/Instagram/domain/search/entity/SearchMember.java
+++ b/src/main/java/cloneproject/Instagram/domain/search/entity/SearchMember.java
@@ -17,15 +17,15 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @DiscriminatorValue("MEMBER")
 @Table(name = "search_members")
-public class SearchMember extends Search{
-    
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
-    private Member member;
+public class SearchMember extends Search {
 
-    public SearchMember(Member member) {
-        super();
-        this.member = member;
-    }
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id")
+	private Member member;
+
+	public SearchMember(Member member) {
+		super();
+		this.member = member;
+	}
 
 }

--- a/src/main/java/cloneproject/Instagram/domain/search/repository/RecentSearchRepository.java
+++ b/src/main/java/cloneproject/Instagram/domain/search/repository/RecentSearchRepository.java
@@ -1,0 +1,16 @@
+package cloneproject.Instagram.domain.search.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import cloneproject.Instagram.domain.search.entity.RecentSearch;
+import cloneproject.Instagram.domain.search.repository.querydsl.RecentSearchRepositoryQuerydsl;
+
+public interface RecentSearchRepository extends JpaRepository<RecentSearch, Long>, RecentSearchRepositoryQuerydsl {
+
+	Optional<RecentSearch> findByMemberIdAndSearchId(Long memberId, Long searchId);
+
+	void deleteAllByMemberId(Long memberId);
+
+}

--- a/src/main/java/cloneproject/Instagram/domain/search/repository/SearchHashtagRepository.java
+++ b/src/main/java/cloneproject/Instagram/domain/search/repository/SearchHashtagRepository.java
@@ -10,7 +10,7 @@ import cloneproject.Instagram.domain.search.entity.SearchHashtag;
 
 public interface SearchHashtagRepository extends JpaRepository<SearchHashtag, Long> {
 
-    Optional<SearchHashtag> findByHashtagName(String name);
+	Optional<SearchHashtag> findByHashtagName(String name);
 
-    List<SearchHashtag> findAllByHashtagIn(List<Hashtag> hashtags);
+	List<SearchHashtag> findAllByHashtagIn(List<Hashtag> hashtags);
 }

--- a/src/main/java/cloneproject/Instagram/domain/search/repository/SearchMemberRepository.java
+++ b/src/main/java/cloneproject/Instagram/domain/search/repository/SearchMemberRepository.java
@@ -6,8 +6,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import cloneproject.Instagram.domain.search.entity.SearchMember;
 
-public interface SearchMemberRepository extends JpaRepository<SearchMember, Long>{
-    
-    Optional<SearchMember> findByMemberUsername(String username);
+public interface SearchMemberRepository extends JpaRepository<SearchMember, Long> {
+
+	Optional<SearchMember> findByMemberUsername(String username);
 
 }

--- a/src/main/java/cloneproject/Instagram/domain/search/repository/SearchRepository.java
+++ b/src/main/java/cloneproject/Instagram/domain/search/repository/SearchRepository.java
@@ -5,6 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import cloneproject.Instagram.domain.search.entity.Search;
 import cloneproject.Instagram.domain.search.repository.querydsl.SearchRepositoryQuerydsl;
 
-public interface SearchRepository extends JpaRepository<Search, Long>, SearchRepositoryQuerydsl{
-    
+public interface SearchRepository extends JpaRepository<Search, Long>, SearchRepositoryQuerydsl {
+
 }

--- a/src/main/java/cloneproject/Instagram/domain/search/repository/querydsl/RecentSearchRepositoryQuerydsl.java
+++ b/src/main/java/cloneproject/Instagram/domain/search/repository/querydsl/RecentSearchRepositoryQuerydsl.java
@@ -9,10 +9,13 @@ import cloneproject.Instagram.domain.search.entity.RecentSearch;
 import cloneproject.Instagram.domain.search.entity.Search;
 
 public interface RecentSearchRepositoryQuerydsl {
+
 	Optional<RecentSearch> findRecentSearchByUsername(Long loginId, String username);
+
 	Optional<RecentSearch> findRecentSearchByHashtagName(Long loginId, String name);
 
 	List<Search> findAllByMemberId(Long loginId, Pageable pageable);
+
 	Long getRecentSearchCount(Long loginId);
 
 }

--- a/src/main/java/cloneproject/Instagram/domain/search/repository/querydsl/RecentSearchRepositoryQuerydsl.java
+++ b/src/main/java/cloneproject/Instagram/domain/search/repository/querydsl/RecentSearchRepositoryQuerydsl.java
@@ -1,0 +1,18 @@
+package cloneproject.Instagram.domain.search.repository.querydsl;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.domain.Pageable;
+
+import cloneproject.Instagram.domain.search.entity.RecentSearch;
+import cloneproject.Instagram.domain.search.entity.Search;
+
+public interface RecentSearchRepositoryQuerydsl {
+	Optional<RecentSearch> findRecentSearchByUsername(Long loginId, String username);
+	Optional<RecentSearch> findRecentSearchByHashtagName(Long loginId, String name);
+
+	List<Search> findAllByMemberId(Long loginId, Pageable pageable);
+	Long getRecentSearchCount(Long loginId);
+
+}

--- a/src/main/java/cloneproject/Instagram/domain/search/repository/querydsl/RecentSearchRepositoryQuerydslImpl.java
+++ b/src/main/java/cloneproject/Instagram/domain/search/repository/querydsl/RecentSearchRepositoryQuerydslImpl.java
@@ -50,7 +50,7 @@ public class RecentSearchRepositoryQuerydslImpl implements RecentSearchRepositor
 			.where(recentSearch.member.id.eq(loginId))
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize())
-			.orderBy(recentSearch.lastSearchedAt.desc())
+			.orderBy(recentSearch.lastSearchedDate.desc())
 			.distinct()
 			.fetch();
 	}

--- a/src/main/java/cloneproject/Instagram/domain/search/repository/querydsl/RecentSearchRepositoryQuerydslImpl.java
+++ b/src/main/java/cloneproject/Instagram/domain/search/repository/querydsl/RecentSearchRepositoryQuerydslImpl.java
@@ -1,0 +1,67 @@
+package cloneproject.Instagram.domain.search.repository.querydsl;
+
+import static cloneproject.Instagram.domain.search.entity.QRecentSearch.*;
+import static cloneproject.Instagram.domain.search.entity.QSearchMember.*;
+import static cloneproject.Instagram.domain.search.entity.QSearchHashtag.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.domain.Pageable;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import cloneproject.Instagram.domain.search.entity.RecentSearch;
+import cloneproject.Instagram.domain.search.entity.Search;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+public class RecentSearchRepositoryQuerydslImpl implements RecentSearchRepositoryQuerydsl {
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public Optional<RecentSearch> findRecentSearchByUsername(Long loginId, String username) {
+		return Optional.ofNullable(queryFactory
+			.select(recentSearch)
+			.from(recentSearch)
+			.innerJoin(recentSearch.search, searchMember._super)
+			.where(recentSearch.member.id.eq(loginId).and(searchMember.member.username.eq(username)))
+			.fetchOne());
+	}
+
+	@Override
+	public Optional<RecentSearch> findRecentSearchByHashtagName(Long loginId, String name) {
+		return Optional.ofNullable(queryFactory
+			.select(recentSearch)
+			.from(recentSearch)
+			.innerJoin(recentSearch.search, searchHashtag._super)
+			.where(recentSearch.member.id.eq(loginId).and(searchHashtag.hashtag.name.eq(name)))
+			.fetchOne());
+	}
+
+	@Override
+	public List<Search> findAllByMemberId(Long loginId, Pageable pageable) {
+		return queryFactory
+			.select(recentSearch.search)
+			.from(recentSearch)
+			.where(recentSearch.member.id.eq(loginId))
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.orderBy(recentSearch.lastSearchedAt.desc())
+			.distinct()
+			.fetch();
+	}
+
+	@Override
+	public Long getRecentSearchCount(Long loginId) {
+		return queryFactory
+			.selectOne()
+			.from(recentSearch)
+			.where(recentSearch.member.id.eq(loginId))
+			.fetchCount();
+	}
+
+}

--- a/src/main/java/cloneproject/Instagram/domain/search/repository/querydsl/SearchRepositoryQuerydsl.java
+++ b/src/main/java/cloneproject/Instagram/domain/search/repository/querydsl/SearchRepositoryQuerydsl.java
@@ -1,12 +1,24 @@
 package cloneproject.Instagram.domain.search.repository.querydsl;
 
 import java.util.List;
+import java.util.Map;
 
-import cloneproject.Instagram.domain.search.dto.SearchDTO;
+import cloneproject.Instagram.domain.search.dto.SearchHashtagDTO;
+import cloneproject.Instagram.domain.search.dto.SearchMemberDTO;
+import cloneproject.Instagram.domain.search.entity.Search;
 
 public interface SearchRepositoryQuerydsl {
-    
-    List<SearchDTO> searchByText(Long loginedId, String text);
-    List<SearchDTO> searchByTextOnlyHashtag(Long loginedId, String text);
+
+	List<Search> findHashtagsByTextLike(String text);
+
+	List<Search> findAllByTextLike(String text);
+
+	void checkMatchingMember(Long loginId, String text, List<Search> searches, List<Long> searchIds);
+
+	void checkMatchingHashtag(String text, List<Search> searches, List<Long> searchIds);
+
+	Map<Long, SearchHashtagDTO> findAllSearchHashtagDTOsByIdIn(List<Long> searchIds);
+
+	Map<Long, SearchMemberDTO> findAllSearchMemberDTOsByIdIn(Long loginId, List<Long> ids);
 
 }

--- a/src/main/java/cloneproject/Instagram/domain/search/repository/querydsl/SearchRepositoryQuerydslImpl.java
+++ b/src/main/java/cloneproject/Instagram/domain/search/repository/querydsl/SearchRepositoryQuerydslImpl.java
@@ -30,7 +30,7 @@ public class SearchRepositoryQuerydslImpl implements SearchRepositoryQuerydsl {
 
 	@Override
 	public List<Search> findAllByTextLike(String text) {
-		String keyword = text + "%";
+		final String keyword = text + "%";
 
 		return queryFactory
 			.select(search)
@@ -57,7 +57,7 @@ public class SearchRepositoryQuerydslImpl implements SearchRepositoryQuerydsl {
 
 	@Override
 	public List<Search> findHashtagsByTextLike(String text) {
-		String keyword = text + "%";
+		final String keyword = text + "%";
 
 		return queryFactory
 			.select(search)
@@ -77,7 +77,7 @@ public class SearchRepositoryQuerydslImpl implements SearchRepositoryQuerydsl {
 
 	@Override
 	public void checkMatchingMember(Long loginId, String text, List<Search> searches, List<Long> searchIds) {
-		Search matchingSearch = queryFactory
+		final Search matchingSearch = queryFactory
 			.select(searchMember._super)
 			.from(searchMember)
 			.where(searchMember.member.username.eq(text))
@@ -94,7 +94,7 @@ public class SearchRepositoryQuerydslImpl implements SearchRepositoryQuerydsl {
 
 	@Override
 	public void checkMatchingHashtag(String text, List<Search> searches, List<Long> searchIds) {
-		Search matchingSearch = queryFactory
+		final Search matchingSearch = queryFactory
 			.select(searchHashtag._super)
 			.from(searchHashtag)
 			.where(searchHashtag.hashtag.name.eq(text))

--- a/src/main/java/cloneproject/Instagram/domain/search/service/SearchService.java
+++ b/src/main/java/cloneproject/Instagram/domain/search/service/SearchService.java
@@ -1,71 +1,197 @@
 package cloneproject.Instagram.domain.search.service;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
-import cloneproject.Instagram.domain.hashtag.entity.Hashtag;
-import cloneproject.Instagram.domain.hashtag.exception.HashtagNotFoundException;
-import cloneproject.Instagram.domain.member.exception.MemberDoesNotExistException;
-import cloneproject.Instagram.domain.search.dto.SearchDTO;
-import cloneproject.Instagram.domain.search.entity.SearchHashtag;
-import cloneproject.Instagram.domain.search.entity.SearchMember;
-import cloneproject.Instagram.domain.search.repository.SearchHashtagRepository;
-import cloneproject.Instagram.domain.search.repository.SearchMemberRepository;
-import cloneproject.Instagram.domain.search.repository.SearchRepository;
-
-import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import cloneproject.Instagram.domain.follow.dto.FollowDTO;
+import cloneproject.Instagram.domain.follow.repository.FollowRepository;
+import cloneproject.Instagram.domain.hashtag.entity.Hashtag;
+import cloneproject.Instagram.domain.hashtag.exception.HashtagNotFoundException;
+import cloneproject.Instagram.domain.member.entity.Member;
+import cloneproject.Instagram.domain.member.exception.MemberDoesNotExistException;
+import cloneproject.Instagram.domain.search.dto.SearchDTO;
+import cloneproject.Instagram.domain.search.dto.SearchHashtagDTO;
+import cloneproject.Instagram.domain.search.dto.SearchMemberDTO;
+import cloneproject.Instagram.domain.search.entity.RecentSearch;
+import cloneproject.Instagram.domain.search.entity.Search;
+import cloneproject.Instagram.domain.search.entity.SearchHashtag;
+import cloneproject.Instagram.domain.search.repository.RecentSearchRepository;
+import cloneproject.Instagram.domain.search.repository.SearchHashtagRepository;
+import cloneproject.Instagram.domain.search.repository.SearchMemberRepository;
+import cloneproject.Instagram.domain.search.repository.SearchRepository;
+import cloneproject.Instagram.domain.story.repository.MemberStoryRedisRepository;
+import cloneproject.Instagram.global.error.exception.EntityTypeInvalidException;
+import cloneproject.Instagram.global.util.AuthUtil;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class SearchService {
 
-    private final SearchRepository searchRepository;
-    private final SearchMemberRepository searchMemberRepository;
-    private final SearchHashtagRepository searchHashtagRepository;
+	private final AuthUtil authUtil;
+	private final SearchRepository searchRepository;
+	private final SearchMemberRepository searchMemberRepository;
+	private final SearchHashtagRepository searchHashtagRepository;
+	private final RecentSearchRepository recentSearchRepository;
+	private final MemberStoryRedisRepository memberStoryRedisRepository;
+	private final FollowRepository followRepository;
+	private static final int FIRST_PAGE_SIZE = 15;
+	private static final int PAGE_SIZE = 5;
+	private static final int PAGE_OFFSET = 2;
 
-    @Transactional(readOnly = true)
-    public List<SearchDTO> searchByText(String text) {
-        final String memberId = SecurityContextHolder.getContext().getAuthentication().getName();
-        final List<SearchDTO> result;
-        text = text.trim();
-        if (text.charAt(0) == '#') {
-            result = searchRepository.searchByTextOnlyHashtag(Long.valueOf(memberId), text.substring(1));
-        } else {
-            result = searchRepository.searchByText(Long.valueOf(memberId), text);
-        }
-        return result;
-    }
+	@Transactional(readOnly = true)
+	public List<SearchDTO> searchByText(String text) {
+		text = text.trim();
+		final Long loginId = authUtil.getLoginMemberId();
+		List<Search> searches;
+		if (text.charAt(0) == '#') {
+			searches = searchRepository.findHashtagsByTextLike(text.substring(1));
+		} else {
+			searches = searchRepository.findAllByTextLike(text);
+		}
 
-    @Transactional
-    public void increaseSearchCount(String entityName, String entityType) {
-        switch(entityType){
-            case "MEMBER":
-                SearchMember searchMember = searchMemberRepository.findByMemberUsername(entityName)
-                        .orElseThrow(MemberDoesNotExistException::new);
-                searchMember.upCount();
-                searchMemberRepository.save(searchMember);
-                break;
-            case "HASHTAG":
-                SearchHashtag searchHashtag = searchHashtagRepository.findByHashtagName(entityName)
-                        .orElseThrow(HashtagNotFoundException::new);
-                searchHashtag.upCount();
-                searchHashtagRepository.save(searchHashtag);
-                break;
-        }
-    }
+		final List<Long> searchIds = searches.stream()
+			.map(Search::getId)
+			.collect(Collectors.toList());
 
-    @Transactional
-    public void createSearchHashtag(Hashtag hashtag) {
-        searchHashtagRepository.save(new SearchHashtag(hashtag));
-    }
+		searchRepository.checkMatchingHashtag(text, searches, searchIds);
+		searchRepository.checkMatchingMember(loginId, text, searches, searchIds);
 
-    @Transactional
-    public void deleteSearchHashtags(List<Hashtag> hashtags) {
-        final List<SearchHashtag> searchHashtags = searchHashtagRepository.findAllByHashtagIn(hashtags);
-        searchHashtagRepository.deleteAllInBatch(searchHashtags);
-    }
+		return setSearchContent(loginId, searches, searchIds);
+	}
+
+	@Transactional(readOnly = true)
+	public Page<SearchDTO> getTop15RecentSearches() {
+		final Long loginId = authUtil.getLoginMemberId();
+		Pageable pageable = PageRequest.of(0, FIRST_PAGE_SIZE);
+		List<Search> searches = recentSearchRepository.findAllByMemberId(loginId, pageable);
+
+		final List<Long> searchIds = searches.stream()
+			.map(Search::getId)
+			.collect(Collectors.toList());
+
+		List<SearchDTO> searchDTOs = setSearchContent(loginId, searches, searchIds);
+		Long total = recentSearchRepository.getRecentSearchCount(loginId);
+		return new PageImpl<>(searchDTOs, pageable, total);
+	}
+
+	@Transactional(readOnly = true)
+	public Page<SearchDTO> getRecentSearches(int page) {
+		final Long loginId = authUtil.getLoginMemberId();
+		Pageable pageable = PageRequest.of(page + PAGE_OFFSET, PAGE_SIZE);
+		List<Search> searches = recentSearchRepository.findAllByMemberId(loginId, pageable);
+
+		final List<Long> searchIds = searches.stream()
+			.map(Search::getId)
+			.collect(Collectors.toList());
+
+		List<SearchDTO> searchDTOs = setSearchContent(loginId, searches, searchIds);
+		Long total = recentSearchRepository.getRecentSearchCount(loginId);
+		return new PageImpl<>(searchDTOs, pageable, total);
+	}
+
+	@Transactional
+	public void deleteRecentSearch(String entityName, String entityType) {
+		Long loginId = authUtil.getLoginMemberId();
+		switch (entityType) {
+			case "MEMBER":
+				recentSearchRepository.findRecentSearchByUsername(loginId, entityName)
+					.ifPresent(recentSearchRepository::delete);
+				break;
+			case "HASHTAG":
+				recentSearchRepository.findRecentSearchByHashtagName(loginId, entityName)
+					.ifPresent(recentSearchRepository::delete);
+				break;
+			default:
+				throw new EntityTypeInvalidException();
+		}
+	}
+
+	@Transactional
+	public void deleteAllRecentSearch() {
+		Long loginId = authUtil.getLoginMemberId();
+		recentSearchRepository.deleteAllByMemberId(loginId);
+	}
+
+	@Transactional
+	public void markSearchedEntity(String entityName, String entityType) {
+		Member loginMember = authUtil.getLoginMember();
+		Search search;
+		switch (entityType) {
+			case "MEMBER":
+				search = searchMemberRepository.findByMemberUsername(entityName)
+					.orElseThrow(MemberDoesNotExistException::new);
+				break;
+			case "HASHTAG":
+				search = searchHashtagRepository.findByHashtagName(entityName)
+					.orElseThrow(HashtagNotFoundException::new);
+				break;
+			default:
+				throw new EntityTypeInvalidException();
+		}
+		search.upCount();
+		searchRepository.save(search);
+
+		RecentSearch recentSearch = recentSearchRepository.findByMemberIdAndSearchId(loginMember.getId(),
+				search.getId())
+			.orElse(RecentSearch.builder()
+				.member(loginMember)
+				.search(search)
+				.build());
+		recentSearch.updateLastSearchedAt();
+		recentSearchRepository.save(recentSearch);
+	}
+
+	private List<SearchDTO> setSearchContent(Long loginId, List<Search> searches, List<Long> searchIds) {
+		final Map<Long, SearchMemberDTO> memberMap = searchRepository.findAllSearchMemberDTOsByIdIn(loginId, searchIds);
+		final Map<Long, SearchHashtagDTO> hashtagMap = searchRepository.findAllSearchHashtagDTOsByIdIn(searchIds);
+		final List<String> searchUsernames = memberMap.values().stream().map(s -> s.getMemberDTO().getUsername())
+			.collect(Collectors.toList());
+
+		// 스토리 주입
+		memberMap.forEach((id, member) -> {
+			member.getMemberDTO().setHasStory(memberStoryRedisRepository.findById(id).isPresent());
+		});
+		
+		// 팔로우 주입
+		final Map<String, List<FollowDTO>> followsMap = followRepository.getFollowingMemberFollowMap(loginId,
+			searchUsernames);
+		memberMap.forEach(
+			(id, member) -> member.setFollowingMemberFollow(followsMap.get(member.getMemberDTO().getUsername())));
+
+		return searches.stream()
+			.map(search -> {
+				switch (search.getDtype()) {
+					case "MEMBER":
+						return memberMap.get(search.getId());
+					case "HASHTAG":
+						return hashtagMap.get(search.getId());
+					default:
+						return null;
+				}
+			})
+			.collect(Collectors.toList());
+	}
+
+	@Transactional
+	public void createSearchHashtag(Hashtag hashtag) {
+		searchHashtagRepository.save(new SearchHashtag(hashtag));
+	}
+
+	@Transactional
+	public void deleteSearchHashtags(List<Hashtag> hashtags) {
+		final List<SearchHashtag> searchHashtags = searchHashtagRepository.findAllByHashtagIn(hashtags);
+		searchHashtagRepository.deleteAllInBatch(searchHashtags);
+	}
+
 }

--- a/src/main/java/cloneproject/Instagram/global/error/ErrorCode.java
+++ b/src/main/java/cloneproject/Instagram/global/error/ErrorCode.java
@@ -23,6 +23,7 @@ public enum ErrorCode {
 	HTTP_HEADER_INVALID(400, "G006", "request header가 유효하지 않습니다."),
 	IMAGE_TYPE_NOT_SUPPORTED(400, "G007", "지원하지 않는 이미지 타입입니다."),
 	FILE_CANT_CONVERT(500, "G008", "변환할 수 없는 파일입니다."),
+	ENTITY_TYPE_INVALID(500, "G009", "올바르지 않은 entity type 입니다."),
 
 	// Member
 	MEMBER_NOT_FOUND(400, "M001", "존재 하지 않는 유저입니다."),

--- a/src/main/java/cloneproject/Instagram/global/error/exception/EntityTypeInvalidException.java
+++ b/src/main/java/cloneproject/Instagram/global/error/exception/EntityTypeInvalidException.java
@@ -1,0 +1,9 @@
+package cloneproject.Instagram.global.error.exception;
+
+import cloneproject.Instagram.global.error.ErrorCode;
+
+public class EntityTypeInvalidException extends BusinessException{
+	public EntityTypeInvalidException(){
+		super(ErrorCode.ENTITY_TYPE_INVALID);
+	}
+}

--- a/src/main/java/cloneproject/Instagram/global/error/exception/EntityTypeInvalidException.java
+++ b/src/main/java/cloneproject/Instagram/global/error/exception/EntityTypeInvalidException.java
@@ -2,8 +2,9 @@ package cloneproject.Instagram.global.error.exception;
 
 import cloneproject.Instagram.global.error.ErrorCode;
 
-public class EntityTypeInvalidException extends BusinessException{
-	public EntityTypeInvalidException(){
+public class EntityTypeInvalidException extends BusinessException {
+	public EntityTypeInvalidException() {
 		super(ErrorCode.ENTITY_TYPE_INVALID);
 	}
+
 }

--- a/src/main/java/cloneproject/Instagram/global/result/ResultCode.java
+++ b/src/main/java/cloneproject/Instagram/global/result/ResultCode.java
@@ -14,98 +14,102 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ResultCode {
 
-    // Member
-    REGISTER_SUCCESS(200, "M001", "회원가입에 성공하였습니다."),
-    LOGIN_SUCCESS(200, "M002", "로그인에 성공하였습니다."),
-    REISSUE_SUCCESS(200, "M003", "재발급에 성공하였습니다."),
-    GET_USERPROFILE_SUCCESS(200, "M004", "회원 프로필을 조회하였습니다."),
-    GET_MINIPROFILE_SUCCESS(200, "M005", "미니 프로필을 조회하였습니다."),
-    UPLOAD_MEMBER_IMAGE_SUCCESS(200, "M006", "회원 이미지를 등록하였습니다."),
-    DELETE_MEMBER_IMAGE_SUCCESS(200, "M007", "회원 이미지를 삭제하였습니다."),
-    GET_EDIT_PROFILE_SUCCESS(200, "M008", "회원 프로필 수정정보를 조회하였습니다."),
-    EDIT_PROFILE_SUCCESS(200, "M009", "회원 프로필을 수정하였습니다."),
-    UPDATE_PASSWORD_SUCCESS(200, "M010", "회원 비밀번호를 변경하였습니다."),
-    CHECK_USERNAME_GOOD(200, "M011", "사용가능한 username 입니다."),
-    CHECK_USERNAME_BAD(200, "M012", "사용불가능한 username 입니다."),
-    CONFIRM_EMAIL_FAIL(200, "M013", "이메일 인증을 완료할 수 없습니다."),
-    SEND_CONFIRM_EMAIL_SUCCESS(200, "M014", "인증코드 이메일을 전송하였습니다."), // 결번 M015
-    GET_MENU_MEMBER_SUCCESS(200, "M016", "상단 메뉴 프로필을 조회하였습니다."),
-    SEND_RESET_PASSWORD_EMAIL_SUCCESS(200, "M017", "비밀번호 재설정 메일을 전송했습니다."),
-    RESET_PASSWORD_SUCCESS(200, "M018", "비밀번호 재설정에 성공했습니다."),
-    LOGIN_WITH_CODE_SUCCESS(200, "M019", "비밀번호 재설정 코드로 로그인 했습니다."),
-    LOGOUT_SUCCESS(200, "M020", "로그아웃하였습니다."),
-    CHECK_RESET_PASSWORD_CODE_GOOD(200, "M021", "올바른 비밀번호 재설정 코드입니다."),
-    CHECK_RESET_PASSWORD_CODE_BAD(200, "M022", "올바르지 않은 비밀번호 재설정 코드입니다."),
-    LOGOUT_BY_ANOTHER_DEVICE(200, "M023", "다른 기기에 의해 로그아웃되었습니다."),
-    GET_LOGIN_DEVICES_SUCCESS(200, "M024", "로그인 한 기기들을 조회하였습니다."),
-    LOGOUT_DEVICE_SUCCESS(200, "M025", "해당 기기를 로그아웃 시켰습니다."),
-    
-    // Alarm
-    GET_ALARMS_SUCCESS(200, "A001", "알림 조회 완료"),
+	// Member
+	REGISTER_SUCCESS(200, "M001", "회원가입에 성공하였습니다."),
+	LOGIN_SUCCESS(200, "M002", "로그인에 성공하였습니다."),
+	REISSUE_SUCCESS(200, "M003", "재발급에 성공하였습니다."),
+	GET_USERPROFILE_SUCCESS(200, "M004", "회원 프로필을 조회하였습니다."),
+	GET_MINIPROFILE_SUCCESS(200, "M005", "미니 프로필을 조회하였습니다."),
+	UPLOAD_MEMBER_IMAGE_SUCCESS(200, "M006", "회원 이미지를 등록하였습니다."),
+	DELETE_MEMBER_IMAGE_SUCCESS(200, "M007", "회원 이미지를 삭제하였습니다."),
+	GET_EDIT_PROFILE_SUCCESS(200, "M008", "회원 프로필 수정정보를 조회하였습니다."),
+	EDIT_PROFILE_SUCCESS(200, "M009", "회원 프로필을 수정하였습니다."),
+	UPDATE_PASSWORD_SUCCESS(200, "M010", "회원 비밀번호를 변경하였습니다."),
+	CHECK_USERNAME_GOOD(200, "M011", "사용가능한 username 입니다."),
+	CHECK_USERNAME_BAD(200, "M012", "사용불가능한 username 입니다."),
+	CONFIRM_EMAIL_FAIL(200, "M013", "이메일 인증을 완료할 수 없습니다."),
+	SEND_CONFIRM_EMAIL_SUCCESS(200, "M014", "인증코드 이메일을 전송하였습니다."), // 결번 M015
+	GET_MENU_MEMBER_SUCCESS(200, "M016", "상단 메뉴 프로필을 조회하였습니다."),
+	SEND_RESET_PASSWORD_EMAIL_SUCCESS(200, "M017", "비밀번호 재설정 메일을 전송했습니다."),
+	RESET_PASSWORD_SUCCESS(200, "M018", "비밀번호 재설정에 성공했습니다."),
+	LOGIN_WITH_CODE_SUCCESS(200, "M019", "비밀번호 재설정 코드로 로그인 했습니다."),
+	LOGOUT_SUCCESS(200, "M020", "로그아웃하였습니다."),
+	CHECK_RESET_PASSWORD_CODE_GOOD(200, "M021", "올바른 비밀번호 재설정 코드입니다."),
+	CHECK_RESET_PASSWORD_CODE_BAD(200, "M022", "올바르지 않은 비밀번호 재설정 코드입니다."),
+	LOGOUT_BY_ANOTHER_DEVICE(200, "M023", "다른 기기에 의해 로그아웃되었습니다."),
+	GET_LOGIN_DEVICES_SUCCESS(200, "M024", "로그인 한 기기들을 조회하였습니다."),
+	LOGOUT_DEVICE_SUCCESS(200, "M025", "해당 기기를 로그아웃 시켰습니다."),
 
-    // Follow
-    FOLLOW_SUCCESS(200, "F001", "회원 팔로우 완료"),
-    UNFOLLOW_SUCCESS(200, "F002", "회원 언팔로우 완료"),
-    GET_FOLLOWINGS_SUCCESS(200, "F003", "회원 팔로우 목록"),
-    GET_FOLLOWERS_SUCCESS(200, "F004", "회원 팔로워 목록"),
-    DELETE_FOLLOWER_SUCCESS(200, "F005", "팔로워 삭제 성공"),
+	// Alarm
+	GET_ALARMS_SUCCESS(200, "A001", "알림 조회 완료"),
 
-    // Block
-    BLOCK_SUCCESS(200, "B001", "회원 차단 완료"),
-    UNBLOCK_SUCCESS(200, "B002", "회원 차단해제 완료"),
+	// Follow
+	FOLLOW_SUCCESS(200, "F001", "회원 팔로우 완료"),
+	UNFOLLOW_SUCCESS(200, "F002", "회원 언팔로우 완료"),
+	GET_FOLLOWINGS_SUCCESS(200, "F003", "회원 팔로우 목록"),
+	GET_FOLLOWERS_SUCCESS(200, "F004", "회원 팔로워 목록"),
+	DELETE_FOLLOWER_SUCCESS(200, "F005", "팔로워 삭제 성공"),
 
-    // MemberPost
-    FIND_RECENT15_MEMBER_POSTS_SUCCESS(200, "MP001", "회원의 최근 게시물 15개 조회 성공"),
-    FIND_MEMBER_POSTS_SUCCESS(200, "MP002", "회원의 게시물 조회 성공"),
-    FIND_RECENT15_MEMBER_SAVED_POSTS_SUCCESS(200, "MP003", "회원의 최근 저장한 게시물 15개 조회 성공"),
-    FIND_MEMBER_SAVED_POSTS_SUCCESS(200, "MP004", "회원의 저장한 게시물 조회 성공"),
-    FIND_RECENT15_MEMBER_TAGGED_POSTS_SUCCESS(200, "MP005", "회원의 최근 태그된 게시물 15개 조회 성공"),
-    FIND_MEMBER_TAGGED_POSTS_SUCCESS(200, "MP006", "회원의 태그된 게시물 조회 성공"),
+	// Block
+	BLOCK_SUCCESS(200, "B001", "회원 차단 완료"),
+	UNBLOCK_SUCCESS(200, "B002", "회원 차단해제 완료"),
 
-    // Feed
-    CREATE_POST_SUCCESS(200, "F001", "게시물 업로드에 성공하였습니다."),
-    DELETE_POST_SUCCESS(200, "F002", "게시물 삭제에 성공하였습니다."),
-    FIND_POST_PAGE_SUCCESS(200, "F003", "게시물 목록 페이지 조회에 성공하였습니다."),
-    FIND_POST_SUCCESS(200, "F004", "게시물 조회에 성공하였습니다."),
-    FIND_RECENT10POSTS_SUCCESS(200, "F005", "최근 게시물 10개 조회에 성공하였습니다."),
-    LIKE_POST_SUCCESS(200, "F006", "게시물 좋아요에 성공하였습니다."),
-    UN_LIKE_POST_SUCCESS(200, "F007", "게시물 좋아요 해제에 성공하였습니다."),
-    BOOKMARK_POST_SUCCESS(200, "F008", "게시물 북마크에 성공하였습니다."),
-    UN_BOOKMARK_POST_SUCCESS(200, "F009", "게시물 북마크 해제에 성공하였습니다."),
-    CREATE_COMMENT_SUCCESS(200, "F010", "댓글 업로드에 성공하였습니다."),
-    DELETE_COMMENT_SUCCESS(200, "F011", "댓글 삭제에 성공하였습니다."),
-    GET_COMMENT_PAGE_SUCCESS(200, "F012", "댓글 목록 페이지 조회에 성공하였습니다."),
-    GET_REPLY_PAGE_SUCCESS(200, "F013", "답글 목록 페이지 조회에 성공하였습니다."),
-    GET_POST_LIKES_SUCCESS(200, "F014", "게시물에 좋아요한 회원 목록 페이지 조회에 성공하였습니다."),
-    LIKE_COMMENT_SUCCESS(200, "F015", "댓글 좋아요에 성공하였습니다."),
-    UNLIKE_COMMENT_SUCCESS(200, "F016", "댓글 좋아요 해제에 성공하였습니다."),
-    GET_COMMENT_LIKES_SUCCESS(200, "F017", "댓글에 좋아요한 회원 목록 페이지 조회에 성공하였습니다."),
-    SHARE_POST_SUCCESS(200, "F018", "게시물 DM 공유에 성공하였습니다."),
+	// MemberPost
+	FIND_RECENT15_MEMBER_POSTS_SUCCESS(200, "MP001", "회원의 최근 게시물 15개 조회 성공"),
+	FIND_MEMBER_POSTS_SUCCESS(200, "MP002", "회원의 게시물 조회 성공"),
+	FIND_RECENT15_MEMBER_SAVED_POSTS_SUCCESS(200, "MP003", "회원의 최근 저장한 게시물 15개 조회 성공"),
+	FIND_MEMBER_SAVED_POSTS_SUCCESS(200, "MP004", "회원의 저장한 게시물 조회 성공"),
+	FIND_RECENT15_MEMBER_TAGGED_POSTS_SUCCESS(200, "MP005", "회원의 최근 태그된 게시물 15개 조회 성공"),
+	FIND_MEMBER_TAGGED_POSTS_SUCCESS(200, "MP006", "회원의 태그된 게시물 조회 성공"),
 
-    // Chat
-    CREATE_CHAT_ROOM_SUCCESS(200, "C001", "채팅방 생성 요청 성공"),
-    INQUIRE_CHAT_ROOM_SUCCESS(200, "C002", "채팅방 조회 성공"),
-    DELETE_JOIN_ROOM_SUCCESS(200, "C003", "참여 중인 채팅방 삭제 성공"),
-    GET_JOIN_ROOMS_SUCCESS(200, "C004", "채팅방 목록 조회 성공"),
-    GET_CHAT_MESSAGES_SUCCESS(200, "C005", "채팅 메시지 목록 조회 성공"),
-    SEND_IMAGE_SUCCESS(200, "C006", "이미지 전송 성공"),
-    
-    // Hashtag
-    GET_HASHTAG_POSTS_SUCCESS(200, "H001", "해시태그 게시물 목록 페이징 조회 성공"),
-    GET_HASHTAGS_SUCCESS(200, "H002", "해시태그 목록 페이징 조회 성공"),
-    FOLLOW_HASHTAG_SUCCESS(200, "H003", "해시태그 팔로우 성공"),
-    UNFOLLOW_HASHTAG_SUCCESS(200, "H004", "해시태그 언팔로우 성공"),
-    
-    // Story
-    CREATE_STORY_SUCCESS(200, "S001", "스토리 업로드 성공"),
-    GET_STORY_SUCCESS(200, "S002", "스토리 조회 성공"),
+	// Feed
+	CREATE_POST_SUCCESS(200, "F001", "게시물 업로드에 성공하였습니다."),
+	DELETE_POST_SUCCESS(200, "F002", "게시물 삭제에 성공하였습니다."),
+	FIND_POST_PAGE_SUCCESS(200, "F003", "게시물 목록 페이지 조회에 성공하였습니다."),
+	FIND_POST_SUCCESS(200, "F004", "게시물 조회에 성공하였습니다."),
+	FIND_RECENT10POSTS_SUCCESS(200, "F005", "최근 게시물 10개 조회에 성공하였습니다."),
+	LIKE_POST_SUCCESS(200, "F006", "게시물 좋아요에 성공하였습니다."),
+	UN_LIKE_POST_SUCCESS(200, "F007", "게시물 좋아요 해제에 성공하였습니다."),
+	BOOKMARK_POST_SUCCESS(200, "F008", "게시물 북마크에 성공하였습니다."),
+	UN_BOOKMARK_POST_SUCCESS(200, "F009", "게시물 북마크 해제에 성공하였습니다."),
+	CREATE_COMMENT_SUCCESS(200, "F010", "댓글 업로드에 성공하였습니다."),
+	DELETE_COMMENT_SUCCESS(200, "F011", "댓글 삭제에 성공하였습니다."),
+	GET_COMMENT_PAGE_SUCCESS(200, "F012", "댓글 목록 페이지 조회에 성공하였습니다."),
+	GET_REPLY_PAGE_SUCCESS(200, "F013", "답글 목록 페이지 조회에 성공하였습니다."),
+	GET_POST_LIKES_SUCCESS(200, "F014", "게시물에 좋아요한 회원 목록 페이지 조회에 성공하였습니다."),
+	LIKE_COMMENT_SUCCESS(200, "F015", "댓글 좋아요에 성공하였습니다."),
+	UNLIKE_COMMENT_SUCCESS(200, "F016", "댓글 좋아요 해제에 성공하였습니다."),
+	GET_COMMENT_LIKES_SUCCESS(200, "F017", "댓글에 좋아요한 회원 목록 페이지 조회에 성공하였습니다."),
+	SHARE_POST_SUCCESS(200, "F018", "게시물 DM 공유에 성공하였습니다."),
 
-    // Search
-    SEARCH_SUCCESS(200, "SE001", "검색 성공"),
-    INCREASE_SEARCH_COUNT_SUCCESS(200, "SE002", "검색 조회수 증가 성공"),
-    ;
+	// Chat
+	CREATE_CHAT_ROOM_SUCCESS(200, "C001", "채팅방 생성 요청 성공"),
+	INQUIRE_CHAT_ROOM_SUCCESS(200, "C002", "채팅방 조회 성공"),
+	DELETE_JOIN_ROOM_SUCCESS(200, "C003", "참여 중인 채팅방 삭제 성공"),
+	GET_JOIN_ROOMS_SUCCESS(200, "C004", "채팅방 목록 조회 성공"),
+	GET_CHAT_MESSAGES_SUCCESS(200, "C005", "채팅 메시지 목록 조회 성공"),
+	SEND_IMAGE_SUCCESS(200, "C006", "이미지 전송 성공"),
 
-    private int status;
-    private final String code;
-    private final String message;
+	// Hashtag
+	GET_HASHTAG_POSTS_SUCCESS(200, "H001", "해시태그 게시물 목록 페이징 조회 성공"),
+	GET_HASHTAGS_SUCCESS(200, "H002", "해시태그 목록 페이징 조회 성공"),
+	FOLLOW_HASHTAG_SUCCESS(200, "H003", "해시태그 팔로우 성공"),
+	UNFOLLOW_HASHTAG_SUCCESS(200, "H004", "해시태그 언팔로우 성공"),
+
+	// Story
+	CREATE_STORY_SUCCESS(200, "S001", "스토리 업로드 성공"),
+	GET_STORY_SUCCESS(200, "S002", "스토리 조회 성공"),
+
+	// Search
+	SEARCH_SUCCESS(200, "SE001", "검색 성공"),
+	MARK_SEARCHED_ENTITY_SUCCESS(200, "SE002", "검색 조회수 증가, 최근검색기록 업데이트 성공"),
+	GET_TOP_15_RECENT_SEARCH_SUCCESS(200, "SE003", "최근 검색 기록 15개 조회 성공"),
+	GET_RECENT_SEARCH_SUCCESS(200, "SE004", "최근 검색 기록 페이지(무한스크롤) 조회 성공"),
+	DELETE_RECENT_SEARCH_SUCCESS(200, "SE005", "최근 검색 기록 삭제 성공"),
+	DELETE_ALL_RECENT_SEARCH_SUCCESS(200, "SE006", "최근 검색 기록 전체 삭제 성공");
+
+	private int status;
+	private final String code;
+	private final String message;
+
 }


### PR DESCRIPTION
<!--
✅ Resolve: #이슈번호 형태로 입력해 주세요.
ex) Resolve: #123
-->
## 📌Linked Issues
- #162 

<!--
✅ 변경 사항을 자세히 알려주세요. (why -> what -> how)
-->
## ✏Change Details
### Search 도메인 리팩토링
- 컨벤션 적용
- searchDTO의 의미 없는 값(count) 삭제 -> 쿼리 조회 시 orderBy로 정렬되기 때문에 사용하지 않음
- SearchRepositoryQuerydslImpl의 복잡한 쿼리 구조 개선
  - 내부 로직을 분리하여 다시 활용할 수 있도록함 -> 이후 최근 검색 조회 시에도 사용 
  - 검색 조회 결과에 검색 키워드와 완전히 일치하는 유저,해시태그가 강제로 추가되는 경우 정상작동 하지 않던 일부 로직 정상화
- EntityTypeInvalidException 추가

### 최근 검색 API 추가
- 최근 검색 기록 조회 API 추가
- 최근 검색 기록 삭제, 전체 삭제 API 추가
- 기존의 조회수 증가 API에 최근 검색기록을 업데이트 하는 기능 추가
<!--
✅ 추가로 전달할 내용이 있다면 적어주세요.
-->
## 💬Comment
- 코드 정렬 때문에 `followRepository`도 변경사항이 많아보이는데, `getFollowingMemberFollowMap` 부분만 추가되었습니다.
 -> 원래 검색 도메인에서 처리하던 내용을 분리했습니다.
- 아직 미완성인 기능이 있습니다. 관련 Issue #163 

<!--
✅ 참고한 사이트가 있다면 공유해주세요.
-->
## 📑References
- https://cjh5414.github.io/jpa-use-composite-key-to-foreign-key/
  - `RecentSearch` 구현시 위 사이트를 참고하여 두개의 FK를 묶어 복합키(PK)로 사용했습니다.
  - `Follow`와 같은 엔티티도 위의 형식으로 바꾸면 좋을거 같은데 어떻게 생각하시나요?
> `Follow`와 같은 경우 이미 두 `member`를 통해 유일성이 보장되기 때문에 추가적인 `id`가 필요없을 것 같습니다 !

## ✅Check List
- [x] 추가한 기능에 대한 테스트는 모두 완료하셨나요?
- [x] 코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?
