### PR TITLE
검색 자동완성 추가, 카카오 맵 API 수정

### DIFF
--- a/src/main/java/cloneproject/Instagram/domain/hashtag/repository/HashtagRepository.java
+++ b/src/main/java/cloneproject/Instagram/domain/hashtag/repository/HashtagRepository.java
@@ -4,6 +4,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import cloneproject.Instagram.domain.hashtag.entity.Hashtag;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -12,5 +13,8 @@ public interface HashtagRepository extends JpaRepository<Hashtag, Long> {
 
     List<Hashtag> findAllByNameIn(Set<String> names);
 
+    List<Hashtag> findAllByIdIn(Collection<Long> ids);
+
     Optional<Hashtag> findByName(String name);
+
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/repository/MemberRepository.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/repository/MemberRepository.java
@@ -20,5 +20,7 @@ public interface MemberRepository
 	boolean existsByUsername(String username);
 
 	List<Member> findAllByUsernameIn(Collection<String> usernames);
+	
+	List<Member> findAllByIdIn(Collection<Long> ids);
 
 }

--- a/src/main/java/cloneproject/Instagram/domain/search/controller/SearchController.java
+++ b/src/main/java/cloneproject/Instagram/domain/search/controller/SearchController.java
@@ -16,6 +16,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import cloneproject.Instagram.domain.hashtag.dto.HashtagDTO;
+import cloneproject.Instagram.domain.member.dto.MemberDto;
 import cloneproject.Instagram.domain.search.dto.SearchDto;
 import cloneproject.Instagram.domain.search.service.SearchService;
 import cloneproject.Instagram.global.result.ResultResponse;
@@ -43,6 +45,24 @@ public class SearchController {
 		final List<SearchDto> searchDtos = searchService.searchByText(text);
 
 		return ResponseEntity.ok(ResultResponse.of(SEARCH_SUCCESS, searchDtos));
+	}
+
+	@ApiOperation(value = "멤버 자동완성")
+	@ApiImplicitParam(name = "text", value = "검색내용", required = true, example = "dlwl")
+	@GetMapping("/auto/member")
+	public ResponseEntity<ResultResponse> getMemberAutoComplete(@RequestParam String text) {
+		final List<MemberDto> searchDtos = searchService.getMemberAutoComplete(text);
+
+		return ResponseEntity.ok(ResultResponse.of(GET_MEMBER_AUTO_COMPLETE_SUCCESS, searchDtos));
+	}
+
+	@ApiOperation(value = "해시태그 자동완성")
+	@ApiImplicitParam(name = "text", value = "검색내용", required = true, example = "#dlwl")
+	@GetMapping("/auto/hashtag")
+	public ResponseEntity<ResultResponse> getHashtagAutoComplete(@RequestParam String text) {
+		final List<HashtagDTO> searchDtos = searchService.getHashtagAutoComplete(text);
+
+		return ResponseEntity.ok(ResultResponse.of(GET_HASHTAG_AUTO_COMPLETE_SUCCESS, searchDtos));
 	}
 
 	@ApiOperation(value = "검색 조회수 증가, 최근 검색 기록 업데이트")

--- a/src/main/java/cloneproject/Instagram/domain/search/controller/SearchController.java
+++ b/src/main/java/cloneproject/Instagram/domain/search/controller/SearchController.java
@@ -25,6 +25,8 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -39,6 +41,12 @@ public class SearchController {
 	private final SearchService searchService;
 
 	@ApiOperation(value = "검색")
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "SE001 - 검색에 성공하였습니다."),
+		@ApiResponse(code = 400, message = "G003 - 유효하지 않은 입력입니다.\n"
+			+ "G004 - 입력 타입이 유효하지 않습니다."),
+		@ApiResponse(code = 401, message = "M003 - 로그인이 필요한 화면입니다.")
+	})
 	@ApiImplicitParam(name = "text", value = "검색내용", required = true, example = "dlwl")
 	@GetMapping
 	public ResponseEntity<ResultResponse> searchText(@RequestParam String text) {
@@ -48,6 +56,12 @@ public class SearchController {
 	}
 
 	@ApiOperation(value = "멤버 자동완성")
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "SE007 - 멤버 자동완성 조회에 성공하였습니다."),
+		@ApiResponse(code = 400, message = "G003 - 유효하지 않은 입력입니다.\n"
+			+ "G004 - 입력 타입이 유효하지 않습니다."),
+		@ApiResponse(code = 401, message = "M003 - 로그인이 필요한 화면입니다.")
+	})
 	@ApiImplicitParam(name = "text", value = "검색내용", required = true, example = "dlwl")
 	@GetMapping("/auto/member")
 	public ResponseEntity<ResultResponse> getMemberAutoComplete(@RequestParam String text) {
@@ -57,6 +71,13 @@ public class SearchController {
 	}
 
 	@ApiOperation(value = "해시태그 자동완성")
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "SE008 - 해시태그 자동완성 조회에 성공하였습니다."),
+		@ApiResponse(code = 400, message = "G003 - 유효하지 않은 입력입니다.\n"
+			+ "G004 - 입력 타입이 유효하지 않습니다.\n"
+			+ "H004 - 해시태그는 #으로 시작해야 합니다."),
+		@ApiResponse(code = 401, message = "M003 - 로그인이 필요한 화면입니다.")
+	})
 	@ApiImplicitParam(name = "text", value = "검색내용", required = true, example = "#dlwl")
 	@GetMapping("/auto/hashtag")
 	public ResponseEntity<ResultResponse> getHashtagAutoComplete(@RequestParam String text) {
@@ -66,6 +87,14 @@ public class SearchController {
 	}
 
 	@ApiOperation(value = "검색 조회수 증가, 최근 검색 기록 업데이트")
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "SE002 - 검색 조회수 증가, 최근검색기록 업데이트에 성공하였습니다."),
+		@ApiResponse(code = 400, message = "G003 - 유효하지 않은 입력입니다.\n"
+			+ "G004 - 입력 타입이 유효하지 않습니다.\n"
+			+ "G009 - 올바르지 않은 entity type 입니다.\n"
+			+ "H004 - 해시태그는 #으로 시작해야 합니다."),
+		@ApiResponse(code = 401, message = "M003 - 로그인이 필요한 화면입니다.")
+	})
 	@ApiImplicitParams({
 		@ApiImplicitParam(name = "entityName", value = "조회수 증가시킬 식별 name", required = true, example = "dlwlrma"),
 		@ApiImplicitParam(name = "entityType", value = "조회수 증가시킬 type", required = true, example = "MEMBER")
@@ -79,6 +108,10 @@ public class SearchController {
 	}
 
 	@ApiOperation(value = "최근 검색 기록(15개 조회)")
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "SE003 - 최근 검색 기록 15개 조회에 성공하였습니다."),
+		@ApiResponse(code = 401, message = "M003 - 로그인이 필요한 화면입니다.")
+	})
 	@GetMapping(value = "/recent/top")
 	public ResponseEntity<ResultResponse> getTop15RecentSearch() {
 		final Page<SearchDto> searchDtos = searchService.getTop15RecentSearches();
@@ -87,6 +120,12 @@ public class SearchController {
 	}
 
 	@ApiOperation(value = "최근 검색 기록 무한스크롤")
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "SE004 - 최근 검색 기록 페이지(무한스크롤) 조회에 성공하였습니다."),
+		@ApiResponse(code = 400, message = "G003 - 유효하지 않은 입력입니다.\n"
+			+ "G004 - 입력 타입이 유효하지 않습니다."),
+		@ApiResponse(code = 401, message = "M003 - 로그인이 필요한 화면입니다.")
+	})
 	@GetMapping(value = "/recent")
 	public ResponseEntity<ResultResponse> getRecentSearch(@Min(1) @RequestParam int page) {
 		final Page<SearchDto> searchDtos = searchService.getRecentSearches(page);
@@ -95,6 +134,14 @@ public class SearchController {
 	}
 
 	@ApiOperation(value = "최근 검색 기록 삭제")
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "SE005 - 최근 검색 기록 삭제에 성공하였습니다."),
+		@ApiResponse(code = 400, message = "G003 - 유효하지 않은 입력입니다.\n"
+			+ "G004 - 입력 타입이 유효하지 않습니다.\n"
+			+ "G009 - 올바르지 않은 entity type 입니다.\n"
+			+ "H004 - 해시태그는 #으로 시작해야 합니다."),
+		@ApiResponse(code = 401, message = "M003 - 로그인이 필요한 화면입니다.")
+	})
 	@ApiImplicitParams({
 		@ApiImplicitParam(name = "entityName", value = "삭제할 식별 name", required = true, example = "dlwlrma"),
 		@ApiImplicitParam(name = "entityType", value = "삭제할 type", required = true, example = "MEMBER")
@@ -108,6 +155,10 @@ public class SearchController {
 	}
 
 	@ApiOperation(value = "최근 검색 기록 모두 삭제")
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "SE006 - 최근 검색 기록 전체 삭제에 성공하였습니다."),
+		@ApiResponse(code = 401, message = "M003 - 로그인이 필요한 화면입니다.")
+	})
 	@DeleteMapping(value = "/recent/all")
 	public ResponseEntity<ResultResponse> deleteAllRecentSearch() {
 		searchService.deleteAllRecentSearch();

--- a/src/main/java/cloneproject/Instagram/domain/search/repository/querydsl/SearchRepositoryQuerydsl.java
+++ b/src/main/java/cloneproject/Instagram/domain/search/repository/querydsl/SearchRepositoryQuerydsl.java
@@ -10,15 +10,17 @@ import cloneproject.Instagram.domain.search.entity.Search;
 public interface SearchRepositoryQuerydsl {
 
 	List<Search> findHashtagsByTextLike(String text);
-
 	List<Search> findAllByTextLike(String text);
 
-	void checkMatchingMember(Long loginId, String text, List<Search> searches, List<Long> searchIds);
+	List<Long> findMemberIdsByTextLike(String text);
+	List<Long> findHashtagIdsByTextLike(String text);
 
+	void checkMatchingMember(String text, List<Search> searches, List<Long> searchIds);
 	void checkMatchingHashtag(String text, List<Search> searches, List<Long> searchIds);
+	void checkMatchingMember(String text, List<Long> memberIds);
+	void checkMatchingHashtag(String text, List<Long> hashtagIds);
 
 	Map<Long, SearchHashtagDto> findAllSearchHashtagDtoByIdIn(List<Long> searchIds);
-
 	Map<Long, SearchMemberDto> findAllSearchMemberDtoByIdIn(Long loginId, List<Long> ids);
 
 }

--- a/src/main/java/cloneproject/Instagram/domain/search/service/SearchService.java
+++ b/src/main/java/cloneproject/Instagram/domain/search/service/SearchService.java
@@ -14,8 +14,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.mysql.cj.x.protobuf.MysqlxCrud.Collection;
-
 import cloneproject.Instagram.domain.follow.dto.FollowDto;
 import cloneproject.Instagram.domain.follow.repository.FollowRepository;
 import cloneproject.Instagram.domain.hashtag.dto.HashtagDTO;

--- a/src/main/java/cloneproject/Instagram/domain/search/service/SearchService.java
+++ b/src/main/java/cloneproject/Instagram/domain/search/service/SearchService.java
@@ -100,7 +100,7 @@ public class SearchService {
 		}
 		final List<Long> hashtagIds = searchRepository.findHashtagIdsByTextLike(text.substring(1));
 
-		searchRepository.checkMatchingMember(text.substring(1), hashtagIds);
+		searchRepository.checkMatchingHashtag(text.substring(1), hashtagIds);
 		final List<Hashtag> hashtags = hashtagRepository.findAllByIdIn(hashtagIds);
 		return hashtags.stream()
 			.map(HashtagDTO::new)

--- a/src/main/java/cloneproject/Instagram/global/result/ResultCode.java
+++ b/src/main/java/cloneproject/Instagram/global/result/ResultCode.java
@@ -106,7 +106,9 @@ public enum ResultCode {
 	GET_TOP_15_RECENT_SEARCH_SUCCESS(200, "SE003", "최근 검색 기록 15개 조회 성공"),
 	GET_RECENT_SEARCH_SUCCESS(200, "SE004", "최근 검색 기록 페이지(무한스크롤) 조회 성공"),
 	DELETE_RECENT_SEARCH_SUCCESS(200, "SE005", "최근 검색 기록 삭제 성공"),
-	DELETE_ALL_RECENT_SEARCH_SUCCESS(200, "SE006", "최근 검색 기록 전체 삭제 성공");
+	DELETE_ALL_RECENT_SEARCH_SUCCESS(200, "SE006", "최근 검색 기록 전체 삭제 성공"),
+	GET_MEMBER_AUTO_COMPLETE_SUCCESS(200, "SE007", "멤버 자동완성 조회 성공"),
+	GET_HASHTAG_AUTO_COMPLETE_SUCCESS(200, "SE008", "해시태그 자동완성 조회 성공");
 
 	private int status;
 	private final String code;

--- a/src/main/java/cloneproject/Instagram/global/result/ResultCode.java
+++ b/src/main/java/cloneproject/Instagram/global/result/ResultCode.java
@@ -101,14 +101,14 @@ public enum ResultCode {
 	GET_STORY_SUCCESS(200, "S002", "스토리 조회 성공"),
 
 	// Search
-	SEARCH_SUCCESS(200, "SE001", "검색 성공"),
-	MARK_SEARCHED_ENTITY_SUCCESS(200, "SE002", "검색 조회수 증가, 최근검색기록 업데이트 성공"),
-	GET_TOP_15_RECENT_SEARCH_SUCCESS(200, "SE003", "최근 검색 기록 15개 조회 성공"),
-	GET_RECENT_SEARCH_SUCCESS(200, "SE004", "최근 검색 기록 페이지(무한스크롤) 조회 성공"),
-	DELETE_RECENT_SEARCH_SUCCESS(200, "SE005", "최근 검색 기록 삭제 성공"),
-	DELETE_ALL_RECENT_SEARCH_SUCCESS(200, "SE006", "최근 검색 기록 전체 삭제 성공"),
-	GET_MEMBER_AUTO_COMPLETE_SUCCESS(200, "SE007", "멤버 자동완성 조회 성공"),
-	GET_HASHTAG_AUTO_COMPLETE_SUCCESS(200, "SE008", "해시태그 자동완성 조회 성공");
+	SEARCH_SUCCESS(200, "SE001", "검색에 성공하였습니다."),
+	MARK_SEARCHED_ENTITY_SUCCESS(200, "SE002", "검색 조회수 증가, 최근검색기록 업데이트에 성공하였습니다."),
+	GET_TOP_15_RECENT_SEARCH_SUCCESS(200, "SE003", "최근 검색 기록 15개 조회에 성공하였습니다."),
+	GET_RECENT_SEARCH_SUCCESS(200, "SE004", "최근 검색 기록 페이지(무한스크롤) 조회에 성공하였습니다."),
+	DELETE_RECENT_SEARCH_SUCCESS(200, "SE005", "최근 검색 기록 삭제에 성공하였습니다."),
+	DELETE_ALL_RECENT_SEARCH_SUCCESS(200, "SE006", "최근 검색 기록 전체 삭제에 성공하였습니다."),
+	GET_MEMBER_AUTO_COMPLETE_SUCCESS(200, "SE007", "멤버 자동완성 조회에 성공하였습니다."),
+	GET_HASHTAG_AUTO_COMPLETE_SUCCESS(200, "SE008", "해시태그 자동완성 조회에 성공하였습니다.");
 
 	private int status;
 	private final String code;

--- a/src/main/java/cloneproject/Instagram/infra/kakao/KakaoMap.java
+++ b/src/main/java/cloneproject/Instagram/infra/kakao/KakaoMap.java
@@ -47,8 +47,8 @@ public class KakaoMap {
 		try {
 			final KakaoSearchResponse kakaoSearchResponse = objectMapper.readValue(result.getBody(),
 				KakaoSearchResponse.class);
-			return kakaoSearchResponse.getDocuments()[0].getRoadAddress().getRegion1DepthName() + " "
-				+ kakaoSearchResponse.getDocuments()[0].getRoadAddress().getRegion2DepthName();
+			return kakaoSearchResponse.getDocuments()[0].getAddress().getRegion1DepthName() + " "
+				+ kakaoSearchResponse.getDocuments()[0].getAddress().getRegion2DepthName();
 		} catch (IOException e) {
 			throw new KakaoMapApiFailException();
 		} catch (NullPointerException e) {

--- a/src/main/java/cloneproject/Instagram/infra/kakao/dto/KakaoSearchResponse.java
+++ b/src/main/java/cloneproject/Instagram/infra/kakao/dto/KakaoSearchResponse.java
@@ -2,8 +2,6 @@ package cloneproject.Instagram.infra.kakao.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -21,13 +19,13 @@ public class KakaoSearchResponse {
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Document {
         
-        @JsonProperty("road_address")
-        private RoadAddress roadAddress;
+        @JsonProperty("address")
+        private Address address;
 
         @Getter
         @NoArgsConstructor(access = AccessLevel.PROTECTED)
         @JsonIgnoreProperties(ignoreUnknown = true)
-        public static class RoadAddress {
+        public static class Address {
             @JsonProperty("region_1depth_name")
             private String region1DepthName;
             @JsonProperty("region_2depth_name")


### PR DESCRIPTION
<!--
✅ Resolve: #이슈번호 형태로 입력해 주세요.
ex) Resolve: #123
-->
## 📌Linked Issues
- 

<!--
✅ 변경 사항을 자세히 알려주세요. (why -> what -> how)
-->
## ✏Change Details
### 검색 API 자동 완성 추가
> 기존엔 태그 자동완성시 검색 API를 이용. -> 그러나 검색 API는 자동완성 시 불필요한 정보(팔로우, 팔로잉 등)까지 반환함. -> 쿼리 최적화를 위해 필요한 정보만 반환하는 자동완성 API를 추가하기로 결정
- 해시태그 자동완성, 멤버 자동완성 API를 추가하였습니다.
### 검색 쿼리 로직 수정
- 기존에 in caluse를 이용하던 쿼리를 최적화
  - 해시태그, 멤버를 모두 검색하는 경우는 `in`을 사용해야 하지만, 단일 엔티티 조회 시에는 불필요하기 때문에 쿼리 개선
-  완전히 일치하는 검색어 처리 시 잘못된 로직 수정
  - 기존엔 현재 검색 사이즈와 관계 없이 항상 list의 마지막 원소를 삭제 -> 검색이 MAX사이즈를 넘을 때만 삭제하도록 수정
  - 해당 코드는 중복적으로 사용되기 때문에 메서드로 추출
### 검색 도메인에 ApiResponse 추가
- ApiResponse 추가
- 관련 ResultCode 메시지 수정
### 카카오 맵 API 개선
- 기존엔 **도로명주소**를 이용하는 형식이었으나, 카카오 맵 API에서 도로명주소보단 **구 주소** 반환이 잘 작동함을 확인하였습니다.
- 따라서, 도로명주소대신 구 주소를 이용하여 로그인 기록을 남기도록 수정
> 현재 로컬에서 테스트 시 정상적으로 출력됩니다. 서버에서 좀 더 많은 IP로 테스트가 필요할 것 같습니다.
<!--
✅ 추가로 전달할 내용이 있다면 적어주세요.
-->
## 💬Comment
-

<!--
✅ 참고한 사이트가 있다면 공유해주세요.
-->
## 📑References
- 

## ✅Check List
- [x] 추가한 기능에 대한 테스트는 모두 완료하셨나요?
- [x] 코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?
