### PR TITLE
해시태그 도메인 컨벤션 적용

### DIFF
--- a/src/main/java/cloneproject/Instagram/domain/hashtag/controller/HashtagController.java
+++ b/src/main/java/cloneproject/Instagram/domain/hashtag/controller/HashtagController.java
@@ -5,6 +5,8 @@ import cloneproject.Instagram.global.result.ResultResponse;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.ResponseEntity;
@@ -27,6 +29,17 @@ public class HashtagController {
 	private final HashtagService hashtagService;
 
 	@ApiOperation(value = "해시태그 팔로우")
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "H002 - 해시태그 팔로우에 성공하였습니다."),
+		@ApiResponse(code = 400, message = "G003 - 유효하지 않은 입력입니다.\n"
+			+ "G004 - 입력 타입이 유효하지 않습니다.\n"
+			+ "G007 - 지원하지 않는 이미지 타입입니다.\n"
+			+ "G008 - 변환할 수 없는 파일입니다.\n"
+			+ "H001 - 존재하지 않는 해시태그 입니다.\n"
+			+ "H002 - 해시태그 팔로우에 실패했습니다.\n"
+			+ "H004 - 해시태그는 #으로 시작해야 합니다."),
+		@ApiResponse(code = 401, message = "M003 - 로그인이 필요한 화면입니다.")
+	})
 	@ApiImplicitParam(name = "hashtag", value = "hashtag", example = "#만두", required = true)
 	@PostMapping("/hashtags/follow")
 	public ResponseEntity<ResultResponse> followHashtag(
@@ -37,6 +50,17 @@ public class HashtagController {
 	}
 
 	@ApiOperation(value = "해시태그 언팔로우")
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "H003 - 해시태그 언팔로우에 성공하였습니다."),
+		@ApiResponse(code = 400, message = "G003 - 유효하지 않은 입력입니다.\n"
+			+ "G004 - 입력 타입이 유효하지 않습니다.\n"
+			+ "G007 - 지원하지 않는 이미지 타입입니다.\n"
+			+ "G008 - 변환할 수 없는 파일입니다.\n"
+			+ "H001 - 존재하지 않는 해시태그 입니다.\n"
+			+ "H003 - 해시태그 언팔로우에 실패했습니다.\n"
+			+ "H004 - 해시태그는 #으로 시작해야 합니다."),
+		@ApiResponse(code = 401, message = "M003 - 로그인이 필요한 화면입니다.")
+	})
 	@ApiImplicitParam(name = "hashtag", value = "hashtag", example = "#만두", required = true)
 	@DeleteMapping("/hashtags/follow")
 	public ResponseEntity<ResultResponse> unfollowHashtag(

--- a/src/main/java/cloneproject/Instagram/domain/hashtag/controller/HashtagController.java
+++ b/src/main/java/cloneproject/Instagram/domain/hashtag/controller/HashtagController.java
@@ -1,13 +1,6 @@
 package cloneproject.Instagram.domain.hashtag.controller;
 
-import cloneproject.Instagram.domain.hashtag.service.HashtagService;
-import cloneproject.Instagram.global.result.ResultResponse;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiImplicitParam;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
-import lombok.RequiredArgsConstructor;
+import javax.validation.constraints.NotBlank;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -16,9 +9,18 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import static cloneproject.Instagram.global.result.ResultCode.*;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import lombok.RequiredArgsConstructor;
 
-import javax.validation.constraints.NotBlank;
+import cloneproject.Instagram.domain.hashtag.service.HashtagService;
+import cloneproject.Instagram.global.result.ResultResponse;
+
+import static cloneproject.Instagram.global.result.ResultCode.FOLLOW_HASHTAG_SUCCESS;
+import static cloneproject.Instagram.global.result.ResultCode.UNFOLLOW_HASHTAG_SUCCESS;
 
 @Api(tags = "해시태그 API")
 @Validated

--- a/src/main/java/cloneproject/Instagram/domain/hashtag/dto/HashtagDTO.java
+++ b/src/main/java/cloneproject/Instagram/domain/hashtag/dto/HashtagDTO.java
@@ -2,8 +2,9 @@ package cloneproject.Instagram.domain.hashtag.dto;
 
 import com.querydsl.core.annotations.QueryProjection;
 
-import cloneproject.Instagram.domain.hashtag.entity.Hashtag;
 import lombok.Getter;
+
+import cloneproject.Instagram.domain.hashtag.entity.Hashtag;
 
 @Getter
 public class HashtagDto {

--- a/src/main/java/cloneproject/Instagram/domain/hashtag/dto/HashtagDTO.java
+++ b/src/main/java/cloneproject/Instagram/domain/hashtag/dto/HashtagDTO.java
@@ -18,4 +18,5 @@ public class HashtagDTO {
         this.name = hashtag.getName();
         this.count = hashtag.getCount();
     }
+
 }

--- a/src/main/java/cloneproject/Instagram/domain/hashtag/dto/HashtagDTO.java
+++ b/src/main/java/cloneproject/Instagram/domain/hashtag/dto/HashtagDTO.java
@@ -4,17 +4,15 @@ import com.querydsl.core.annotations.QueryProjection;
 
 import cloneproject.Instagram.domain.hashtag.entity.Hashtag;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
-public class HashtagDTO {
+public class HashtagDto {
 
     private String name;
     private Integer count;
 
     @QueryProjection
-    public HashtagDTO(Hashtag hashtag) {
+    public HashtagDto(Hashtag hashtag) {
         this.name = hashtag.getName();
         this.count = hashtag.getCount();
     }

--- a/src/main/java/cloneproject/Instagram/domain/hashtag/entity/Hashtag.java
+++ b/src/main/java/cloneproject/Instagram/domain/hashtag/entity/Hashtag.java
@@ -41,4 +41,5 @@ public class Hashtag {
     public void downCount(int count) {
         this.count -= count;
     }
+
 }

--- a/src/main/java/cloneproject/Instagram/domain/hashtag/entity/Hashtag.java
+++ b/src/main/java/cloneproject/Instagram/domain/hashtag/entity/Hashtag.java
@@ -1,11 +1,16 @@
 package cloneproject.Instagram.domain.hashtag.entity;
 
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import javax.persistence.*;
 
 @Getter
 @Entity

--- a/src/main/java/cloneproject/Instagram/domain/hashtag/entity/HashtagPost.java
+++ b/src/main/java/cloneproject/Instagram/domain/hashtag/entity/HashtagPost.java
@@ -32,4 +32,5 @@ public class HashtagPost {
         this.hashtag = hashtag;
         this.post = post;
     }
+
 }

--- a/src/main/java/cloneproject/Instagram/domain/hashtag/entity/HashtagPost.java
+++ b/src/main/java/cloneproject/Instagram/domain/hashtag/entity/HashtagPost.java
@@ -1,13 +1,20 @@
 package cloneproject.Instagram.domain.hashtag.entity;
 
-import cloneproject.Instagram.domain.feed.entity.Post;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.*;
-
-import cloneproject.Instagram.domain.hashtag.entity.Hashtag;
+import cloneproject.Instagram.domain.feed.entity.Post;
 
 @Getter
 @Entity

--- a/src/main/java/cloneproject/Instagram/domain/hashtag/exception/HashtagNotFoundException.java
+++ b/src/main/java/cloneproject/Instagram/domain/hashtag/exception/HashtagNotFoundException.java
@@ -3,8 +3,10 @@ package cloneproject.Instagram.domain.hashtag.exception;
 import cloneproject.Instagram.global.error.ErrorCode;
 import cloneproject.Instagram.global.error.exception.BusinessException;
 
-public class HashtagNotFoundException extends BusinessException{
-    public HashtagNotFoundException(){
+public class HashtagNotFoundException extends BusinessException {
+
+    public HashtagNotFoundException() {
         super(ErrorCode.HASHTAG_NOT_FOUND);
     }
+
 }

--- a/src/main/java/cloneproject/Instagram/domain/hashtag/repository/HashtagPostRepository.java
+++ b/src/main/java/cloneproject/Instagram/domain/hashtag/repository/HashtagPostRepository.java
@@ -13,11 +13,12 @@ import java.util.List;
 
 public interface HashtagPostRepository extends JpaRepository<HashtagPost, Long>, HashtagPostRepositoryJdbc {
 
-    List<HashtagPost> findAllByPost(Post post);
+	List<HashtagPost> findAllByPost(Post post);
 
 	List<HashtagPost> findByHashtagAndPost(Hashtag hashtag, Post post);
 
 	List<HashtagPost> findAllByPostAndHashtagIn(Post post, List<Hashtag> hashtags);
 
 	Page<HashtagPost> findAllByHashtagOrderByPostIdDesc(Pageable pageable, Hashtag hashtag);
+
 }

--- a/src/main/java/cloneproject/Instagram/domain/hashtag/repository/HashtagPostRepository.java
+++ b/src/main/java/cloneproject/Instagram/domain/hashtag/repository/HashtagPostRepository.java
@@ -1,15 +1,15 @@
 package cloneproject.Instagram.domain.hashtag.repository;
 
-import cloneproject.Instagram.domain.feed.entity.Post;
-import cloneproject.Instagram.domain.hashtag.entity.Hashtag;
-import cloneproject.Instagram.domain.hashtag.entity.HashtagPost;
-import cloneproject.Instagram.domain.hashtag.repository.jdbc.HashtagPostRepositoryJdbc;
+import java.util.List;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
+import cloneproject.Instagram.domain.feed.entity.Post;
+import cloneproject.Instagram.domain.hashtag.entity.Hashtag;
+import cloneproject.Instagram.domain.hashtag.entity.HashtagPost;
+import cloneproject.Instagram.domain.hashtag.repository.jdbc.HashtagPostRepositoryJdbc;
 
 public interface HashtagPostRepository extends JpaRepository<HashtagPost, Long>, HashtagPostRepositoryJdbc {
 

--- a/src/main/java/cloneproject/Instagram/domain/hashtag/repository/HashtagRepository.java
+++ b/src/main/java/cloneproject/Instagram/domain/hashtag/repository/HashtagRepository.java
@@ -1,13 +1,13 @@
 package cloneproject.Instagram.domain.hashtag.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-
-import cloneproject.Instagram.domain.hashtag.entity.Hashtag;
-
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import cloneproject.Instagram.domain.hashtag.entity.Hashtag;
 
 public interface HashtagRepository extends JpaRepository<Hashtag, Long> {
 

--- a/src/main/java/cloneproject/Instagram/domain/hashtag/repository/jdbc/HashtagPostRepositoryJdbc.java
+++ b/src/main/java/cloneproject/Instagram/domain/hashtag/repository/jdbc/HashtagPostRepositoryJdbc.java
@@ -7,4 +7,5 @@ import cloneproject.Instagram.domain.hashtag.entity.HashtagPost;
 public interface HashtagPostRepositoryJdbc {
 
     void saveAllBatch(List<HashtagPost> newHashtagPost);
+
 }

--- a/src/main/java/cloneproject/Instagram/domain/hashtag/repository/jdbc/HashtagPostRepositoryJdbcImpl.java
+++ b/src/main/java/cloneproject/Instagram/domain/hashtag/repository/jdbc/HashtagPostRepositoryJdbcImpl.java
@@ -1,14 +1,15 @@
 package cloneproject.Instagram.domain.hashtag.repository.jdbc;
 
-import lombok.RequiredArgsConstructor;
-import org.springframework.jdbc.core.BatchPreparedStatementSetter;
-import org.springframework.jdbc.core.JdbcTemplate;
-
-import cloneproject.Instagram.domain.hashtag.entity.HashtagPost;
-
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.List;
+
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import lombok.RequiredArgsConstructor;
+
+import cloneproject.Instagram.domain.hashtag.entity.HashtagPost;
 
 @RequiredArgsConstructor
 public class HashtagPostRepositoryJdbcImpl implements HashtagPostRepositoryJdbc {

--- a/src/main/java/cloneproject/Instagram/domain/hashtag/repository/jdbc/HashtagPostRepositoryJdbcImpl.java
+++ b/src/main/java/cloneproject/Instagram/domain/hashtag/repository/jdbc/HashtagPostRepositoryJdbcImpl.java
@@ -17,24 +17,23 @@ public class HashtagPostRepositoryJdbcImpl implements HashtagPostRepositoryJdbc 
 
     @Override
     public void saveAllBatch(List<HashtagPost> newHashtagPost) {
-        final String sql =
-                "INSERT INTO hashtag_posts (`hashtag_id`, `post_id`) " +
-                        "VALUES(?, ?)";
+        final String sql = "INSERT INTO hashtag_posts (`hashtag_id`, `post_id`) " +
+            "VALUES(?, ?)";
 
         jdbcTemplate.batchUpdate(
-                sql,
-                new BatchPreparedStatementSetter() {
-                    @Override
-                    public void setValues(PreparedStatement ps, int i) throws SQLException {
-                        ps.setString(1, newHashtagPost.get(i).getHashtag().getId().toString());
-                        ps.setString(2, newHashtagPost.get(i).getPost().getId().toString());
-                    }
-
-                    @Override
-                    public int getBatchSize() {
-                        return newHashtagPost.size();
-                    }
+            sql,
+            new BatchPreparedStatementSetter() {
+                @Override
+                public void setValues(PreparedStatement ps, int i) throws SQLException {
+                    ps.setString(1, newHashtagPost.get(i).getHashtag().getId().toString());
+                    ps.setString(2, newHashtagPost.get(i).getPost().getId().toString());
                 }
-        );
+
+                @Override
+                public int getBatchSize() {
+                    return newHashtagPost.size();
+                }
+            });
     }
+
 }

--- a/src/main/java/cloneproject/Instagram/domain/hashtag/service/HashtagService.java
+++ b/src/main/java/cloneproject/Instagram/domain/hashtag/service/HashtagService.java
@@ -1,9 +1,21 @@
 package cloneproject.Instagram.domain.hashtag.service;
 
-import static cloneproject.Instagram.global.error.ErrorCode.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
 
 import cloneproject.Instagram.domain.feed.entity.Comment;
 import cloneproject.Instagram.domain.feed.entity.Post;
+import cloneproject.Instagram.domain.follow.entity.HashtagFollow;
 import cloneproject.Instagram.domain.follow.exception.HashtagFollowFailException;
 import cloneproject.Instagram.domain.follow.exception.HashtagUnfollowFailException;
 import cloneproject.Instagram.domain.follow.repository.HashtagFollowRepository;
@@ -12,19 +24,13 @@ import cloneproject.Instagram.domain.hashtag.entity.HashtagPost;
 import cloneproject.Instagram.domain.hashtag.exception.HashtagPrefixMismatchException;
 import cloneproject.Instagram.domain.hashtag.repository.HashtagPostRepository;
 import cloneproject.Instagram.domain.hashtag.repository.HashtagRepository;
-import cloneproject.Instagram.domain.follow.entity.HashtagFollow;
 import cloneproject.Instagram.domain.member.entity.Member;
 import cloneproject.Instagram.domain.search.service.SearchService;
 import cloneproject.Instagram.global.error.exception.EntityNotFoundException;
 import cloneproject.Instagram.global.util.AuthUtil;
 import cloneproject.Instagram.global.util.StringExtractUtil;
-import lombok.RequiredArgsConstructor;
 
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.*;
-import java.util.stream.Collectors;
+import static cloneproject.Instagram.global.error.ErrorCode.HASHTAG_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/cloneproject/Instagram/domain/hashtag/service/HashtagService.java
+++ b/src/main/java/cloneproject/Instagram/domain/hashtag/service/HashtagService.java
@@ -59,9 +59,9 @@ public class HashtagService {
 		final Member loginMember = authUtil.getLoginMember();
 		final Hashtag hashtag = getHashtag(hashtagName);
 
-		final HashtagFollow hashtagFollow =
-			hashtagFollowRepository.findByMemberIdAndHashtagId(loginMember.getId(), hashtag.getId())
-				.orElseThrow(HashtagUnfollowFailException::new);
+		final HashtagFollow hashtagFollow = hashtagFollowRepository
+			.findByMemberIdAndHashtagId(loginMember.getId(), hashtag.getId())
+			.orElseThrow(HashtagUnfollowFailException::new);
 
 		hashtagFollowRepository.delete(hashtagFollow);
 	}
@@ -165,4 +165,5 @@ public class HashtagService {
 		return hashtagRepository.findByName(hashtagName.substring(1))
 			.orElseThrow(() -> new EntityNotFoundException(HASHTAG_NOT_FOUND));
 	}
+
 }

--- a/src/main/java/cloneproject/Instagram/domain/hashtag/service/HashtagService.java
+++ b/src/main/java/cloneproject/Instagram/domain/hashtag/service/HashtagService.java
@@ -9,6 +9,7 @@ import cloneproject.Instagram.domain.follow.exception.HashtagUnfollowFailExcepti
 import cloneproject.Instagram.domain.follow.repository.HashtagFollowRepository;
 import cloneproject.Instagram.domain.hashtag.entity.Hashtag;
 import cloneproject.Instagram.domain.hashtag.entity.HashtagPost;
+import cloneproject.Instagram.domain.hashtag.exception.HashtagPrefixMismatchException;
 import cloneproject.Instagram.domain.hashtag.repository.HashtagPostRepository;
 import cloneproject.Instagram.domain.hashtag.repository.HashtagRepository;
 import cloneproject.Instagram.domain.follow.entity.HashtagFollow;
@@ -162,6 +163,9 @@ public class HashtagService {
 	}
 
 	private Hashtag getHashtag(String hashtagName) {
+		if (!hashtagName.startsWith("#")) {
+			throw new HashtagPrefixMismatchException();
+		}
 		return hashtagRepository.findByName(hashtagName.substring(1))
 			.orElseThrow(() -> new EntityNotFoundException(HASHTAG_NOT_FOUND));
 	}

--- a/src/main/java/cloneproject/Instagram/domain/search/controller/SearchController.java
+++ b/src/main/java/cloneproject/Instagram/domain/search/controller/SearchController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import cloneproject.Instagram.domain.hashtag.dto.HashtagDTO;
+import cloneproject.Instagram.domain.hashtag.dto.HashtagDto;
 import cloneproject.Instagram.domain.member.dto.MemberDto;
 import cloneproject.Instagram.domain.search.dto.SearchDto;
 import cloneproject.Instagram.domain.search.service.SearchService;
@@ -81,7 +81,7 @@ public class SearchController {
 	@ApiImplicitParam(name = "text", value = "검색내용", required = true, example = "#dlwl")
 	@GetMapping("/auto/hashtag")
 	public ResponseEntity<ResultResponse> getHashtagAutoComplete(@RequestParam String text) {
-		final List<HashtagDTO> searchDtos = searchService.getHashtagAutoComplete(text);
+		final List<HashtagDto> searchDtos = searchService.getHashtagAutoComplete(text);
 
 		return ResponseEntity.ok(ResultResponse.of(GET_HASHTAG_AUTO_COMPLETE_SUCCESS, searchDtos));
 	}

--- a/src/main/java/cloneproject/Instagram/domain/search/service/SearchService.java
+++ b/src/main/java/cloneproject/Instagram/domain/search/service/SearchService.java
@@ -16,7 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import cloneproject.Instagram.domain.follow.dto.FollowDto;
 import cloneproject.Instagram.domain.follow.repository.FollowRepository;
-import cloneproject.Instagram.domain.hashtag.dto.HashtagDTO;
+import cloneproject.Instagram.domain.hashtag.dto.HashtagDto;
 import cloneproject.Instagram.domain.hashtag.entity.Hashtag;
 import cloneproject.Instagram.domain.hashtag.exception.HashtagNotFoundException;
 import cloneproject.Instagram.domain.hashtag.exception.HashtagPrefixMismatchException;
@@ -93,7 +93,7 @@ public class SearchService {
 			.collect(Collectors.toList());
 	}
 
-	public List<HashtagDTO> getHashtagAutoComplete(String text) {
+	public List<HashtagDto> getHashtagAutoComplete(String text) {
 		text = text.trim();
 		if (!text.startsWith("#")) {
 			throw new HashtagPrefixMismatchException();
@@ -103,7 +103,7 @@ public class SearchService {
 		searchRepository.checkMatchingHashtag(text.substring(1), hashtagIds);
 		final List<Hashtag> hashtags = hashtagRepository.findAllByIdIn(hashtagIds);
 		return hashtags.stream()
-			.map(HashtagDTO::new)
+			.map(HashtagDto::new)
 			.collect(Collectors.toList());
 	}
 

--- a/src/main/java/cloneproject/Instagram/global/error/ErrorCode.java
+++ b/src/main/java/cloneproject/Instagram/global/error/ErrorCode.java
@@ -84,10 +84,10 @@ public enum ErrorCode {
 	CANT_SEND_EMAIL(500, "E001", "이메일 전송 중 오류가 발생했습니다."),
 
 	// HashTag
-	HASHTAG_NOT_FOUND(400, "H001", "존재하지 않는 해시태그 입니다"),
-	HASHTAG_FOLLOW_FAIL(400, "H002", "해시태그 팔로우 실패"),
-	HASHTAG_UNFOLLOW_FAIL(400, "H003", "해시태그 언팔로우 실패"),
-	HASHTAG_PREFIX_MISMATCH(400, "H004", "해시태그는 #으로 시작해야 합니다"),
+	HASHTAG_NOT_FOUND(400, "H001", "존재하지 않는 해시태그 입니다."),
+	HASHTAG_FOLLOW_FAIL(400, "H002", "해시태그 팔로우에 실패했습니다."),
+	HASHTAG_UNFOLLOW_FAIL(400, "H003", "해시태그 언팔로우에 실패했습니다."),
+	HASHTAG_PREFIX_MISMATCH(400, "H004", "해시태그는 #으로 시작해야 합니다."),
 
 	// Story
 	INVALID_STORY_IMAGE(400, "S001", "스토리 이미지는 필수입니다."),

--- a/src/main/java/cloneproject/Instagram/global/result/ResultCode.java
+++ b/src/main/java/cloneproject/Instagram/global/result/ResultCode.java
@@ -92,9 +92,9 @@ public enum ResultCode {
 	SEND_IMAGE_SUCCESS(200, "C006", "이미지 전송 성공"),
 
 	// Hashtag
-	GET_HASHTAGS_SUCCESS(200, "H001", "해시태그 목록 페이징 조회 성공"),
-	FOLLOW_HASHTAG_SUCCESS(200, "H002", "해시태그 팔로우 성공"),
-	UNFOLLOW_HASHTAG_SUCCESS(200, "H003", "해시태그 언팔로우 성공"),
+	GET_HASHTAGS_SUCCESS(200, "H001", "해시태그 목록 페이징 조회에 성공하였습니다."),
+	FOLLOW_HASHTAG_SUCCESS(200, "H002", "해시태그 팔로우에 성공하였습니다."),
+	UNFOLLOW_HASHTAG_SUCCESS(200, "H003", "해시태그 언팔로우에 성공하였습니다."),
 
 	// Story
 	CREATE_STORY_SUCCESS(200, "S001", "스토리 업로드 성공"),


### PR DESCRIPTION
<!--
✅ Resolve: #이슈번호 형태로 입력해 주세요.
ex) Resolve: #123
-->
## 📌Linked Issues
- 

<!--
✅ 변경 사항을 자세히 알려주세요. (why -> what -> how)
-->
## ✏Change Details
### 해시태그 리팩토링
 - 해시태그 컨트롤러에 Swagger ApiResonse 적용
 - 일부 Error, Result 메시지 수정
 - Api호출 시 해시태그가 #으로 시작하지 않으면 에러를 반환하도록 수정 
### 컨벤션 적용
- 해시태그 도메인에 빈줄 컨벤션 적용
- Dto 명명 컨벤션 적용
- 해시태그 도메인 import order 정렬
<!--
✅ 추가로 전달할 내용이 있다면 적어주세요.
-->
## 💬Comment
- @seonpilKim 현재 코드 확인해본 결과 import order관련 컨벤션이 전체적으로 지켜지지 않고 있는 것 같습니다. 코드 정렬 시 import 정렬은 따로 키가 있어서 정렬 시 함께 적용이 안되는 것 같습니다.
- 다음 PR로 전체 코드 import order에 컨벤션을 적용하려하는데, 현재 선필님이 작업 중이신 도메인이 feed만 있나요? 머지 컨플릭트 때문에 현재 작업 중이신 도메인 제외한 코드에 import 정렬을 하려고합니다. 작업 중이신 도메인만 직접 해주시면 됩니다. feed 외 추가 작업중인 도메인 있으시면 댓글로 남겨주세요 !

<!--
✅ 참고한 사이트가 있다면 공유해주세요.
-->
## 📑References
- 

## ✅Check List
- [x] 추가한 기능에 대한 테스트는 모두 완료하셨나요?
- [x] 코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?
