### PR TITLE
Member 관련 Swagger 컨벤션 적용

### DIFF
--- a/src/main/java/cloneproject/Instagram/domain/feed/controller/CommentController.java
+++ b/src/main/java/cloneproject/Instagram/domain/feed/controller/CommentController.java
@@ -4,7 +4,7 @@ import cloneproject.Instagram.domain.feed.dto.CommentUploadRequest;
 import cloneproject.Instagram.domain.feed.dto.CommentUploadResponse;
 import cloneproject.Instagram.domain.feed.dto.CommentDto;
 import cloneproject.Instagram.domain.feed.service.CommentService;
-import cloneproject.Instagram.domain.member.dto.LikeMembersDto;
+import cloneproject.Instagram.domain.member.dto.LikeMemberDto;
 import cloneproject.Instagram.global.result.ResultResponse;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
@@ -152,7 +152,7 @@ public class CommentController {
 	@GetMapping("/{commentId}/likes")
 	public ResponseEntity<ResultResponse> getCommentLikes(@PathVariable Long commentId, @RequestParam int page,
 		@RequestParam int size) {
-		final Page<LikeMembersDto> response = commentService.getCommentLikeMembersDtoPage(commentId, page, size);
+		final Page<LikeMemberDto> response = commentService.getCommentLikeMembersDtoPage(commentId, page, size);
 
 		return ResponseEntity.ok(ResultResponse.of(GET_COMMENT_LIKES_SUCCESS, response));
 	}

--- a/src/main/java/cloneproject/Instagram/domain/feed/controller/PostController.java
+++ b/src/main/java/cloneproject/Instagram/domain/feed/controller/PostController.java
@@ -5,7 +5,7 @@ import cloneproject.Instagram.domain.feed.dto.PostDto;
 import cloneproject.Instagram.domain.feed.dto.PostResponse;
 import cloneproject.Instagram.domain.feed.dto.PostUploadRequest;
 import cloneproject.Instagram.domain.feed.service.PostService;
-import cloneproject.Instagram.domain.member.dto.LikeMembersDto;
+import cloneproject.Instagram.domain.member.dto.LikeMemberDto;
 import cloneproject.Instagram.global.result.ResultResponse;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
@@ -159,7 +159,7 @@ public class PostController {
 	@GetMapping("/{postId}/likes")
 	public ResponseEntity<ResultResponse> getMembersLikedPost(
 		@PathVariable Long postId, @RequestParam int page, @RequestParam int size) {
-		final Page<LikeMembersDto> response = postService.getPostLikeMembersDtoPage(postId, page, size);
+		final Page<LikeMemberDto> response = postService.getPostLikeMembersDtoPage(postId, page, size);
 
 		return ResponseEntity.ok(ResultResponse.of(GET_POST_LIKES_SUCCESS, response));
 	}

--- a/src/main/java/cloneproject/Instagram/domain/feed/repository/querydsl/PostLikeRepositoryQuerydsl.java
+++ b/src/main/java/cloneproject/Instagram/domain/feed/repository/querydsl/PostLikeRepositoryQuerydsl.java
@@ -6,14 +6,14 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import cloneproject.Instagram.domain.feed.dto.PostLikeDto;
-import cloneproject.Instagram.domain.member.dto.LikeMembersDto;
+import cloneproject.Instagram.domain.member.dto.LikeMemberDto;
 
 public interface PostLikeRepositoryQuerydsl {
 
 	List<PostLikeDto> findAllPostLikeDtoOfFollowings(Long memberId, List<Long> postIds);
 
-	Page<LikeMembersDto> findPostLikeMembersDtoPage(Pageable pageable, Long postId, Long memberId);
+	Page<LikeMemberDto> findPostLikeMembersDtoPage(Pageable pageable, Long postId, Long memberId);
 
-	Page<LikeMembersDto> findCommentLikeMembersDtoPage(Pageable pageable, Long commentId, Long memberId);
+	Page<LikeMemberDto> findCommentLikeMembersDtoPage(Pageable pageable, Long commentId, Long memberId);
 
 }

--- a/src/main/java/cloneproject/Instagram/domain/feed/repository/querydsl/PostLikeRepositoryQuerydslImpl.java
+++ b/src/main/java/cloneproject/Instagram/domain/feed/repository/querydsl/PostLikeRepositoryQuerydslImpl.java
@@ -2,7 +2,7 @@ package cloneproject.Instagram.domain.feed.repository.querydsl;
 
 import cloneproject.Instagram.domain.feed.dto.PostLikeDto;
 import cloneproject.Instagram.domain.feed.dto.QPostLikeDto;
-import cloneproject.Instagram.domain.member.dto.LikeMembersDto;
+import cloneproject.Instagram.domain.member.dto.LikeMemberDto;
 import cloneproject.Instagram.domain.member.entity.Member;
 import cloneproject.Instagram.domain.member.entity.QMember;
 import cloneproject.Instagram.domain.member.dto.QLikeMembersDto;
@@ -56,8 +56,8 @@ public class PostLikeRepositoryQuerydslImpl implements PostLikeRepositoryQueryds
 	}
 
 	@Override
-	public Page<LikeMembersDto> findPostLikeMembersDtoPage(Pageable pageable, Long postId, Long memberId) {
-		final List<LikeMembersDto> likeMembersDtos = queryFactory
+	public Page<LikeMemberDto> findPostLikeMembersDtoPage(Pageable pageable, Long postId, Long memberId) {
+		final List<LikeMemberDto> likeMembersDtos = queryFactory
 			.select(new QLikeMembersDto(
 				postLike.member,
 				isFollowing(memberId, postLike.member),
@@ -86,8 +86,8 @@ public class PostLikeRepositoryQuerydslImpl implements PostLikeRepositoryQueryds
 	}
 
 	@Override
-	public Page<LikeMembersDto> findCommentLikeMembersDtoPage(Pageable pageable, Long commentId, Long memberId) {
-		final List<LikeMembersDto> likeMembersDtos = queryFactory
+	public Page<LikeMemberDto> findCommentLikeMembersDtoPage(Pageable pageable, Long commentId, Long memberId) {
+		final List<LikeMemberDto> likeMembersDtos = queryFactory
 			.select(new QLikeMembersDto(
 				commentLike.member,
 				isFollowing(memberId, commentLike.member),

--- a/src/main/java/cloneproject/Instagram/domain/feed/service/CommentService.java
+++ b/src/main/java/cloneproject/Instagram/domain/feed/service/CommentService.java
@@ -12,7 +12,7 @@ import cloneproject.Instagram.domain.feed.exception.CantDeleteCommentException;
 import cloneproject.Instagram.domain.feed.exception.CantUploadReplyException;
 import cloneproject.Instagram.domain.feed.repository.*;
 import cloneproject.Instagram.domain.hashtag.service.HashtagService;
-import cloneproject.Instagram.domain.member.dto.LikeMembersDto;
+import cloneproject.Instagram.domain.member.dto.LikeMemberDto;
 import cloneproject.Instagram.domain.member.dto.MemberDto;
 import cloneproject.Instagram.domain.member.entity.Member;
 import cloneproject.Instagram.domain.mention.service.MentionService;
@@ -162,11 +162,11 @@ public class CommentService {
 		alarmService.delete(LIKE_COMMENT, comment.getMember(), comment);
 	}
 
-	public Page<LikeMembersDto> getCommentLikeMembersDtoPage(Long commentId, int page, int size) {
+	public Page<LikeMemberDto> getCommentLikeMembersDtoPage(Long commentId, int page, int size) {
 		final Member loginMember = authUtil.getLoginMember();
 		page = (page == 0 ? 0 : page - 1);
 		final Pageable pageable = PageRequest.of(page, size);
-		final Page<LikeMembersDto> likeMembersDTOs =
+		final Page<LikeMemberDto> likeMembersDTOs =
 			postLikeRepository.findCommentLikeMembersDtoPage(pageable, commentId, loginMember.getId());
 
 		setHasStory(likeMembersDTOs);
@@ -174,7 +174,7 @@ public class CommentService {
 		return likeMembersDTOs;
 	}
 
-	private void setHasStory(Page<LikeMembersDto> likeMembersDTOs) {
+	private void setHasStory(Page<LikeMemberDto> likeMembersDTOs) {
 		likeMembersDTOs.getContent()
 			.forEach(dto -> dto.setHasStory(
 				memberStoryRedisRepository.findAllByMemberId(dto.getMember().getId()).size() > 0));

--- a/src/main/java/cloneproject/Instagram/domain/feed/service/PostService.java
+++ b/src/main/java/cloneproject/Instagram/domain/feed/service/PostService.java
@@ -10,7 +10,7 @@ import cloneproject.Instagram.domain.hashtag.entity.Hashtag;
 import cloneproject.Instagram.domain.hashtag.repository.HashtagPostRepository;
 import cloneproject.Instagram.domain.hashtag.repository.HashtagRepository;
 import cloneproject.Instagram.domain.hashtag.service.HashtagService;
-import cloneproject.Instagram.domain.member.dto.LikeMembersDto;
+import cloneproject.Instagram.domain.member.dto.LikeMemberDto;
 import cloneproject.Instagram.domain.member.dto.MemberDto;
 import cloneproject.Instagram.domain.member.entity.Member;
 import cloneproject.Instagram.domain.member.repository.MemberRepository;
@@ -296,11 +296,11 @@ public class PostService {
 		alarmService.delete(LIKE_POST, post.getMember(), post);
 	}
 
-	public Page<LikeMembersDto> getPostLikeMembersDtoPage(Long postId, int page, int size) {
+	public Page<LikeMemberDto> getPostLikeMembersDtoPage(Long postId, int page, int size) {
 		final Member loginMember = authUtil.getLoginMember();
 		page = (page == 0 ? 0 : page - 1);
 		final Pageable pageable = PageRequest.of(page, size);
-		final Page<LikeMembersDto> likeMembersDTOs =
+		final Page<LikeMemberDto> likeMembersDTOs =
 			postLikeRepository.findPostLikeMembersDtoPage(pageable, postId, loginMember.getId());
 
 		setHasStory(likeMembersDTOs);
@@ -308,7 +308,7 @@ public class PostService {
 		return likeMembersDTOs;
 	}
 
-	private void setHasStory(Page<LikeMembersDto> likeMembersDTOs) {
+	private void setHasStory(Page<LikeMemberDto> likeMembersDTOs) {
 		likeMembersDTOs.getContent()
 			.forEach(dto -> dto.setHasStory(
 				memberStoryRedisRepository.findAllByMemberId(dto.getMember().getId()).size() > 0));

--- a/src/main/java/cloneproject/Instagram/domain/member/controller/MemberAuthController.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/controller/MemberAuthController.java
@@ -24,7 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import cloneproject.Instagram.domain.member.dto.JwtDto;
 import cloneproject.Instagram.domain.member.dto.JwtResponse;
-import cloneproject.Instagram.domain.member.dto.LoginDevicesDTO;
+import cloneproject.Instagram.domain.member.dto.LoginDevicesDto;
 import cloneproject.Instagram.domain.member.dto.LoginRequest;
 import cloneproject.Instagram.domain.member.dto.LoginWithCodeRequest;
 import cloneproject.Instagram.domain.member.dto.RegisterRequest;
@@ -299,9 +299,9 @@ public class MemberAuthController {
 	})
 	@GetMapping(value = "/accounts/login/device")
 	public ResponseEntity<ResultResponse> getLoginDevices() {
-		final List<LoginDevicesDTO> loginDevicesDTOs = memberAuthService.getLoginDevices();
+		final List<LoginDevicesDto> loginDevicesDtos = memberAuthService.getLoginDevices();
 
-		return ResponseEntity.ok(ResultResponse.of(GET_LOGIN_DEVICES_SUCCESS, loginDevicesDTOs));
+		return ResponseEntity.ok(ResultResponse.of(GET_LOGIN_DEVICES_SUCCESS, loginDevicesDtos));
 	}
 
 	@ApiOperation(value = "기기 로그아웃 시키기")

--- a/src/main/java/cloneproject/Instagram/domain/member/controller/MemberAuthController.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/controller/MemberAuthController.java
@@ -39,6 +39,8 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -56,10 +58,13 @@ public class MemberAuthController {
 	private String COOKIE_DOMAIN;
 
 	@ApiOperation(value = "username 중복 조회")
-	@ApiImplicitParams({
-		@ApiImplicitParam(name = "Authorization", value = "불필요", required = false, example = " "),
-		@ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma")
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "M011 - 사용가능한 username 입니다.\n"
+			+ "M012 - 사용불가능한 username 입니다."),
+		@ApiResponse(code = 400, message = "G003 - 유효하지 않은 입력입니다.\n"
+			+ "G004 - 입력 타입이 유효하지 않습니다.")
 	})
+	@ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma")
 	@GetMapping(value = "/accounts/check")
 	public ResponseEntity<ResultResponse> checkUsername(
 		@RequestParam
@@ -75,7 +80,14 @@ public class MemberAuthController {
 	}
 
 	@ApiOperation(value = "회원가입")
-	@ApiImplicitParam(name = "Authorization", value = "불필요", required = false, example = " ")
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "M001 - 회원가입에 성공하였습니다.\n"
+			+ "M013 - 이메일 인증을 완료할 수 없습니다."),
+		@ApiResponse(code = 400, message = "G003 - 유효하지 않은 입력입니다.\n"
+			+ "G004 - 입력 타입이 유효하지 않습니다.\n"
+			+ "M002 - 이미 존재하는 사용자 이름입니다.\n"
+			+ "M007 - 인증 이메일 전송을 먼저 해야합니다.")
+	})
 	@PostMapping(value = "/accounts")
 	public ResponseEntity<ResultResponse> register(@Valid @RequestBody RegisterRequest registerRequest) {
 		final boolean isRegistered = memberAuthService.register(registerRequest);
@@ -87,7 +99,12 @@ public class MemberAuthController {
 	}
 
 	@ApiOperation(value = "인증코드 이메일 전송")
-	@ApiImplicitParam(name = "Authorization", value = "불필요", required = false, example = " ")
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "M014 - 인증코드 이메일을 전송하였습니다."),
+		@ApiResponse(code = 400, message = "G003 - 유효하지 않은 입력입니다.\n"
+			+ "G004 - 입력 타입이 유효하지 않습니다.\n"
+			+ "M002 - 이미 존재하는 사용자 이름입니다.")
+	})
 	@PostMapping(value = "/accounts/email")
 	public ResponseEntity<ResultResponse> sendConfirmEmail(
 		@Valid @RequestBody SendConfirmationEmailRequest sendConfirmationEmailRequest) {
@@ -98,8 +115,11 @@ public class MemberAuthController {
 	}
 
 	@ApiOperation(value = "로그인")
-	@ApiImplicitParams({
-		@ApiImplicitParam(name = "Authorization", value = "불필요", required = false, example = " ")
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "M002 - 로그인에 성공하였습니다."),
+		@ApiResponse(code = 400, message = "G003 - 유효하지 않은 입력입니다.\n"
+			+ "G004 - 입력 타입이 유효하지 않습니다."),
+		@ApiResponse(code = 401, message = "M005 - 계정 정보가 일치하지 않습니다.")
 	})
 	@PostMapping(value = "/login")
 	public ResponseEntity<ResultResponse> login(@Valid @RequestBody LoginRequest loginRequest) {
@@ -107,7 +127,11 @@ public class MemberAuthController {
 	}
 
 	@ApiOperation(value = "토큰 재발급")
-	@ApiImplicitParam(name = "Authorization", value = "불필요", required = false, example = " ")
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "M003 - 재발급에 성공하였습니다."),
+		@ApiResponse(code = 401, message = "J001 - 유효하지 않은 토큰입니다.\n"
+			+ "J002 - 만료된 토큰입니다.")
+	})
 	@PostMapping(value = "/reissue")
 	public ResponseEntity<ResultResponse> reissue(
 		@CookieValue(value = "refreshToken", required = false) Cookie refreshCookie) {
@@ -115,7 +139,14 @@ public class MemberAuthController {
 	}
 
 	@ApiOperation(value = "비밀번호 변경")
-	@ApiImplicitParam(name = "Authorization", value = "불필요", required = false, example = " ")
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "M010 - 회원 비밀번호를 변경하였습니다."),
+		@ApiResponse(code = 400, message = "G003 - 유효하지 않은 입력입니다.\n"
+			+ "G004 - 입력 타입이 유효하지 않습니다.\n"
+			+ "M013 - 기존 비밀번호와 동일하게 변경할 수 없습니다."),
+		@ApiResponse(code = 401, message = "M003 - 로그인이 필요한 화면입니다.\n"
+			+ "M005 - 계정 정보가 일치하지 않습니다."),
+	})
 	@PutMapping(value = "/accounts/password")
 	public ResponseEntity<ResultResponse> updatePassword(
 		@Valid @RequestBody UpdatePasswordRequest updatePasswordRequest) {
@@ -125,10 +156,13 @@ public class MemberAuthController {
 	}
 
 	@ApiOperation(value = "비밀번호변경 이메일 전송")
-	@ApiImplicitParams({
-		@ApiImplicitParam(name = "Authorization", value = "불필요", required = false, example = " "),
-		@ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma")
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "M017 - 비밀번호 재설정 메일을 전송했습니다."),
+		@ApiResponse(code = 400, message = "G003 - 유효하지 않은 입력입니다.\n"
+			+ "G004 - 입력 타입이 유효하지 않습니다.\n"
+			+ "M001 - 존재 하지 않는 유저입니다.")
 	})
+	@ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma")
 	@PostMapping(value = "/accounts/password/email")
 	public ResponseEntity<ResultResponse> sendResetPasswordCode(
 		@RequestParam @Length(min = 4, max = 12, message = "사용자 이름은 4문자 이상 12문자 이하여야 합니다")
@@ -140,7 +174,15 @@ public class MemberAuthController {
 
 	// TODO filter로 옮길 방법?
 	@ApiOperation(value = "코드를 통한 비밀번호 재설정")
-	@ApiImplicitParam(name = "Authorization", value = "불필요", required = false, example = " ")
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "M018 - 비밀번호 재설정에 성공했습니다."),
+		@ApiResponse(code = 400, message = "G003 - 유효하지 않은 입력입니다.\n"
+			+ "G004 - 입력 타입이 유효하지 않습니다.\n"
+			+ "M001 - 존재 하지 않는 유저입니다.\n"
+			+ "M007 - 인증 이메일 전송을 먼저 해야합니다.\n"
+			+ "M008 - 잘못되거나 만료된 코드입니다.\n"
+			+ "M013 - 기존 비밀번호와 동일하게 변경할 수 없습니다.")
+	})
 	@PutMapping(value = "/accounts/password/reset")
 	public ResponseEntity<ResultResponse> resetPassword(@Valid @RequestBody ResetPasswordRequest resetPasswordRequest,
 		HttpServletRequest request,
@@ -162,7 +204,15 @@ public class MemberAuthController {
 	}
 
 	@ApiOperation(value = "코드를 통한 로그인")
-	@ApiImplicitParam(name = "Authorization", value = "불필요", required = false, example = " ")
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "M019 - 비밀번호 재설정 코드로 로그인 했습니다."),
+		@ApiResponse(code = 400, message = "G003 - 유효하지 않은 입력입니다.\n"
+			+ "G004 - 입력 타입이 유효하지 않습니다.\n"
+			+ "M001 - 존재 하지 않는 유저입니다.\n"
+			+ "M007 - 인증 이메일 전송을 먼저 해야합니다.\n"
+			+ "M008 - 잘못되거나 만료된 코드입니다."),
+		@ApiResponse(code = 401, message = "M005 - 계정 정보가 일치하지 않습니다.")
+	})
 	@PostMapping(value = "/login/recovery")
 	public ResponseEntity<ResultResponse> loginWithCode(
 		@Valid @RequestBody LoginWithCodeRequest loginWithCodeRequest) {
@@ -170,6 +220,13 @@ public class MemberAuthController {
 	}
 
 	@ApiOperation(value = "로그아웃")
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "M020 - 로그아웃하였습니다."),
+		@ApiResponse(code = 400, message = "G003 - 유효하지 않은 입력입니다.\n"
+			+ "G004 - 입력 타입이 유효하지 않습니다.\n"),
+		@ApiResponse(code = 401, message = "M003 - 로그인이 필요한 화면입니다.\n"
+			+ "J001 - 유효하지 않은 토큰입니다.")
+	})
 	@PostMapping(value = "/logout")
 	public ResponseEntity<ResultResponse> logout(
 		@CookieValue(value = "refreshToken", required = true) Cookie refreshCookie,
@@ -192,6 +249,9 @@ public class MemberAuthController {
 
 	@ApiOperation(value = "토큰 없이 로그아웃(쿠키만 초기화)")
 	@PostMapping(value = "/logout/only/cookie")
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "M020 - 로그아웃하였습니다.")
+	})
 	public ResponseEntity<ResultResponse> deleteRefreshToken(HttpServletResponse response) {
 		final Cookie cookie = new Cookie("refreshToken", null);
 
@@ -208,8 +268,14 @@ public class MemberAuthController {
 	}
 
 	@ApiOperation(value = "비밀번호 재설정 코드 검증")
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "M021 - 올바른 비밀번호 재설정 코드입니다.\n"
+			+ "M022 - 올바르지 않은 비밀번호 재설정 코드입니다."),
+		@ApiResponse(code = 400, message = "G003 - 유효하지 않은 입력입니다.\n"
+			+ "G004 - 입력 타입이 유효하지 않습니다.\n"
+			+ "M007 - 인증 이메일 전송을 먼저 해야합니다.")
+	})
 	@ApiImplicitParams({
-		@ApiImplicitParam(name = "Authorization", value = "불필요", required = false, example = " "),
 		@ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma"),
 		@ApiImplicitParam(name = "code", value = "인증코드", required = true, example = "AAABBB")
 	})
@@ -227,6 +293,10 @@ public class MemberAuthController {
 	}
 
 	@ApiOperation(value = "로그인한 기기 조회")
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "M024 - 로그인 한 기기들을 조회하였습니다."),
+		@ApiResponse(code = 401, message = "M003 - 로그인이 필요한 화면입니다.\n")
+	})
 	@GetMapping(value = "/accounts/login/device")
 	public ResponseEntity<ResultResponse> getLoginDevices() {
 		final List<LoginDevicesDTO> loginDevicesDTOs = memberAuthService.getLoginDevices();
@@ -235,6 +305,16 @@ public class MemberAuthController {
 	}
 
 	@ApiOperation(value = "기기 로그아웃 시키기")
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "M025 - 해당 기기를 로그아웃 시켰습니다."),
+		@ApiResponse(code = 400, message = "G003 - 유효하지 않은 입력입니다.\n"
+			+ "G004 - 입력 타입이 유효하지 않습니다.\n"
+			+ "M007 - 인증 이메일 전송을 먼저 해야합니다."),
+		@ApiResponse(code = 401, message = "M003 - 로그인이 필요한 화면입니다.\n"
+			+ "J001 - 유효하지 않은 토큰입니다.")
+	})
+	@ApiImplicitParam(name = "tokenId", value = "로그아웃시킬 기기의 tokenId", required = true,
+		example = "aaaaaa-aaaa-aaaa-aaaa-39f9a58c8c3d")
 	@PostMapping(value = "/logout/device")
 	public ResponseEntity<ResultResponse> logoutDevice(@RequestParam String tokenId) {
 		memberAuthService.logoutDevice(tokenId);

--- a/src/main/java/cloneproject/Instagram/domain/member/controller/MemberController.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/controller/MemberController.java
@@ -1,5 +1,7 @@
 package cloneproject.Instagram.domain.member.controller;
 
+import static cloneproject.Instagram.global.result.ResultCode.*;
+
 import javax.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
@@ -24,12 +26,11 @@ import cloneproject.Instagram.domain.member.service.MemberService;
 import cloneproject.Instagram.global.result.ResultResponse;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
-import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
-import static cloneproject.Instagram.global.result.ResultCode.*;
 
 @Slf4j
 @Validated
@@ -42,6 +43,10 @@ public class MemberController {
 	private final MemberService memberService;
 
 	@ApiOperation(value = "상단 메뉴 로그인한 유저 프로필 조회")
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "M016 - 상단 메뉴 프로필을 조회하였습니다."),
+		@ApiResponse(code = 401, message = "M003 - 로그인이 필요한 화면입니다.")
+	})
 	@GetMapping(value = "/profile")
 	public ResponseEntity<ResultResponse> getMenuMemberProfile() {
 		final MenuMemberDTO menuMemberProfile = memberService.getMenuMemberProfile();
@@ -50,10 +55,14 @@ public class MemberController {
 	}
 
 	@ApiOperation(value = "유저 프로필 조회")
-	@ApiImplicitParams({
-		@ApiImplicitParam(name = "Authorization", value = "있어도 되고 없어도됨", required = false, example = "Bearer AAA.BBB.CCC"),
-		@ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma")
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "M004 - 회원 프로필을 조회하였습니다."),
+		@ApiResponse(code = 400, message = "G003 - 유효하지 않은 입력입니다.\n"
+			+ "G004 - 입력 타입이 유효하지 않습니다.\n"
+			+ "M001 - 존재 하지 않는 유저입니다."),
+		@ApiResponse(code = 401, message = "M003 - 로그인이 필요한 화면입니다.")
 	})
+	@ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma")
 	@GetMapping(value = "/{username}")
 	public ResponseEntity<ResultResponse> getUserProfile(@PathVariable("username") String username) {
 		final UserProfileResponse userProfileResponse = memberService.getUserProfile(username);
@@ -62,9 +71,14 @@ public class MemberController {
 	}
 
 	@ApiOperation(value = "미니 프로필 조회")
-	@ApiImplicitParams({
-		@ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma")
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "M005 - 미니 프로필을 조회하였습니다."),
+		@ApiResponse(code = 400, message = "G003 - 유효하지 않은 입력입니다.\n"
+			+ "G004 - 입력 타입이 유효하지 않습니다.\n"
+			+ "M001 - 존재 하지 않는 유저입니다."),
+		@ApiResponse(code = 401, message = "M003 - 로그인이 필요한 화면입니다.")
 	})
+	@ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma")
 	@GetMapping(value = "/{username}/mini")
 	public ResponseEntity<ResultResponse> getMiniProfile(@PathVariable("username") String username) {
 		final MiniProfileResponse miniProfileResponse = memberService.getMiniProfile(username);
@@ -73,6 +87,14 @@ public class MemberController {
 	}
 
 	@ApiOperation(value = "회원 프로필 사진 업로드")
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "M006 - 회원 이미지를 등록하였습니다."),
+		@ApiResponse(code = 400, message = "G003 - 유효하지 않은 입력입니다.\n"
+			+ "G004 - 입력 타입이 유효하지 않습니다.\n"
+			+ "G007 - 지원하지 않는 이미지 타입입니다.\n"
+			+ "G008 - 변환할 수 없는 파일입니다."),
+		@ApiResponse(code = 401, message = "M003 - 로그인이 필요한 화면입니다.")
+	})
 	@PostMapping(value = "/image")
 	public ResponseEntity<ResultResponse> uploadImage(@RequestParam MultipartFile uploadedImage) {
 		memberService.uploadMemberImage(uploadedImage);
@@ -81,6 +103,10 @@ public class MemberController {
 	}
 
 	@ApiOperation(value = "회원 프로필 사진 삭제")
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "M007 - 회원 이미지를 삭제하였습니다."),
+		@ApiResponse(code = 401, message = "M003 - 로그인이 필요한 화면입니다.")
+	})
 	@DeleteMapping(value = "/image")
 	public ResponseEntity<ResultResponse> deleteImage() {
 		memberService.deleteMemberImage();
@@ -89,6 +115,10 @@ public class MemberController {
 	}
 
 	@ApiOperation(value = "회원 프로필 수정정보 조회")
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "M008 - 회원 프로필 수정정보를 조회하였습니다."),
+		@ApiResponse(code = 401, message = "M003 - 로그인이 필요한 화면입니다.")
+	})
 	@GetMapping(value = "/edit")
 	public ResponseEntity<ResultResponse> getMemberEdit() {
 		final EditProfileResponse editProfileResponse = memberService.getEditProfile();
@@ -97,6 +127,12 @@ public class MemberController {
 	}
 
 	@ApiOperation(value = "회원 프로필 수정")
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "M009 - 회원 프로필을 수정하였습니다."),
+		@ApiResponse(code = 400, message = "G003 - 유효하지 않은 입력입니다.\n"
+			+ "G004 - 입력 타입이 유효하지 않습니다.\n"),
+		@ApiResponse(code = 401, message = "M003 - 로그인이 필요한 화면입니다.")
+	})
 	@PutMapping(value = "/edit")
 	public ResponseEntity<ResultResponse> editProfile(@Valid @RequestBody EditProfileRequest editProfileRequest) {
 		memberService.editProfile(editProfileRequest);

--- a/src/main/java/cloneproject/Instagram/domain/member/controller/MemberController.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/controller/MemberController.java
@@ -19,7 +19,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import cloneproject.Instagram.domain.member.dto.EditProfileRequest;
 import cloneproject.Instagram.domain.member.dto.EditProfileResponse;
-import cloneproject.Instagram.domain.member.dto.MenuMemberDTO;
+import cloneproject.Instagram.domain.member.dto.MenuMemberProfile;
 import cloneproject.Instagram.domain.member.dto.MiniProfileResponse;
 import cloneproject.Instagram.domain.member.dto.UserProfileResponse;
 import cloneproject.Instagram.domain.member.service.MemberService;
@@ -49,7 +49,7 @@ public class MemberController {
 	})
 	@GetMapping(value = "/profile")
 	public ResponseEntity<ResultResponse> getMenuMemberProfile() {
-		final MenuMemberDTO menuMemberProfile = memberService.getMenuMemberProfile();
+		final MenuMemberProfile menuMemberProfile = memberService.getMenuMemberProfile();
 
 		return ResponseEntity.ok(ResultResponse.of(GET_MENU_MEMBER_SUCCESS, menuMemberProfile));
 	}

--- a/src/main/java/cloneproject/Instagram/domain/member/controller/MemberPostController.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/controller/MemberPostController.java
@@ -9,6 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,85 +21,120 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import lombok.RequiredArgsConstructor;
 
 @Api(tags = "멤버 게시물 API")
 @RestController
 @RequiredArgsConstructor
 @Validated
+@RequestMapping("/accounts")
 public class MemberPostController {
 
 	private final MemberPostService memberPostService;
 
 	@ApiOperation(value = "멤버 게시물 15개 조회")
-	@ApiImplicitParams({
-		@ApiImplicitParam(name = "Authorization", value = "있어도 되고 없어도됨", example = "Bearer AAA.BBB.CCC"),
-		@ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma")
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "MP001 - 회원의 최근 게시물 15개 조회에 성공하였습니다."),
+		@ApiResponse(code = 400, message = "G003 - 유효하지 않은 입력입니다.\n"
+			+ "G004 - 입력 타입이 유효하지 않습니다.\n"
+			+ "M001 - 존재 하지 않는 유저입니다."),
+		@ApiResponse(code = 401, message = "M003 - 로그인이 필요한 화면입니다.")
 	})
-	@GetMapping("/accounts/{username}/posts/recent")
+	@ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma")
+	@GetMapping("/{username}/posts/recent")
 	public ResponseEntity<ResultResponse> getRecent10Posts(@PathVariable("username") String username) {
 		final List<MemberPostDto> postList = memberPostService.getRecent15PostDTOs(username);
 
-		return ResponseEntity.ok(ResultResponse.of(ResultCode.FIND_RECENT15_MEMBER_POSTS_SUCCESS, postList));
+		return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_RECENT15_MEMBER_POSTS_SUCCESS, postList));
 	}
 
 	@ApiOperation(value = "멤버 게시물 페이징 조회(무한스크롤)")
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "MP002 - 회원의 게시물 조회에 성공하였습니다."),
+		@ApiResponse(code = 400, message = "G003 - 유효하지 않은 입력입니다.\n"
+			+ "G004 - 입력 타입이 유효하지 않습니다.\n"
+			+ "M001 - 존재 하지 않는 유저입니다."),
+		@ApiResponse(code = 401, message = "M003 - 로그인이 필요한 화면입니다.")
+	})
 	@ApiImplicitParams({
-		@ApiImplicitParam(name = "Authorization", value = "있어도 되고 없어도됨", example = "Bearer AAA.BBB.CCC"),
 		@ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma"),
 		@ApiImplicitParam(name = "page", value = "페이지", required = true, example = "1")
 	})
-	@GetMapping("/accounts/{username}/posts")
+	@GetMapping("/{username}/posts")
 	public ResponseEntity<ResultResponse> getPostPage(@PathVariable("username") String username,
 		@Min(1) @RequestParam int page) {
 		final Page<MemberPostDto> postPage = memberPostService.getMemberPostDTOs(username, 3, page);
 
-		return ResponseEntity.ok(ResultResponse.of(ResultCode.FIND_MEMBER_POSTS_SUCCESS, postPage));
+		return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_MEMBER_POSTS_SUCCESS, postPage));
 	}
 
 	// ============== 저장 ================
 	@ApiOperation(value = "멤버 저장한 게시물 15개 조회")
-	@GetMapping("/accounts/posts/saved/recent")
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "MP003 - 회원의 최근 저장한 게시물 15개 조회에 성공하였습니다."),
+		@ApiResponse(code = 400, message = "G003 - 유효하지 않은 입력입니다.\n"
+			+ "G004 - 입력 타입이 유효하지 않습니다."),
+		@ApiResponse(code = 401, message = "M003 - 로그인이 필요한 화면입니다.")
+	})
+	@GetMapping("/posts/saved/recent")
 	public ResponseEntity<ResultResponse> getRecent1SavedPosts() {
 		final List<MemberPostDto> postList = memberPostService.getRecent15SavedPostDTOs();
 
-		return ResponseEntity.ok(ResultResponse.of(ResultCode.FIND_RECENT15_MEMBER_SAVED_POSTS_SUCCESS, postList));
+		return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_RECENT15_MEMBER_SAVED_POSTS_SUCCESS, postList));
 	}
 
 	@ApiOperation(value = "멤버 저장한 게시물 페이징 조회(무한스크롤)")
-	@GetMapping("/accounts/posts/saved")
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "MP004 - 회원의 저장한 게시물 조회에 성공하였습니다."),
+		@ApiResponse(code = 400, message = "G003 - 유효하지 않은 입력입니다.\n"
+			+ "G004 - 입력 타입이 유효하지 않습니다."),
+		@ApiResponse(code = 401, message = "M003 - 로그인이 필요한 화면입니다.")
+	})
+	@GetMapping("/posts/saved")
 	@ApiImplicitParam(name = "page", value = "페이지", required = true, example = "1")
 	public ResponseEntity<ResultResponse> getSavedPostPage(@Min(1) @RequestParam int page) {
 		final Page<MemberPostDto> postPage = memberPostService.getMemberSavedPostDTOs(3, page);
 
-		return ResponseEntity.ok(ResultResponse.of(ResultCode.FIND_MEMBER_SAVED_POSTS_SUCCESS, postPage));
+		return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_MEMBER_SAVED_POSTS_SUCCESS, postPage));
 	}
 
 	// ============== 태그 ================
 	@ApiOperation(value = "멤버 태그된 게시물 15개 조회")
-	@ApiImplicitParams({
-		@ApiImplicitParam(name = "Authorization", value = "있어도 되고 없어도됨", example = "Bearer AAA.BBB.CCC"),
-		@ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma")
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "MP005 - 회원의 최근 태그된 게시물 15개 조회에 성공하였습니다."),
+		@ApiResponse(code = 400, message = "G003 - 유효하지 않은 입력입니다.\n"
+			+ "G004 - 입력 타입이 유효하지 않습니다.\n"
+			+ "M001 - 존재 하지 않는 유저입니다."),
+		@ApiResponse(code = 401, message = "M003 - 로그인이 필요한 화면입니다.")
 	})
-	@GetMapping("/accounts/{username}/posts/tagged/recent")
+	@ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma")
+	@GetMapping("/{username}/posts/tagged/recent")
 	public ResponseEntity<ResultResponse> getRecent10TaggedPosts(@PathVariable("username") String username) {
 		final List<MemberPostDto> postList = memberPostService.getRecent15TaggedPostDTOs(username);
 
-		return ResponseEntity.ok(ResultResponse.of(ResultCode.FIND_RECENT15_MEMBER_TAGGED_POSTS_SUCCESS, postList));
+		return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_RECENT15_MEMBER_TAGGED_POSTS_SUCCESS, postList));
 	}
 
 	@ApiOperation(value = "멤버 태그된 게시물 페이징 조회(무한스크롤)")
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "MP006 - 회원의 태그된 게시물 조회에 성공하였습니다."),
+		@ApiResponse(code = 400, message = "G003 - 유효하지 않은 입력입니다.\n"
+			+ "G004 - 입력 타입이 유효하지 않습니다.\n"
+			+ "M001 - 존재 하지 않는 유저입니다."),
+		@ApiResponse(code = 401, message = "M003 - 로그인이 필요한 화면입니다.")
+	})
 	@ApiImplicitParams({
-		@ApiImplicitParam(name = "Authorization", value = "있어도 되고 없어도됨", example = "Bearer AAA.BBB.CCC"),
 		@ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma"),
 		@ApiImplicitParam(name = "page", value = "페이지", required = true, example = "1")
 	})
-	@GetMapping("/accounts/{username}/posts/tagged")
+	@GetMapping("/{username}/posts/tagged")
 	public ResponseEntity<ResultResponse> getTaggedPostPage(@PathVariable("username") String username,
 		@Min(1) @RequestParam int page) {
 		final Page<MemberPostDto> postPage = memberPostService.getMemberTaggedPostDTOs(username, 3, page);
 
-		return ResponseEntity.ok(ResultResponse.of(ResultCode.FIND_MEMBER_TAGGED_POSTS_SUCCESS, postPage));
+		return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_MEMBER_TAGGED_POSTS_SUCCESS, postPage));
 	}
 
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/controller/MemberPostController.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/controller/MemberPostController.java
@@ -45,7 +45,7 @@ public class MemberPostController {
 	@ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma")
 	@GetMapping("/{username}/posts/recent")
 	public ResponseEntity<ResultResponse> getRecent10Posts(@PathVariable("username") String username) {
-		final List<MemberPostDto> postList = memberPostService.getRecent15PostDTOs(username);
+		final List<MemberPostDto> postList = memberPostService.getRecent15PostDtos(username);
 
 		return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_RECENT15_MEMBER_POSTS_SUCCESS, postList));
 	}
@@ -65,7 +65,7 @@ public class MemberPostController {
 	@GetMapping("/{username}/posts")
 	public ResponseEntity<ResultResponse> getPostPage(@PathVariable("username") String username,
 		@Min(1) @RequestParam int page) {
-		final Page<MemberPostDto> postPage = memberPostService.getMemberPostDTOs(username, 3, page);
+		final Page<MemberPostDto> postPage = memberPostService.getMemberPostDtos(username, 3, page);
 
 		return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_MEMBER_POSTS_SUCCESS, postPage));
 	}
@@ -80,7 +80,7 @@ public class MemberPostController {
 	})
 	@GetMapping("/posts/saved/recent")
 	public ResponseEntity<ResultResponse> getRecent1SavedPosts() {
-		final List<MemberPostDto> postList = memberPostService.getRecent15SavedPostDTOs();
+		final List<MemberPostDto> postList = memberPostService.getRecent15SavedPostDtos();
 
 		return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_RECENT15_MEMBER_SAVED_POSTS_SUCCESS, postList));
 	}
@@ -95,7 +95,7 @@ public class MemberPostController {
 	@GetMapping("/posts/saved")
 	@ApiImplicitParam(name = "page", value = "페이지", required = true, example = "1")
 	public ResponseEntity<ResultResponse> getSavedPostPage(@Min(1) @RequestParam int page) {
-		final Page<MemberPostDto> postPage = memberPostService.getMemberSavedPostDTOs(3, page);
+		final Page<MemberPostDto> postPage = memberPostService.getMemberSavedPostDtos(3, page);
 
 		return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_MEMBER_SAVED_POSTS_SUCCESS, postPage));
 	}
@@ -112,7 +112,7 @@ public class MemberPostController {
 	@ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma")
 	@GetMapping("/{username}/posts/tagged/recent")
 	public ResponseEntity<ResultResponse> getRecent10TaggedPosts(@PathVariable("username") String username) {
-		final List<MemberPostDto> postList = memberPostService.getRecent15TaggedPostDTOs(username);
+		final List<MemberPostDto> postList = memberPostService.getRecent15TaggedPostDtos(username);
 
 		return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_RECENT15_MEMBER_TAGGED_POSTS_SUCCESS, postList));
 	}
@@ -132,7 +132,7 @@ public class MemberPostController {
 	@GetMapping("/{username}/posts/tagged")
 	public ResponseEntity<ResultResponse> getTaggedPostPage(@PathVariable("username") String username,
 		@Min(1) @RequestParam int page) {
-		final Page<MemberPostDto> postPage = memberPostService.getMemberTaggedPostDTOs(username, 3, page);
+		final Page<MemberPostDto> postPage = memberPostService.getMemberTaggedPostDtos(username, 3, page);
 
 		return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_MEMBER_TAGGED_POSTS_SUCCESS, postPage));
 	}

--- a/src/main/java/cloneproject/Instagram/domain/member/dto/EditProfileRequest.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/dto/EditProfileRequest.java
@@ -8,6 +8,7 @@ import org.hibernate.validator.constraints.Length;
 import org.hibernate.validator.constraints.URL;
 
 import io.swagger.annotations.ApiModelProperty;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,7 +16,7 @@ import lombok.Setter;
 
 @Getter
 @Setter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class EditProfileRequest {
 

--- a/src/main/java/cloneproject/Instagram/domain/member/dto/JwtDto.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/dto/JwtDto.java
@@ -3,12 +3,10 @@ package cloneproject.Instagram.domain.member.dto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
 @Builder
+@AllArgsConstructor
 public class JwtDto {
 
 	private String type;

--- a/src/main/java/cloneproject/Instagram/domain/member/dto/JwtResponse.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/dto/JwtResponse.java
@@ -5,13 +5,11 @@ import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @ApiModel("JWT 토큰 응답 데이터 모델")
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
 @Builder
+@AllArgsConstructor
 public class JwtResponse {
 
 	@ApiModelProperty(value = "토큰 타입", example = "Bearer")

--- a/src/main/java/cloneproject/Instagram/domain/member/dto/LikeMemberDto.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/dto/LikeMemberDto.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-public class LikeMembersDto {
+public class LikeMemberDto {
 
 	private MemberDto member;
 	private boolean isFollowing;
@@ -20,7 +20,7 @@ public class LikeMembersDto {
 	}
 
 	@QueryProjection
-	public LikeMembersDto(Member member, boolean isFollowing, boolean isFollower) {
+	public LikeMemberDto(Member member, boolean isFollowing, boolean isFollower) {
 		this.member = new MemberDto(member);
 		this.isFollowing = isFollowing;
 		this.isFollower = isFollower;

--- a/src/main/java/cloneproject/Instagram/domain/member/dto/LikeMembersDto.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/dto/LikeMembersDto.java
@@ -6,7 +6,6 @@ import cloneproject.Instagram.domain.member.entity.Member;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-// @Data
 @Getter
 @NoArgsConstructor
 public class LikeMembersDto {

--- a/src/main/java/cloneproject/Instagram/domain/member/dto/LikeMembersDto.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/dto/LikeMembersDto.java
@@ -3,10 +3,11 @@ package cloneproject.Instagram.domain.member.dto;
 import com.querydsl.core.annotations.QueryProjection;
 
 import cloneproject.Instagram.domain.member.entity.Member;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Data
+// @Data
+@Getter
 @NoArgsConstructor
 public class LikeMembersDto {
 
@@ -14,6 +15,10 @@ public class LikeMembersDto {
 	private boolean isFollowing;
 	private boolean isFollower;
 	private boolean hasStory;
+
+	public void setHasStory(boolean hasStory) {
+		this.hasStory = hasStory;
+	}
 
 	@QueryProjection
 	public LikeMembersDto(Member member, boolean isFollowing, boolean isFollower) {

--- a/src/main/java/cloneproject/Instagram/domain/member/dto/LoginDevicesDto.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/dto/LoginDevicesDto.java
@@ -6,12 +6,10 @@ import cloneproject.Instagram.infra.geoip.dto.GeoIP;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@AllArgsConstructor
-@NoArgsConstructor
-@Builder
 @Getter
+@Builder
+@AllArgsConstructor
 public class LoginDevicesDto {
 
 	private String tokenId;

--- a/src/main/java/cloneproject/Instagram/domain/member/dto/LoginDevicesDto.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/dto/LoginDevicesDto.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Builder
 @Getter
-public class LoginDevicesDTO {
+public class LoginDevicesDto {
 
 	private String tokenId;
 	private GeoIP location;

--- a/src/main/java/cloneproject/Instagram/domain/member/dto/LoginRequest.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/dto/LoginRequest.java
@@ -5,6 +5,7 @@ import javax.validation.constraints.NotBlank;
 import org.hibernate.validator.constraints.Length;
 
 import io.swagger.annotations.ApiModelProperty;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,7 +13,7 @@ import lombok.Setter;
 
 @Getter
 @Setter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class LoginRequest {
 

--- a/src/main/java/cloneproject/Instagram/domain/member/dto/LoginWithCodeRequest.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/dto/LoginWithCodeRequest.java
@@ -6,6 +6,7 @@ import javax.validation.constraints.Pattern;
 import org.hibernate.validator.constraints.Length;
 
 import io.swagger.annotations.ApiModelProperty;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,7 +14,7 @@ import lombok.Setter;
 
 @Getter
 @Setter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class LoginWithCodeRequest {
 

--- a/src/main/java/cloneproject/Instagram/domain/member/dto/MemberDto.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/dto/MemberDto.java
@@ -2,10 +2,11 @@ package cloneproject.Instagram.domain.member.dto;
 
 import cloneproject.Instagram.domain.member.entity.Member;
 import cloneproject.Instagram.global.vo.Image;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Data
+// @Data
+@Getter
 @NoArgsConstructor
 public class MemberDto {
 
@@ -14,6 +15,10 @@ public class MemberDto {
 	private String name;
 	private Image image;
 	private boolean hasStory;
+
+	public void setHasStory(boolean hasStory) {
+		this.hasStory = hasStory;
+	}
 
 	public MemberDto(Member member) {
 		this.id = member.getId();

--- a/src/main/java/cloneproject/Instagram/domain/member/dto/MemberDto.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/dto/MemberDto.java
@@ -5,7 +5,6 @@ import cloneproject.Instagram.global.vo.Image;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-// @Data
 @Getter
 @NoArgsConstructor
 public class MemberDto {

--- a/src/main/java/cloneproject/Instagram/domain/member/dto/MenuMemberProfile.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/dto/MenuMemberProfile.java
@@ -5,13 +5,11 @@ import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @ApiModel("상단 메뉴 유저 프로필 모델")
 @Getter
 @Builder
 @AllArgsConstructor
-@NoArgsConstructor
 public class MenuMemberProfile {
 
 	@ApiModelProperty(value = "DB상 유저의 ID(PK)", example = "1")

--- a/src/main/java/cloneproject/Instagram/domain/member/dto/MenuMemberProfile.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/dto/MenuMemberProfile.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class MenuMemberDTO {
+public class MenuMemberProfile {
 
 	@ApiModelProperty(value = "DB상 유저의 ID(PK)", example = "1")
 	private Long memberId;

--- a/src/main/java/cloneproject/Instagram/domain/member/dto/RegisterRequest.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/dto/RegisterRequest.java
@@ -8,6 +8,7 @@ import org.hibernate.validator.constraints.Length;
 
 import cloneproject.Instagram.domain.member.entity.Member;
 import io.swagger.annotations.ApiModelProperty;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,7 +16,7 @@ import lombok.Setter;
 
 @Getter
 @Setter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class RegisterRequest {
 
@@ -48,11 +49,11 @@ public class RegisterRequest {
 
 	public Member convert() {
 		return Member.builder()
-				.username(getUsername())
-				.name(getName())
-				.password(getPassword())
-				.email(getEmail())
-				.build();
+			.username(getUsername())
+			.name(getName())
+			.password(getPassword())
+			.email(getEmail())
+			.build();
 	}
 
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/dto/ResetPasswordRequest.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/dto/ResetPasswordRequest.java
@@ -6,6 +6,7 @@ import javax.validation.constraints.Pattern;
 import org.hibernate.validator.constraints.Length;
 
 import io.swagger.annotations.ApiModelProperty;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,7 +14,7 @@ import lombok.Setter;
 
 @Getter
 @Setter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class ResetPasswordRequest {
 

--- a/src/main/java/cloneproject/Instagram/domain/member/dto/SendConfirmationEmailRequest.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/dto/SendConfirmationEmailRequest.java
@@ -7,15 +7,16 @@ import javax.validation.constraints.Pattern;
 import org.hibernate.validator.constraints.Length;
 
 import io.swagger.annotations.ApiModelProperty;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
 @Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class SendConfirmationEmailRequest {
 
 	@ApiModelProperty(value = "유저네임", example = "dlwlrma", required = true)

--- a/src/main/java/cloneproject/Instagram/domain/member/dto/UpdatePasswordRequest.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/dto/UpdatePasswordRequest.java
@@ -6,6 +6,7 @@ import javax.validation.constraints.Pattern;
 import org.hibernate.validator.constraints.Length;
 
 import io.swagger.annotations.ApiModelProperty;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,7 +14,7 @@ import lombok.Setter;
 
 @Getter
 @Setter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class UpdatePasswordRequest {
 

--- a/src/main/java/cloneproject/Instagram/domain/member/dto/UserProfileResponse.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/dto/UserProfileResponse.java
@@ -9,10 +9,7 @@ import cloneproject.Instagram.domain.follow.dto.FollowDto;
 import cloneproject.Instagram.global.vo.Image;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @ApiModel("유저 프로필 조회 응답 모델")
 @Getter

--- a/src/main/java/cloneproject/Instagram/domain/member/exception/EmailNotConfirmedException.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/exception/EmailNotConfirmedException.java
@@ -3,8 +3,8 @@ package cloneproject.Instagram.domain.member.exception;
 import cloneproject.Instagram.global.error.ErrorCode;
 import cloneproject.Instagram.global.error.exception.BusinessException;
 
-public class NoConfirmEmailException extends BusinessException {
-	public NoConfirmEmailException() {
+public class EmailNotConfirmedException extends BusinessException {
+	public EmailNotConfirmedException() {
 		super(ErrorCode.EMAIL_NOT_CONFIRMED);
 	}
 

--- a/src/main/java/cloneproject/Instagram/domain/member/repository/querydsl/MemberPostRepositoryQuerydsl.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/repository/querydsl/MemberPostRepositoryQuerydsl.java
@@ -7,10 +7,10 @@ import cloneproject.Instagram.domain.feed.dto.MemberPostDto;
 
 public interface MemberPostRepositoryQuerydsl {
 
-	Page<MemberPostDto> getMemberPostDtos(String username, Pageable pageable);
+	Page<MemberPostDto> findMemberPostDtos(String username, Pageable pageable);
 
-	Page<MemberPostDto> getMemberSavedPostDtos(Long loginUserId, Pageable pageable);
+	Page<MemberPostDto> findMemberSavedPostDtos(Long loginUserId, Pageable pageable);
 
-	Page<MemberPostDto> getMemberTaggedPostDtos(String username, Pageable pageable);
+	Page<MemberPostDto> findMemberTaggedPostDtos(String username, Pageable pageable);
 
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/repository/querydsl/MemberPostRepositoryQuerydslImpl.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/repository/querydsl/MemberPostRepositoryQuerydslImpl.java
@@ -22,7 +22,7 @@ public class MemberPostRepositoryQuerydslImpl implements MemberPostRepositoryQue
 	private final JPAQueryFactory queryFactory;
 
 	@Override
-	public Page<MemberPostDto> getMemberPostDtos(String username, Pageable pageable) {
+	public Page<MemberPostDto> findMemberPostDtos(String username, Pageable pageable) {
 		final List<MemberPostDto> posts = queryFactory
 			.select(new QMemberPostDto(
 				post.id,
@@ -45,7 +45,7 @@ public class MemberPostRepositoryQuerydslImpl implements MemberPostRepositoryQue
 	}
 
 	@Override
-	public Page<MemberPostDto> getMemberSavedPostDtos(Long loginUserId, Pageable pageable) {
+	public Page<MemberPostDto> findMemberSavedPostDtos(Long loginUserId, Pageable pageable) {
 		final List<MemberPostDto> posts = queryFactory
 			.select(new QMemberPostDto(
 				bookmark.post.id,
@@ -68,7 +68,7 @@ public class MemberPostRepositoryQuerydslImpl implements MemberPostRepositoryQue
 	}
 
 	@Override
-	public Page<MemberPostDto> getMemberTaggedPostDtos(String username, Pageable pageable) {
+	public Page<MemberPostDto> findMemberTaggedPostDtos(String username, Pageable pageable) {
 		final List<MemberPostDto> posts = queryFactory
 			.select(new QMemberPostDto(
 				postTag.postImage.post.id,

--- a/src/main/java/cloneproject/Instagram/domain/member/repository/querydsl/MemberRepositoryQuerydsl.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/repository/querydsl/MemberRepositoryQuerydsl.java
@@ -8,9 +8,9 @@ import cloneproject.Instagram.domain.member.entity.Member;
 
 public interface MemberRepositoryQuerydsl {
 
-	UserProfileResponse getUserProfile(Long loginUserId, String username);
+	UserProfileResponse findUserProfile(Long loginUserId, String username);
 
-	MiniProfileResponse getMiniProfile(Long loginUserId, String username);
+	MiniProfileResponse findMiniProfile(Long loginUserId, String username);
 
 	List<Member> findAllByUsernames(List<String> usernames);
 

--- a/src/main/java/cloneproject/Instagram/domain/member/repository/querydsl/MemberRepositoryQuerydslImpl.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/repository/querydsl/MemberRepositoryQuerydslImpl.java
@@ -25,7 +25,7 @@ public class MemberRepositoryQuerydslImpl implements MemberRepositoryQuerydsl {
 	private final JPAQueryFactory queryFactory;
 
 	@Override
-	public UserProfileResponse getUserProfile(Long loginUserId, String username) {
+	public UserProfileResponse findUserProfile(Long loginUserId, String username) {
 		return queryFactory
 			.select(new QUserProfileResponse(
 				member.username,
@@ -47,7 +47,7 @@ public class MemberRepositoryQuerydslImpl implements MemberRepositoryQuerydsl {
 	}
 
 	@Override
-	public MiniProfileResponse getMiniProfile(Long loginUserId, String username) {
+	public MiniProfileResponse findMiniProfile(Long loginUserId, String username) {
 		return queryFactory
 			.select(new QMiniProfileResponse(
 				member.username,

--- a/src/main/java/cloneproject/Instagram/domain/member/service/EmailCodeService.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/service/EmailCodeService.java
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Service;
 import cloneproject.Instagram.domain.member.entity.Member;
 import cloneproject.Instagram.domain.member.entity.redis.EmailCode;
 import cloneproject.Instagram.domain.member.entity.redis.ResetPasswordCode;
-import cloneproject.Instagram.domain.member.exception.NoConfirmEmailException;
+import cloneproject.Instagram.domain.member.exception.EmailNotConfirmedException;
 import cloneproject.Instagram.domain.member.exception.PasswordResetFailException;
 import cloneproject.Instagram.domain.member.repository.MemberRepository;
 import cloneproject.Instagram.domain.member.repository.redis.EmailCodeRedisRepository;
@@ -69,7 +69,7 @@ public class EmailCodeService {
 		final Optional<EmailCode> optionalEmailCode = emailCodeRedisRepository.findByUsername(username);
 
 		if (optionalEmailCode.isEmpty()) {
-			throw new NoConfirmEmailException();
+			throw new EmailNotConfirmedException();
 		}
 
 		final EmailCode emailCode = optionalEmailCode.get();
@@ -106,7 +106,7 @@ public class EmailCodeService {
 			.findByUsername(username);
 
 		if (optionalResetPasswordCode.isEmpty()) {
-			throw new PasswordResetFailException();
+			throw new EmailNotConfirmedException();
 		}
 
 		final ResetPasswordCode resetPasswordCode = optionalResetPasswordCode.get();

--- a/src/main/java/cloneproject/Instagram/domain/member/service/MemberAuthService.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/service/MemberAuthService.java
@@ -3,7 +3,6 @@ package cloneproject.Instagram.domain.member.service;
 import static cloneproject.Instagram.global.error.ErrorCode.*;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -14,17 +13,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import cloneproject.Instagram.domain.member.dto.JwtDto;
-import cloneproject.Instagram.domain.member.dto.LoginDevicesDTO;
+import cloneproject.Instagram.domain.member.dto.LoginDevicesDto;
 import cloneproject.Instagram.domain.member.dto.LoginRequest;
-import cloneproject.Instagram.domain.member.dto.LoginWithCodeRequest;
 import cloneproject.Instagram.domain.member.dto.RegisterRequest;
 import cloneproject.Instagram.domain.member.dto.ResetPasswordRequest;
 import cloneproject.Instagram.domain.member.dto.UpdatePasswordRequest;
 import cloneproject.Instagram.domain.member.entity.Member;
-import cloneproject.Instagram.domain.member.entity.redis.RefreshToken;
 import cloneproject.Instagram.domain.member.exception.AccountMismatchException;
-import cloneproject.Instagram.domain.member.exception.JwtExpiredException;
-import cloneproject.Instagram.domain.member.exception.JwtInvalidException;
 import cloneproject.Instagram.domain.member.exception.PasswordResetFailException;
 import cloneproject.Instagram.domain.member.repository.MemberRepository;
 import cloneproject.Instagram.domain.search.entity.SearchMember;
@@ -35,8 +30,6 @@ import cloneproject.Instagram.global.util.AuthUtil;
 import cloneproject.Instagram.global.util.JwtUtil;
 import cloneproject.Instagram.infra.geoip.GeoIPLocationService;
 import cloneproject.Instagram.infra.geoip.dto.GeoIP;
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.JwtException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -161,7 +154,7 @@ public class MemberAuthService {
 		refreshTokenService.deleteRefreshTokenWithValue(authUtil.getLoginMemberId(), refreshToken);
 	}
 
-	public List<LoginDevicesDTO> getLoginDevices() {
+	public List<LoginDevicesDto> getLoginDevices() {
 		final Member member = authUtil.getLoginMember();
 		return refreshTokenService.getLoginDevices(member.getId());
 	}

--- a/src/main/java/cloneproject/Instagram/domain/member/service/MemberPostService.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/service/MemberPostService.java
@@ -33,7 +33,7 @@ public class MemberPostService {
 	private static final int FIRST_PAGE_SIZE = 15;
 	private static final int PAGE_OFFSET = 4;
 
-	public Page<MemberPostDto> getMemberPostDTOs(String username, int size, int page) {
+	public Page<MemberPostDto> getMemberPostDtos(String username, int size, int page) {
 		final Long loginMemberId = authUtil.getLoginMemberIdOrNull();
 
 		final Member member = memberRepository.findByUsername(username)
@@ -44,12 +44,12 @@ public class MemberPostService {
 		}
 
 		final Pageable pageable = PageRequest.of(page + PAGE_OFFSET, size);
-		final Page<MemberPostDto> posts = memberRepository.getMemberPostDtos(username, pageable);
-		setMemberPostImageDTOs(posts.getContent());
+		final Page<MemberPostDto> posts = memberRepository.findMemberPostDtos(username, pageable);
+		setMemberPostImageDtos(posts.getContent());
 		return posts;
 	}
 
-	public List<MemberPostDto> getRecent15PostDTOs(String username) {
+	public List<MemberPostDto> getRecent15PostDtos(String username) {
 		final Long loginMemberId = authUtil.getLoginMemberIdOrNull();
 
 		final Member member = memberRepository.findByUsername(username)
@@ -60,30 +60,30 @@ public class MemberPostService {
 		}
 
 		final Pageable pageable = PageRequest.of(0, FIRST_PAGE_SIZE);
-		final Page<MemberPostDto> posts = memberRepository.getMemberPostDtos(username, pageable);
-		setMemberPostImageDTOs(posts.getContent());
+		final Page<MemberPostDto> posts = memberRepository.findMemberPostDtos(username, pageable);
+		setMemberPostImageDtos(posts.getContent());
 		return posts.getContent();
 	}
 
-	public Page<MemberPostDto> getMemberSavedPostDTOs(int size, int page) {
+	public Page<MemberPostDto> getMemberSavedPostDtos(int size, int page) {
 		final Long loginMemberId = authUtil.getLoginMemberId();
 
 		final Pageable pageable = PageRequest.of(page + PAGE_OFFSET, size);
-		final Page<MemberPostDto> posts = memberRepository.getMemberSavedPostDtos(loginMemberId, pageable);
-		setMemberPostImageDTOs(posts.getContent());
+		final Page<MemberPostDto> posts = memberRepository.findMemberSavedPostDtos(loginMemberId, pageable);
+		setMemberPostImageDtos(posts.getContent());
 		return posts;
 	}
 
-	public List<MemberPostDto> getRecent15SavedPostDTOs() {
+	public List<MemberPostDto> getRecent15SavedPostDtos() {
 		final Long loginMemberId = authUtil.getLoginMemberId();
 
 		final Pageable pageable = PageRequest.of(0, FIRST_PAGE_SIZE);
-		final Page<MemberPostDto> posts = memberRepository.getMemberSavedPostDtos(loginMemberId, pageable);
-		setMemberPostImageDTOs(posts.getContent());
+		final Page<MemberPostDto> posts = memberRepository.findMemberSavedPostDtos(loginMemberId, pageable);
+		setMemberPostImageDtos(posts.getContent());
 		return posts.getContent();
 	}
 
-	public Page<MemberPostDto> getMemberTaggedPostDTOs(String username, int size, int page) {
+	public Page<MemberPostDto> getMemberTaggedPostDtos(String username, int size, int page) {
 		final Long loginMemberId = authUtil.getLoginMemberIdOrNull();
 
 		final Member member = memberRepository.findByUsername(username)
@@ -94,12 +94,12 @@ public class MemberPostService {
 		}
 
 		final Pageable pageable = PageRequest.of(page + PAGE_OFFSET, size);
-		final Page<MemberPostDto> posts = memberRepository.getMemberTaggedPostDtos(username, pageable);
-		setMemberPostImageDTOs(posts.getContent());
+		final Page<MemberPostDto> posts = memberRepository.findMemberTaggedPostDtos(username, pageable);
+		setMemberPostImageDtos(posts.getContent());
 		return posts;
 	}
 
-	public List<MemberPostDto> getRecent15TaggedPostDTOs(String username) {
+	public List<MemberPostDto> getRecent15TaggedPostDtos(String username) {
 		final Long loginMemberId = authUtil.getLoginMemberIdOrNull();
 
 		final Member member = memberRepository.findByUsername(username)
@@ -110,12 +110,12 @@ public class MemberPostService {
 		}
 
 		final Pageable pageable = PageRequest.of(0, FIRST_PAGE_SIZE);
-		final Page<MemberPostDto> posts = memberRepository.getMemberTaggedPostDtos(username, pageable);
-		setMemberPostImageDTOs(posts.getContent());
+		final Page<MemberPostDto> posts = memberRepository.findMemberTaggedPostDtos(username, pageable);
+		setMemberPostImageDtos(posts.getContent());
 		return posts.getContent();
 	}
 
-	private void setMemberPostImageDTOs(List<MemberPostDto> memberPostDtos) {
+	private void setMemberPostImageDtos(List<MemberPostDto> memberPostDtos) {
 		final List<Long> postIds = memberPostDtos.stream()
 			.map(MemberPostDto::getPostId)
 			.collect(Collectors.toList());

--- a/src/main/java/cloneproject/Instagram/domain/member/service/MemberService.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/service/MemberService.java
@@ -20,7 +20,7 @@ import cloneproject.Instagram.domain.follow.dto.FollowDto;
 import cloneproject.Instagram.domain.follow.repository.FollowRepository;
 import cloneproject.Instagram.domain.member.dto.EditProfileRequest;
 import cloneproject.Instagram.domain.member.dto.EditProfileResponse;
-import cloneproject.Instagram.domain.member.dto.MenuMemberDTO;
+import cloneproject.Instagram.domain.member.dto.MenuMemberProfile;
 import cloneproject.Instagram.domain.member.dto.MiniProfileResponse;
 import cloneproject.Instagram.domain.member.dto.UserProfileResponse;
 import cloneproject.Instagram.domain.member.entity.Gender;
@@ -51,10 +51,10 @@ public class MemberService {
 	private static final int MAX_MINI_PROFILE_FOLLOWING_MEMBER_FOLLOW_COUNT = 1;
 
 	@Transactional(readOnly = true)
-	public MenuMemberDTO getMenuMemberProfile() {
+	public MenuMemberProfile getMenuMemberProfile() {
 		final Member member = authUtil.getLoginMember();
 
-		return MenuMemberDTO.builder()
+		return MenuMemberProfile.builder()
 			.memberId(member.getId())
 			.memberUsername(member.getUsername())
 			.memberName(member.getName())
@@ -69,7 +69,7 @@ public class MemberService {
 		final Member member = memberRepository.findByUsername(username)
 			.orElseThrow(() -> new EntityNotFoundException(MEMBER_NOT_FOUND));
 
-		final UserProfileResponse result = memberRepository.getUserProfile(memberId, member.getUsername());
+		final UserProfileResponse result = memberRepository.findUserProfile(memberId, member.getUsername());
 		final List<FollowDto> followDtos = followRepository.getFollowingMemberFollowList(memberId, username);
 
 		result.setFollowingMemberFollow(followDtos, MAX_PROFILE_FOLLOWING_MEMBER_FOLLOW_COUNT);
@@ -85,7 +85,7 @@ public class MemberService {
 		final Member member = memberRepository.findByUsername(username)
 			.orElseThrow(() -> new EntityNotFoundException(MEMBER_NOT_FOUND));
 
-		final MiniProfileResponse result = memberRepository.getMiniProfile(memberId, member.getUsername());
+		final MiniProfileResponse result = memberRepository.findMiniProfile(memberId, member.getUsername());
 		final List<FollowDto> followDtos = followRepository.getFollowingMemberFollowList(memberId, username);
 
 		result.setFollowingMemberFollow(followDtos, MAX_MINI_PROFILE_FOLLOWING_MEMBER_FOLLOW_COUNT);

--- a/src/main/java/cloneproject/Instagram/domain/member/service/RefreshTokenService.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/service/RefreshTokenService.java
@@ -9,11 +9,10 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import cloneproject.Instagram.domain.member.dto.LoginDevicesDTO;
+import cloneproject.Instagram.domain.member.dto.LoginDevicesDto;
 import cloneproject.Instagram.domain.member.entity.redis.RefreshToken;
 import cloneproject.Instagram.domain.member.exception.JwtInvalidException;
 import cloneproject.Instagram.domain.member.repository.redis.RefreshTokenRedisRepository;
-import cloneproject.Instagram.global.util.DateUtil;
 import cloneproject.Instagram.infra.geoip.dto.GeoIP;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -90,7 +89,7 @@ public class RefreshTokenService {
 	}
 
 	@Transactional(readOnly = true)
-	public List<LoginDevicesDTO> getLoginDevices(Long memberId) {
+	public List<LoginDevicesDto> getLoginDevices(Long memberId) {
 		final List<RefreshToken> refreshTokens = refreshTokenRedisRepository.findByMemberId(memberId)
 				.stream()
 				.sorted(Comparator.comparing(RefreshToken::getLastUpdateDate).reversed())
@@ -100,8 +99,8 @@ public class RefreshTokenService {
 				.collect(Collectors.toList());
 	}
 
-	private LoginDevicesDTO convertRefreshTokenToLoginedDevicesDTO(RefreshToken refreshToken) {
-		return LoginDevicesDTO.builder()
+	private LoginDevicesDto convertRefreshTokenToLoginedDevicesDTO(RefreshToken refreshToken) {
+		return LoginDevicesDto.builder()
 				.tokenId(refreshToken.getId())
 				.device(refreshToken.getDevice())
 				.location(refreshToken.getGeoIP())

--- a/src/main/java/cloneproject/Instagram/global/config/security/WebSecurityConfig.java
+++ b/src/main/java/cloneproject/Instagram/global/config/security/WebSecurityConfig.java
@@ -73,7 +73,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 	private static final String[] AUTH_WHITELIST_SWAGGER = {"/v2/api-docs", "/configuration/ui", "/swagger-resources",
 		"/configuration/security", "/swagger-ui.html", "/webjars/**", "/swagger/**"};
 	private static final String[] AUTH_WHITELIST_STATIC = {"/static/css/**", "/static/js/**", "*.ico"};
-	private static final String[] AUTH_WHITELIST = {"/login", "/login/recovery", "/accounts/password/email",
+	private static final String[] AUTH_WHITELIST = {"/login", "/login/recovery", "/accounts", "/accounts/password/email",
 		"/accounts/password/reset", "/reissue", "/swagger-ui.html", "/swagger/**", "/swagger-resources/**",
 		"swagger-ui/**", "/accounts/email", "/accounts/check", "/logout/only/cookie"};
 

--- a/src/main/java/cloneproject/Instagram/global/config/security/filter/ReissueAuthenticationFilter.java
+++ b/src/main/java/cloneproject/Instagram/global/config/security/filter/ReissueAuthenticationFilter.java
@@ -30,6 +30,9 @@ public class ReissueAuthenticationFilter extends AbstractAuthenticationProcessin
 		if (!request.getMethod().equals("POST")) {
 			throw new AuthenticationServiceException("Authentication method not supported: " + request.getMethod());
 		} else {
+			if (request.getCookies() == null) {
+				throw new JwtInvalidException();
+			}
 			final Cookie refreshToken = Arrays.stream(request.getCookies())
 				.filter(c -> c.getName().equals("refreshToken"))
 				.findFirst()

--- a/src/main/java/cloneproject/Instagram/global/error/ErrorCode.java
+++ b/src/main/java/cloneproject/Instagram/global/error/ErrorCode.java
@@ -33,7 +33,7 @@ public enum ErrorCode {
 	AUTHORITY_INVALID(403, "M004", "권한이 없습니다."),
 	ACCOUNT_MISMATCH(401, "M005", "계정 정보가 일치하지 않습니다."),
 	EMAIL_NOT_CONFIRMED(400, "M007", "인증 이메일 전송을 먼저 해야합니다."),
-	PASSWORD_RESET_FAIL(400, "M008", "잘못되거나 만료된 코드입니다"),
+	PASSWORD_RESET_FAIL(400, "M008", "잘못되거나 만료된 코드입니다."),
 	ALREADY_BLOCK(400, "M009", "이미 차단한 유저입니다."),
 	CANT_UNBLOCK(400, "M010", "차단하지 않은 유저는 차단해제 할 수 없습니다."),
 	CANT_BLOCK_MYSELF(400, "M011", "자기 자신을 차단 할 수 없습니다."),
@@ -49,7 +49,7 @@ public enum ErrorCode {
 
 	// Jwt
 	JWT_INVALID(401, "J001", "유효하지 않은 토큰입니다."),
-	JWT_EXPIRED(401, "J002", "만료된 ACCESS 토큰입니다. REISSUE 해주십시오."),
+	JWT_EXPIRED(401, "J002", "만료된 토큰입니다."),
 	EXPIRED_REFRESH_TOKEN(401, "J003", "만료된 REFRESH 토큰입니다. 재로그인 해주십시오."),
 
 	// Feed

--- a/src/main/java/cloneproject/Instagram/global/result/ResultCode.java
+++ b/src/main/java/cloneproject/Instagram/global/result/ResultCode.java
@@ -55,12 +55,12 @@ public enum ResultCode {
 	UNBLOCK_SUCCESS(200, "B002", "회원 차단해제 완료"),
 
 	// MemberPost
-	FIND_RECENT15_MEMBER_POSTS_SUCCESS(200, "MP001", "회원의 최근 게시물 15개 조회 성공"),
-	FIND_MEMBER_POSTS_SUCCESS(200, "MP002", "회원의 게시물 조회 성공"),
-	FIND_RECENT15_MEMBER_SAVED_POSTS_SUCCESS(200, "MP003", "회원의 최근 저장한 게시물 15개 조회 성공"),
-	FIND_MEMBER_SAVED_POSTS_SUCCESS(200, "MP004", "회원의 저장한 게시물 조회 성공"),
-	FIND_RECENT15_MEMBER_TAGGED_POSTS_SUCCESS(200, "MP005", "회원의 최근 태그된 게시물 15개 조회 성공"),
-	FIND_MEMBER_TAGGED_POSTS_SUCCESS(200, "MP006", "회원의 태그된 게시물 조회 성공"),
+	GET_RECENT15_MEMBER_POSTS_SUCCESS(200, "MP001", "회원의 최근 게시물 15개 조회에 성공하였습니다."),
+	GET_MEMBER_POSTS_SUCCESS(200, "MP002", "회원의 게시물 조회에 성공하였습니다."),
+	GET_RECENT15_MEMBER_SAVED_POSTS_SUCCESS(200, "MP003", "회원의 최근 저장한 게시물 15개 조회에 성공하였습니다."),
+	GET_MEMBER_SAVED_POSTS_SUCCESS(200, "MP004", "회원의 저장한 게시물 조회에 성공하였습니다."),
+	GET_RECENT15_MEMBER_TAGGED_POSTS_SUCCESS(200, "MP005", "회원의 최근 태그된 게시물 15개 조회에 성공하였습니다."),
+	GET_MEMBER_TAGGED_POSTS_SUCCESS(200, "MP006", "회원의 태그된 게시물 조회에 성공하였습니다."),
 
 	// Feed
 	CREATE_POST_SUCCESS(200, "F001", "게시물 업로드에 성공하였습니다."),

--- a/src/test/java/cloneproject/Instagram/repository/MemberRepositoryTest.java
+++ b/src/test/java/cloneproject/Instagram/repository/MemberRepositoryTest.java
@@ -97,7 +97,7 @@ public class MemberRepositoryTest {
             @Test
             @DisplayName("정상적으로 결과를 반환한다")
             void it_returns_well(){
-                UserProfileResponse userProfileResponse = memberRepository.getUserProfile(loginedId, savedMemberTwo.getUsername());
+                UserProfileResponse userProfileResponse = memberRepository.findUserProfile(loginedId, savedMemberTwo.getUsername());
                 assertEquals(savedMemberTwo.getUsername(), userProfileResponse.getMemberUsername());
                 assertEquals(savedMemberTwo.getName(), userProfileResponse.getMemberName());
                 assertEquals(2L, userProfileResponse.getMemberFollowersCount());
@@ -111,7 +111,7 @@ public class MemberRepositoryTest {
             @Test
             @DisplayName("정상적으로 결과를 반환하나, 특정 결과가 고정된다")
             void it_returns_well(){
-                UserProfileResponse userProfileResponse = memberRepository.getUserProfile(-1L, savedMemberTwo.getUsername());
+                UserProfileResponse userProfileResponse = memberRepository.findUserProfile(-1L, savedMemberTwo.getUsername());
                 assertEquals(savedMemberTwo.getUsername(), userProfileResponse.getMemberUsername());
                 assertEquals(savedMemberTwo.getName(), userProfileResponse.getMemberName());
                 assertEquals(2L, userProfileResponse.getMemberFollowersCount());
@@ -129,7 +129,7 @@ public class MemberRepositoryTest {
             @Test
             @DisplayName("정상적으로 결과를 반환한다")
             void it_returns_well(){
-                MiniProfileResponse miniProfileResponse = memberRepository.getMiniProfile(loginedId, savedMemberTwo.getUsername());
+                MiniProfileResponse miniProfileResponse = memberRepository.findMiniProfile(loginedId, savedMemberTwo.getUsername());
                 assertEquals(savedMemberTwo.getUsername(), miniProfileResponse.getMemberUsername());
                 assertEquals(savedMemberTwo.getName(), miniProfileResponse.getMemberName());
                 assertEquals(2L, miniProfileResponse.getMemberFollowersCount());

--- a/src/test/java/cloneproject/Instagram/service/MemberServiceTest.java
+++ b/src/test/java/cloneproject/Instagram/service/MemberServiceTest.java
@@ -92,7 +92,7 @@ public class MemberServiceTest {
             @DisplayName("정상적으로 조회된다")
             @Test
             void it_load_well(){
-                when(memberRepository.getUserProfile(1L, "dlwlrma")).thenReturn(
+                when(memberRepository.findUserProfile(1L, "dlwlrma")).thenReturn(
                     new UserProfileResponse("dlwlrma", "이지금", "", ImageUtil.getBaseImage(),
                     true, false, false, false, "이지금 입니다", 2L, 1L, 1L, true)
                 );
@@ -126,7 +126,7 @@ public class MemberServiceTest {
             @DisplayName("정상적으로 조회된다")
             @Test
             void it_load_well(){
-                when(memberRepository.getMiniProfile(1L, "dlwlrma")).thenReturn(
+                when(memberRepository.findMiniProfile(1L, "dlwlrma")).thenReturn(
                     new MiniProfileResponse("dlwlrma", "이지금", ImageUtil.getBaseImage(),
                     true, false, false, false, 2L, 1L, 1L, true)
                 );


### PR DESCRIPTION
<!--
✅ 변경 사항을 자세히 알려주세요. (why -> what -> how)
-->
## ✏Change Details
### 리팩토링, 컨벤션 적용
- 멤버 관련 Controller에 ApiResponse 적용
  - 관련하여, 일부 ResultCode, ErrorCode 수정
- Dto 관련 컨벤션 적용
  - DTO, Dto로 혼재되어있던 메서드와 클래스 명을 Dto로 통일
  - Request에 `NoargsConstructor(access = AccessLevel.PROTECTED)` 적용
  - Response의 의미없는 생성자 및 `@Data` 삭제
  - `LikeMembersDto`를 `LikeMemberDto`로 수정 (의미없는 복수형 제거)
-  get/find 표현 통일화
- 
### 버그 수정
- RefreshToken(쿠키)이 없는 상태로 재발급 API 호출시 500 에러가 발생하던 문제 수정
 - 쿠키 배열에서 `refreshToken`을 찾는 로직이 있었는데, 쿠키가 아예 없는 경우 `NullPointerException`이 발생 -> 쿠키 배열에 null 체크를 하여 문제 해결
<!--
✅ 추가로 전달할 내용이 있다면 적어주세요.
-->
## 💬Comment 
- 멤버쪽 리팩토링은 이전에 완료해서, 이후 추가된 컨벤션만 추가 적용 위주로 작업했습니다.

<!--
✅ 참고한 사이트가 있다면 공유해주세요.
-->
## 📑References
- 

## ✅Check List
- [x] 추가한 기능에 대한 테스트는 모두 완료하셨나요?
- [x] 코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?
