### PR TITLE
FollowingMemberFollow 로직 수정

### DIFF
--- a/src/main/java/cloneproject/Instagram/domain/follow/repository/querydsl/FollowRepositoryQuerydsl.java
+++ b/src/main/java/cloneproject/Instagram/domain/follow/repository/querydsl/FollowRepositoryQuerydsl.java
@@ -15,6 +15,8 @@ public interface FollowRepositoryQuerydsl {
 
 	Map<String, List<FollowDto>> getFollowingMemberFollowMap(Long loginId, List<String> usernames);
 
+	List<FollowDto> getFollowingMemberFollowList(Long loginId, String username);
+
 	List<Follow> findFollows(Long memberId, List<Long> agentIds);
 
 }

--- a/src/main/java/cloneproject/Instagram/domain/follow/repository/querydsl/FollowRepositoryQuerydslImpl.java
+++ b/src/main/java/cloneproject/Instagram/domain/follow/repository/querydsl/FollowRepositoryQuerydslImpl.java
@@ -120,6 +120,24 @@ public class FollowRepositoryQuerydslImpl implements FollowRepositoryQuerydsl {
 			.collect(Collectors.groupingBy(FollowDto::getFollowMemberUsername));
 	}
 
+	@Override
+	public List<FollowDto> getFollowingMemberFollowList(Long loginId, String username) {
+		return queryFactory
+			.select(new QFollowDto(
+				follow.member.username,
+				follow.followMember.username
+			))
+			.from(follow)
+			.where(follow.followMember.username.eq(username)
+				.and(follow.member.id.in(
+					JPAExpressions
+						.select(follow.followMember.id)
+						.from(follow)
+						.where(follow.member.id.eq(loginId))
+				)))
+			.fetch();
+	}
+
 	private BooleanExpression isFollowing(Long memberId, List<Long> agentIds) {
 		return follow.member.id.eq(memberId).and(
 			follow.followMember.id.in(agentIds)

--- a/src/main/java/cloneproject/Instagram/domain/hashtag/exception/HashtagPrefixMismatchException.java
+++ b/src/main/java/cloneproject/Instagram/domain/hashtag/exception/HashtagPrefixMismatchException.java
@@ -1,0 +1,12 @@
+package cloneproject.Instagram.domain.hashtag.exception;
+
+import cloneproject.Instagram.global.error.ErrorCode;
+import cloneproject.Instagram.global.error.exception.BusinessException;
+
+public class HashtagPrefixMismatchException extends BusinessException {
+
+	public HashtagPrefixMismatchException() {
+		super(ErrorCode.HASHTAG_PREFIX_MISMATCH);
+	}
+
+}

--- a/src/main/java/cloneproject/Instagram/domain/member/dto/MiniProfileResponse.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/dto/MiniProfileResponse.java
@@ -2,10 +2,12 @@ package cloneproject.Instagram.domain.member.dto;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import com.querydsl.core.annotations.QueryProjection;
 
 import cloneproject.Instagram.domain.feed.dto.MiniProfilePostDto;
+import cloneproject.Instagram.domain.follow.dto.FollowDto;
 import cloneproject.Instagram.global.vo.Image;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -54,7 +56,8 @@ public class MiniProfileResponse {
 	private List<MiniProfilePostDto> memberPosts;
 
 	@ApiModelProperty(value = "내 팔로잉 중 해당 유저를 팔로우 하는 사람", example = "dlwlrma")
-	private String followingMemberFollow;
+	private List<FollowDto> followingMemberFollow;
+	private int followingMemberFollowCount;
 
 	@ApiModelProperty(value = "본인 여부", example = "false")
 	private boolean isMe;
@@ -65,7 +68,7 @@ public class MiniProfileResponse {
 	public MiniProfileResponse(String username, String name, Image image,
 		boolean isFollowing, boolean isFollower, boolean isBlocking, boolean isBlocked,
 		Long postsCount, Long followingsCount, Long followersCount,
-		boolean isMe, String followingMemberFollow) {
+		boolean isMe) {
 		this.memberUsername = username;
 		this.memberName = name;
 		this.memberImage = image;
@@ -78,8 +81,15 @@ public class MiniProfileResponse {
 		this.memberFollowersCount = followersCount;
 		this.isMe = isMe;
 		this.hasStory = false;
-		this.followingMemberFollow = followingMemberFollow;
 		checkBlock();
+	}
+
+	public void setFollowingMemberFollow(List<FollowDto> followingMemberFollow, int maxCount) {
+		this.followingMemberFollow = followingMemberFollow
+			.stream()
+			.limit(maxCount)
+			.collect(Collectors.toList());
+		this.followingMemberFollowCount = followingMemberFollow.size() - this.followingMemberFollow.size();
 	}
 
 	public void setHasStory(boolean hasStory) {

--- a/src/main/java/cloneproject/Instagram/domain/member/dto/UserProfileResponse.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/dto/UserProfileResponse.java
@@ -1,16 +1,21 @@
 package cloneproject.Instagram.domain.member.dto;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import com.querydsl.core.annotations.QueryProjection;
 
+import cloneproject.Instagram.domain.follow.dto.FollowDto;
 import cloneproject.Instagram.global.vo.Image;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @ApiModel("유저 프로필 조회 응답 모델")
 @Getter
-@Setter
 public class UserProfileResponse {
 
 	@ApiModelProperty(value = "유저네임", example = "dlwlrma")
@@ -50,7 +55,8 @@ public class UserProfileResponse {
 	private Long memberFollowersCount;
 
 	@ApiModelProperty(value = "내 팔로잉 중 해당 유저를 팔로우 하는 사람", example = "dlwlrma")
-	private String followingMemberFollow;
+	private List<FollowDto> followingMemberFollow;
+	private int followingMemberFollowCount;
 
 	@ApiModelProperty(value = "본인 여부", example = "false")
 	private boolean isMe;
@@ -61,7 +67,7 @@ public class UserProfileResponse {
 	public UserProfileResponse(String username, String name, String website, Image image,
 		boolean isFollowing, boolean isFollower, boolean isBlocking, boolean isBlocked,
 		String introduce, Long postsCount, Long followingsCount, Long followersCount,
-		boolean isMe, String followingMemberFollow) {
+		boolean isMe) {
 		this.memberUsername = username;
 		this.memberName = name;
 		this.memberWebsite = website;
@@ -76,8 +82,15 @@ public class UserProfileResponse {
 		this.memberFollowersCount = followersCount;
 		this.isMe = isMe;
 		this.hasStory = false;
-		this.followingMemberFollow = followingMemberFollow;
 		checkBlock();
+	}
+
+	public void setFollowingMemberFollow(List<FollowDto> followingMemberFollow, int maxCount) {
+		this.followingMemberFollow = followingMemberFollow
+			.stream()
+			.limit(maxCount)
+			.collect(Collectors.toList());
+		this.followingMemberFollowCount = followingMemberFollow.size() - this.followingMemberFollow.size();
 	}
 
 	public void setHasStory(boolean hasStory) {

--- a/src/main/java/cloneproject/Instagram/domain/member/repository/querydsl/MemberRepositoryQuerydslImpl.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/repository/querydsl/MemberRepositoryQuerydslImpl.java
@@ -40,8 +40,7 @@ public class MemberRepositoryQuerydslImpl implements MemberRepositoryQuerydsl {
 				getPostCount(username),
 				getFollowingCount(username),
 				getFollowerCount(username),
-				member.id.eq(loginUserId),
-				getFollowingMemberFollow(loginUserId, username)))
+				member.id.eq(loginUserId)))
 			.from(member)
 			.where(member.username.eq(username))
 			.fetchOne();
@@ -61,8 +60,7 @@ public class MemberRepositoryQuerydslImpl implements MemberRepositoryQuerydsl {
 				getPostCount(username),
 				getFollowingCount(username),
 				getFollowerCount(username),
-				member.id.eq(loginUserId),
-				getFollowingMemberFollow(loginUserId, username)))
+				member.id.eq(loginUserId)))
 			.from(member)
 			.where(member.username.eq(username))
 			.fetchOne();
@@ -74,18 +72,6 @@ public class MemberRepositoryQuerydslImpl implements MemberRepositoryQuerydsl {
 			.selectFrom(member)
 			.where(member.username.in(usernames))
 			.fetch();
-	}
-
-	private JPQLQuery<String> getFollowingMemberFollow(Long loginUserId, String targetUsername) {
-		return JPAExpressions
-			.select(follow.member.username.min())
-			.from(follow)
-			.where(follow.followMember.username.eq(targetUsername)
-				.and(follow.member.id.in(
-					JPAExpressions
-						.select(follow.followMember.id)
-						.from(follow)
-						.where(follow.member.id.eq(loginUserId)))));
 	}
 
 	private JPQLQuery<Long> getPostCount(String targetUsername) {

--- a/src/main/java/cloneproject/Instagram/domain/search/dto/SearchMemberDto.java
+++ b/src/main/java/cloneproject/Instagram/domain/search/dto/SearchMemberDto.java
@@ -1,6 +1,8 @@
 package cloneproject.Instagram.domain.search.dto;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import com.querydsl.core.annotations.QueryProjection;
 
@@ -10,29 +12,36 @@ import cloneproject.Instagram.domain.member.entity.Member;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Getter
-@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SearchMemberDto extends SearchDto {
-    
-    private MemberDto member;
-    private boolean isFollowing;
-    private boolean isFollower;
-    private List<FollowDto> followingMemberFollow;
 
-    @QueryProjection
-    public SearchMemberDto(String dtype, Member member, boolean isFollowing, boolean isFollower) {
-        super(dtype);
-        this.member = new MemberDto(member);
-        this.isFollowing = isFollowing;
-        this.isFollower = isFollower;
-        // this.followingMemberFollow = followingMemberFollow;
-    }
+	private MemberDto member;
+	private boolean isFollowing;
+	private boolean isFollower;
+	private List<FollowDto> followingMemberFollow;
+	private int followingMemberFollowCount;
 
-    public void setFollowingMemberFollow(List<FollowDto> followingMemberFollow) {
-        this.followingMemberFollow = followingMemberFollow;
-    }
+	@QueryProjection
+	public SearchMemberDto(String dtype, Member member, boolean isFollowing, boolean isFollower) {
+		super(dtype);
+		this.member = new MemberDto(member);
+		this.isFollowing = isFollowing;
+		this.isFollower = isFollower;
+	}
+
+	public void setFollowingMemberFollow(List<FollowDto> followingMemberFollow, int maxCount) {
+		if (followingMemberFollow == null) {
+			this.followingMemberFollow = Collections.emptyList();
+			this.followingMemberFollowCount = 0;
+			return;
+		}
+		this.followingMemberFollow = followingMemberFollow
+			.stream()
+			.limit(maxCount)
+			.collect(Collectors.toList());
+		this.followingMemberFollowCount = followingMemberFollow.size() - this.followingMemberFollow.size();
+	}
 
 }

--- a/src/main/java/cloneproject/Instagram/domain/search/service/SearchService.java
+++ b/src/main/java/cloneproject/Instagram/domain/search/service/SearchService.java
@@ -15,6 +15,7 @@ import cloneproject.Instagram.domain.follow.dto.FollowDto;
 import cloneproject.Instagram.domain.follow.repository.FollowRepository;
 import cloneproject.Instagram.domain.hashtag.entity.Hashtag;
 import cloneproject.Instagram.domain.hashtag.exception.HashtagNotFoundException;
+import cloneproject.Instagram.domain.hashtag.exception.HashtagPrefixMismatchException;
 import cloneproject.Instagram.domain.member.entity.Member;
 import cloneproject.Instagram.domain.member.exception.MemberDoesNotExistException;
 import cloneproject.Instagram.domain.search.dto.SearchDto;
@@ -109,7 +110,10 @@ public class SearchService {
 					.ifPresent(recentSearchRepository::delete);
 				break;
 			case "HASHTAG":
-				recentSearchRepository.findRecentSearchByHashtagName(loginId, entityName)
+				if(!entityName.startsWith("#")){
+					throw new HashtagPrefixMismatchException();
+				}
+				recentSearchRepository.findRecentSearchByHashtagName(loginId, entityName.substring(1))
 					.ifPresent(recentSearchRepository::delete);
 				break;
 			default:
@@ -133,7 +137,10 @@ public class SearchService {
 					.orElseThrow(MemberDoesNotExistException::new);
 				break;
 			case "HASHTAG":
-				search = searchHashtagRepository.findByHashtagName(entityName)
+				if(!entityName.startsWith("#")){
+					throw new HashtagPrefixMismatchException();
+				}
+				search = searchHashtagRepository.findByHashtagName(entityName.substring(1))
 					.orElseThrow(HashtagNotFoundException::new);
 				break;
 			default:

--- a/src/main/java/cloneproject/Instagram/domain/search/service/SearchService.java
+++ b/src/main/java/cloneproject/Instagram/domain/search/service/SearchService.java
@@ -50,6 +50,7 @@ public class SearchService {
 	private static final int FIRST_PAGE_SIZE = 15;
 	private static final int PAGE_SIZE = 5;
 	private static final int PAGE_OFFSET = 2;
+	private static final int MAX_FOLLOWING_MEMBER_FOLLOW_COUNT = 3;
 
 	public List<SearchDto> searchByText(String text) {
 		text = text.trim();
@@ -166,7 +167,11 @@ public class SearchService {
 		final Map<String, List<FollowDto>> followsMap = followRepository.getFollowingMemberFollowMap(loginId,
 			searchUsernames);
 		memberMap.forEach(
-			(id, member) -> member.setFollowingMemberFollow(followsMap.get(member.getMember().getUsername())));
+			(id, member) -> member.setFollowingMemberFollow(
+				followsMap.get(
+						member.getMember().getUsername()
+					), MAX_FOLLOWING_MEMBER_FOLLOW_COUNT)
+		);
 
 		return searches.stream()
 			.map(search -> {

--- a/src/main/java/cloneproject/Instagram/global/error/ErrorCode.java
+++ b/src/main/java/cloneproject/Instagram/global/error/ErrorCode.java
@@ -86,6 +86,7 @@ public enum ErrorCode {
 	HASHTAG_NOT_FOUND(400, "H001", "존재하지 않는 해시태그 입니다"),
 	CANT_FOLLOW_HASHTAG(400, "H002", "해시태그 팔로우 실패"),
 	CANT_UNFOLLOW_HASHTAG(400, "H003", "해시태그 언팔로우 실패"),
+	HASHTAG_PREFIX_MISMATCH(400, "H004", "해시태그는 #으로 시작해야 합니다"),
 
 	// Story
 	INVALID_STORY_IMAGE(400, "S001", "스토리 이미지는 필수입니다."),


### PR DESCRIPTION
<!--
✅ Resolve: #이슈번호 형태로 입력해 주세요.
ex) Resolve: #123
-->
## 📌Linked Issues
- Resolve: #163 

<!--
✅ 변경 사항을 자세히 알려주세요. (why -> what -> how)
-->
## ✏Change Details
### FollowingMemberFollow
- 이제 전체 List를 반환하지 않고 maxCount를 지정할 수 있음
- List를 인자로 받아 maxCount를 적용 후 Response에 주입
- 초과되는 양은 followingMemberFollowCount로 표시
### 검색 일부 로직
- 프론트분들의 의견으로 해시태그 관련 검색 API 요청시 `entityName`앞에 #이 붙어야 하도록 수정
- 앞에 #이 붙지 않는 경우 전용 예외를 반환하도록 추가
<!--
✅ 추가로 전달할 내용이 있다면 적어주세요.
-->
## 💬Comment
- 전체 List를 받아 온 후 Service단에서 max limit을 적용하는게 아닌 쿼리 상에서 처리하고 싶었으나, 서브쿼리에서 limit을 지원하지 않아서 현재 코드로 처리하였습니다. 쿼리 상에서 처리할 수 있는 아이디어가 있으시면 수정하겠습니다 !
- 해당 PR 머지되면 다시 컨벤션 관련 리팩토링 시작하겠습니다. (get/find 통일, 스웨거 관련 등)


## ✅Check List
- [x] 추가한 기능에 대한 테스트는 모두 완료하셨나요?
- [x] 코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?
