### PR TITLE
로그인 없이 호출하는 API 추가

### DIFF
--- a/src/main/java/cloneproject/Instagram/domain/member/controller/MemberAuthController.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/controller/MemberAuthController.java
@@ -173,7 +173,6 @@ public class MemberAuthController {
 		return ResponseEntity.ok(ResultResponse.of(SEND_RESET_PASSWORD_EMAIL_SUCCESS, email));
 	}
 
-	// TODO filter로 옮길 방법?
 	@ApiOperation(value = "코드를 통한 비밀번호 재설정")
 	@ApiResponses({
 		@ApiResponse(code = 200, message = "M018 - 비밀번호 재설정에 성공했습니다."),

--- a/src/main/java/cloneproject/Instagram/domain/member/controller/MemberController.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/controller/MemberController.java
@@ -66,7 +66,7 @@ public class MemberController {
 	@ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma")
 	@GetMapping(value = "/{username}")
 	public ResponseEntity<ResultResponse> getUserProfile(@PathVariable("username") String username) {
-		final UserProfileResponse userProfileResponse = memberService.getUserProfileWithLogin(username);
+		final UserProfileResponse userProfileResponse = memberService.getUserProfile(username);
 
 		return ResponseEntity.ok(ResultResponse.of(GET_USERPROFILE_SUCCESS, userProfileResponse));
 	}

--- a/src/main/java/cloneproject/Instagram/domain/member/controller/MemberController.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/controller/MemberController.java
@@ -32,7 +32,6 @@ import cloneproject.Instagram.domain.member.dto.MiniProfileResponse;
 import cloneproject.Instagram.domain.member.dto.UserProfileResponse;
 import cloneproject.Instagram.domain.member.service.MemberService;
 import cloneproject.Instagram.global.result.ResultResponse;
-import cloneproject.Instagram.infra.kakao.KakaoMap;
 
 @Slf4j
 @Validated
@@ -42,7 +41,6 @@ import cloneproject.Instagram.infra.kakao.KakaoMap;
 @RequestMapping("/accounts")
 public class MemberController {
 
-	private final KakaoMap kakaoMap;
 	private final MemberService memberService;
 
 	@ApiOperation(value = "상단 메뉴 로그인한 유저 프로필 조회")
@@ -68,7 +66,22 @@ public class MemberController {
 	@ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma")
 	@GetMapping(value = "/{username}")
 	public ResponseEntity<ResultResponse> getUserProfile(@PathVariable("username") String username) {
-		final UserProfileResponse userProfileResponse = memberService.getUserProfile(username);
+		final UserProfileResponse userProfileResponse = memberService.getUserProfileWithLogin(username);
+
+		return ResponseEntity.ok(ResultResponse.of(GET_USERPROFILE_SUCCESS, userProfileResponse));
+	}
+
+	@ApiOperation(value = "로그인 없이 유저 프로필 조회")
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "M004 - 회원 프로필을 조회하였습니다."),
+		@ApiResponse(code = 400, message = "G003 - 유효하지 않은 입력입니다.\n"
+			+ "G004 - 입력 타입이 유효하지 않습니다.\n"
+			+ "M001 - 존재 하지 않는 유저입니다.")
+	})
+	@ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma")
+	@GetMapping(value = "/{username}/without")
+	public ResponseEntity<ResultResponse> getUserProfileWithoutLogin(@PathVariable("username") String username) {
+		final UserProfileResponse userProfileResponse = memberService.getUserProfileWithoutLogin(username);
 
 		return ResponseEntity.ok(ResultResponse.of(GET_USERPROFILE_SUCCESS, userProfileResponse));
 	}

--- a/src/main/java/cloneproject/Instagram/domain/member/controller/MemberPostController.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/controller/MemberPostController.java
@@ -66,7 +66,7 @@ public class MemberPostController {
 	@GetMapping("/{username}/posts")
 	public ResponseEntity<ResultResponse> getPostPage(@PathVariable("username") String username,
 		@Min(1) @RequestParam int page) {
-		final Page<MemberPostDto> postPage = memberPostService.getMemberPostDtos(username, 3, page);
+		final Page<MemberPostDto> postPage = memberPostService.getMemberPostDtoPage(username, 3, page);
 
 		return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_MEMBER_POSTS_SUCCESS, postPage));
 	}
@@ -100,7 +100,7 @@ public class MemberPostController {
 	@GetMapping("/{username}/posts/without")
 	public ResponseEntity<ResultResponse> getPostPageWithoutLogin(@PathVariable("username") String username,
 		@Min(1) @RequestParam int page) {
-		final Page<MemberPostDto> postPage = memberPostService.getMemberPostDtosWithoutLogin(username, 3, page);
+		final Page<MemberPostDto> postPage = memberPostService.getMemberPostDtoPageWithoutLogin(username, 3, page);
 
 		return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_MEMBER_POSTS_SUCCESS, postPage));
 	}
@@ -130,7 +130,7 @@ public class MemberPostController {
 	@GetMapping("/posts/saved")
 	@ApiImplicitParam(name = "page", value = "페이지", required = true, example = "1")
 	public ResponseEntity<ResultResponse> getSavedPostPage(@Min(1) @RequestParam int page) {
-		final Page<MemberPostDto> postPage = memberPostService.getMemberSavedPostDtos(3, page);
+		final Page<MemberPostDto> postPage = memberPostService.getMemberSavedPostPage(3, page);
 
 		return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_MEMBER_SAVED_POSTS_SUCCESS, postPage));
 	}
@@ -167,7 +167,7 @@ public class MemberPostController {
 	@GetMapping("/{username}/posts/tagged")
 	public ResponseEntity<ResultResponse> getTaggedPostPage(@PathVariable("username") String username,
 		@Min(1) @RequestParam int page) {
-		final Page<MemberPostDto> postPage = memberPostService.getMemberTaggedPostDtos(username, 3, page);
+		final Page<MemberPostDto> postPage = memberPostService.getMemberTaggedPostDtoPage(username, 3, page);
 
 		return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_MEMBER_TAGGED_POSTS_SUCCESS, postPage));
 	}

--- a/src/main/java/cloneproject/Instagram/domain/member/controller/MemberPostController.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/controller/MemberPostController.java
@@ -45,7 +45,7 @@ public class MemberPostController {
 	})
 	@ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma")
 	@GetMapping("/{username}/posts/recent")
-	public ResponseEntity<ResultResponse> getRecent10Posts(@PathVariable("username") String username) {
+	public ResponseEntity<ResultResponse> getRecent15Posts(@PathVariable("username") String username) {
 		final List<MemberPostDto> postList = memberPostService.getRecent15PostDtos(username);
 
 		return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_RECENT15_MEMBER_POSTS_SUCCESS, postList));
@@ -67,6 +67,40 @@ public class MemberPostController {
 	public ResponseEntity<ResultResponse> getPostPage(@PathVariable("username") String username,
 		@Min(1) @RequestParam int page) {
 		final Page<MemberPostDto> postPage = memberPostService.getMemberPostDtos(username, 3, page);
+
+		return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_MEMBER_POSTS_SUCCESS, postPage));
+	}
+
+	@ApiOperation(value = "로그인 없이 멤버 게시물 15개 조회")
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "MP001 - 회원의 최근 게시물 15개 조회에 성공하였습니다."),
+		@ApiResponse(code = 400, message = "G003 - 유효하지 않은 입력입니다.\n"
+			+ "G004 - 입력 타입이 유효하지 않습니다.\n"
+			+ "M001 - 존재 하지 않는 유저입니다.")
+	})
+	@ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma")
+	@GetMapping("/{username}/posts/recent/without")
+	public ResponseEntity<ResultResponse> getRecent15PostsWithoutLogin(@PathVariable("username") String username) {
+		final List<MemberPostDto> postList = memberPostService.getRecent15PostDtosWithoutLogin(username);
+
+		return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_RECENT15_MEMBER_POSTS_SUCCESS, postList));
+	}
+
+	@ApiOperation(value = "로그인 없이 멤버 게시물 페이징 조회(무한스크롤)")
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "MP002 - 회원의 게시물 조회에 성공하였습니다."),
+		@ApiResponse(code = 400, message = "G003 - 유효하지 않은 입력입니다.\n"
+			+ "G004 - 입력 타입이 유효하지 않습니다.\n"
+			+ "M001 - 존재 하지 않는 유저입니다.")
+	})
+	@ApiImplicitParams({
+		@ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma"),
+		@ApiImplicitParam(name = "page", value = "페이지", required = true, example = "1")
+	})
+	@GetMapping("/{username}/posts/without")
+	public ResponseEntity<ResultResponse> getPostPageWithoutLogin(@PathVariable("username") String username,
+		@Min(1) @RequestParam int page) {
+		final Page<MemberPostDto> postPage = memberPostService.getMemberPostDtosWithoutLogin(username, 3, page);
 
 		return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_MEMBER_POSTS_SUCCESS, postPage));
 	}

--- a/src/main/java/cloneproject/Instagram/domain/member/repository/querydsl/MemberPostRepositoryQuerydsl.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/repository/querydsl/MemberPostRepositoryQuerydsl.java
@@ -4,15 +4,14 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import cloneproject.Instagram.domain.feed.dto.MemberPostDto;
-import cloneproject.Instagram.domain.member.entity.Member;
 
 public interface MemberPostRepositoryQuerydsl {
 
 
 	Page<MemberPostDto> findMemberPostDtos(Long loginMemberId, String username, Pageable pageable);
 
-	Page<MemberPostDto> findMemberSavedPostDtos(Long loginMemberId, Pageable pageable);
+	Page<MemberPostDto> findMemberSavedPostDtoPage(Long loginMemberId, Pageable pageable);
 
-	Page<MemberPostDto> findMemberTaggedPostDtos(Long loginMemberId, String username, Pageable pageable);
+	Page<MemberPostDto> findMemberTaggedPostDtoPage(Long loginMemberId, String username, Pageable pageable);
 
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/repository/querydsl/MemberPostRepositoryQuerydsl.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/repository/querydsl/MemberPostRepositoryQuerydsl.java
@@ -9,10 +9,10 @@ import cloneproject.Instagram.domain.member.entity.Member;
 public interface MemberPostRepositoryQuerydsl {
 
 
-	Page<MemberPostDto> findMemberPostDtos(Member loginMember, String username, Pageable pageable);
+	Page<MemberPostDto> findMemberPostDtos(Long loginMemberId, String username, Pageable pageable);
 
-	Page<MemberPostDto> findMemberSavedPostDtos(Long loginUserId, Pageable pageable);
+	Page<MemberPostDto> findMemberSavedPostDtos(Long loginMemberId, Pageable pageable);
 
-	Page<MemberPostDto> findMemberTaggedPostDtos(Member loginMember, String username, Pageable pageable);
+	Page<MemberPostDto> findMemberTaggedPostDtos(Long loginMemberId, String username, Pageable pageable);
 
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/repository/querydsl/MemberPostRepositoryQuerydslImpl.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/repository/querydsl/MemberPostRepositoryQuerydslImpl.java
@@ -27,14 +27,14 @@ public class MemberPostRepositoryQuerydslImpl implements MemberPostRepositoryQue
 	private final JPAQueryFactory queryFactory;
 
 	@Override
-	public Page<MemberPostDto> findMemberPostDtos(Member loginMember, String username, Pageable pageable) {
+	public Page<MemberPostDto> findMemberPostDtos(Long loginMemberId, String username, Pageable pageable) {
 		final List<MemberPostDto> posts = queryFactory
 			.select(new QMemberPostDto(
 				post.id,
 				post.member,
 				post.postImages.size().gt(1),
 				post.likeFlag,
-				isExistPostLikeWherePostEqAndMemberUsernameEq(loginMember.getUsername()),
+				isExistPostLikeWherePostEqAndMemberUsernameEq(loginMemberId),
 				post.comments.size(),
 				post.postLikes.size()))
 			.from(post)
@@ -53,7 +53,7 @@ public class MemberPostRepositoryQuerydslImpl implements MemberPostRepositoryQue
 	}
 
 	@Override
-	public Page<MemberPostDto> findMemberSavedPostDtos(Long loginUserId, Pageable pageable) {
+	public Page<MemberPostDto> findMemberSavedPostDtos(Long loginMemberId, Pageable pageable) {
 		final List<MemberPostDto> posts = queryFactory
 			.select(new QMemberPostDto(
 				bookmark.post.id,
@@ -62,7 +62,7 @@ public class MemberPostRepositoryQuerydslImpl implements MemberPostRepositoryQue
 				bookmark.post.comments.size(),
 				bookmark.post.postLikes.size()))
 			.from(bookmark)
-			.where(bookmark.member.id.eq(loginUserId))
+			.where(bookmark.member.id.eq(loginMemberId))
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize())
 			.orderBy(bookmark.post.id.desc())
@@ -71,20 +71,20 @@ public class MemberPostRepositoryQuerydslImpl implements MemberPostRepositoryQue
 
 		final long total = queryFactory
 			.selectFrom(bookmark)
-			.where(bookmark.member.id.eq(loginUserId))
+			.where(bookmark.member.id.eq(loginMemberId))
 			.fetchCount();
 		return new PageImpl<>(posts, pageable, total);
 	}
 
 	@Override
-	public Page<MemberPostDto> findMemberTaggedPostDtos(Member loginMember, String username, Pageable pageable) {
+	public Page<MemberPostDto> findMemberTaggedPostDtos(Long loginMemberId, String username, Pageable pageable) {
 		final List<MemberPostDto> posts = queryFactory
 			.select(new QMemberPostDto(
 				postTag.postImage.post.id,
 				postTag.postImage.post.member,
 				postTag.postImage.post.postImages.size().gt(1),
 				postTag.postImage.post.likeFlag,
-				isExistPostLikeWherePostEqAndMemberUsernameEq(loginMember.getUsername()),
+				isExistPostLikeWherePostEqAndMemberUsernameEq(loginMemberId),
 				postTag.postImage.post.comments.size(),
 				postTag.postImage.post.postLikes.size()))
 			.from(postTag)
@@ -102,10 +102,10 @@ public class MemberPostRepositoryQuerydslImpl implements MemberPostRepositoryQue
 		return new PageImpl<>(posts, pageable, total);
 	}
 
-	private BooleanExpression isExistPostLikeWherePostEqAndMemberUsernameEq(String username) {
+	private BooleanExpression isExistPostLikeWherePostEqAndMemberUsernameEq(Long id) {
 		return JPAExpressions
 			.selectFrom(postLike)
-			.where(postLike.post.eq(post).and(postLike.member.username.eq(username)))
+			.where(postLike.post.eq(post).and(postLike.member.id.eq(id)))
 			.exists();
 	}
 

--- a/src/main/java/cloneproject/Instagram/domain/member/repository/querydsl/MemberPostRepositoryQuerydslImpl.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/repository/querydsl/MemberPostRepositoryQuerydslImpl.java
@@ -19,7 +19,6 @@ import lombok.RequiredArgsConstructor;
 
 import cloneproject.Instagram.domain.feed.dto.MemberPostDto;
 import cloneproject.Instagram.domain.feed.dto.QMemberPostDto;
-import cloneproject.Instagram.domain.member.entity.Member;
 
 @RequiredArgsConstructor
 public class MemberPostRepositoryQuerydslImpl implements MemberPostRepositoryQuerydsl {
@@ -34,7 +33,7 @@ public class MemberPostRepositoryQuerydslImpl implements MemberPostRepositoryQue
 				post.member,
 				post.postImages.size().gt(1),
 				post.likeFlag,
-				isExistPostLikeWherePostEqAndMemberUsernameEq(loginMemberId),
+				existPostLikeWherePostEqAndMemberIdEq(loginMemberId),
 				post.comments.size(),
 				post.postLikes.size()))
 			.from(post)
@@ -53,7 +52,7 @@ public class MemberPostRepositoryQuerydslImpl implements MemberPostRepositoryQue
 	}
 
 	@Override
-	public Page<MemberPostDto> findMemberSavedPostDtos(Long loginMemberId, Pageable pageable) {
+	public Page<MemberPostDto> findMemberSavedPostDtoPage(Long loginMemberId, Pageable pageable) {
 		final List<MemberPostDto> posts = queryFactory
 			.select(new QMemberPostDto(
 				bookmark.post.id,
@@ -77,14 +76,14 @@ public class MemberPostRepositoryQuerydslImpl implements MemberPostRepositoryQue
 	}
 
 	@Override
-	public Page<MemberPostDto> findMemberTaggedPostDtos(Long loginMemberId, String username, Pageable pageable) {
+	public Page<MemberPostDto> findMemberTaggedPostDtoPage(Long loginMemberId, String username, Pageable pageable) {
 		final List<MemberPostDto> posts = queryFactory
 			.select(new QMemberPostDto(
 				postTag.postImage.post.id,
 				postTag.postImage.post.member,
 				postTag.postImage.post.postImages.size().gt(1),
 				postTag.postImage.post.likeFlag,
-				isExistPostLikeWherePostEqAndMemberUsernameEq(loginMemberId),
+				existPostLikeWherePostEqAndMemberIdEq(loginMemberId),
 				postTag.postImage.post.comments.size(),
 				postTag.postImage.post.postLikes.size()))
 			.from(postTag)
@@ -102,7 +101,7 @@ public class MemberPostRepositoryQuerydslImpl implements MemberPostRepositoryQue
 		return new PageImpl<>(posts, pageable, total);
 	}
 
-	private BooleanExpression isExistPostLikeWherePostEqAndMemberUsernameEq(Long id) {
+	private BooleanExpression existPostLikeWherePostEqAndMemberIdEq(Long id) {
 		return JPAExpressions
 			.selectFrom(postLike)
 			.where(postLike.post.eq(post).and(postLike.member.id.eq(id)))

--- a/src/main/java/cloneproject/Instagram/domain/member/service/MemberPostService.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/service/MemberPostService.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 
@@ -26,6 +27,7 @@ import cloneproject.Instagram.global.util.AuthUtil;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class MemberPostService {
 
 	private static final int FIRST_PAGE_SIZE = 15;

--- a/src/main/java/cloneproject/Instagram/domain/member/service/MemberPostService.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/service/MemberPostService.java
@@ -39,9 +39,9 @@ public class MemberPostService {
 	private final PostImageRepository postImageRepository;
 	private final PostService postService;
 
-	public Page<MemberPostDto> getMemberPostDtosWithoutLogin(String username, int size, int page) {
+	public Page<MemberPostDto> getMemberPostDtoPageWithoutLogin(String username, int size, int page) {
 		final Pageable pageable = PageRequest.of(page + PAGE_OFFSET, size);
-		final Page<MemberPostDto> posts = getMemberPostDtos(-1L, username, pageable);
+		final Page<MemberPostDto> posts = getMemberPostDtoPage(-1L, username, pageable);
 		final List<MemberPostDto> content = posts.getContent();
 		setMemberPostImageDtos(content);
 		setPostLikesCount(null, content);
@@ -50,17 +50,17 @@ public class MemberPostService {
 
 	public List<MemberPostDto> getRecent15PostDtosWithoutLogin(String username) {
 		final Pageable pageable = PageRequest.of(0, FIRST_PAGE_SIZE);
-		final Page<MemberPostDto> posts = getMemberPostDtos(-1L, username, pageable);
+		final Page<MemberPostDto> posts = getMemberPostDtoPage(-1L, username, pageable);
 		final List<MemberPostDto> content = posts.getContent();
 		setMemberPostImageDtos(content);
 		setPostLikesCount(null, content);
 		return content;
 	}
 
-	public Page<MemberPostDto> getMemberPostDtos(String username, int size, int page) {
+	public Page<MemberPostDto> getMemberPostDtoPage(String username, int size, int page) {
 		final Member loginMember = authUtil.getLoginMember();
 		final Pageable pageable = PageRequest.of(page + PAGE_OFFSET, size);
-		final Page<MemberPostDto> posts = getMemberPostDtos(loginMember.getId(), username, pageable);
+		final Page<MemberPostDto> posts = getMemberPostDtoPage(loginMember.getId(), username, pageable);
 		final List<MemberPostDto> content = posts.getContent();
 		setMemberPostImageDtos(content);
 		setPostLikesCount(loginMember, content);
@@ -70,17 +70,17 @@ public class MemberPostService {
 	public List<MemberPostDto> getRecent15PostDtos(String username) {
 		final Member loginMember = authUtil.getLoginMember();
 		final Pageable pageable = PageRequest.of(0, FIRST_PAGE_SIZE);
-		final Page<MemberPostDto> posts = getMemberPostDtos(loginMember.getId(), username, pageable);
+		final Page<MemberPostDto> posts = getMemberPostDtoPage(loginMember.getId(), username, pageable);
 		final List<MemberPostDto> content = posts.getContent();
 		setMemberPostImageDtos(content);
 		setPostLikesCount(loginMember, content);
 		return content;
 	}
 
-	public Page<MemberPostDto> getMemberSavedPostDtos(int size, int page) {
+	public Page<MemberPostDto> getMemberSavedPostPage(int size, int page) {
 		final Member loginMember = authUtil.getLoginMember();
 		final Pageable pageable = PageRequest.of(page + PAGE_OFFSET, size);
-		final Page<MemberPostDto> posts = memberRepository.findMemberSavedPostDtos(loginMember.getId(), pageable);
+		final Page<MemberPostDto> posts = memberRepository.findMemberSavedPostDtoPage(loginMember.getId(), pageable);
 		final List<MemberPostDto> content = posts.getContent();
 		setMemberPostImageDtos(content);
 		setPostLikesCount(loginMember, content);
@@ -90,13 +90,13 @@ public class MemberPostService {
 	public List<MemberPostDto> getRecent15SavedPostDtos() {
 		final Member loginMember = authUtil.getLoginMember();
 		final Pageable pageable = PageRequest.of(0, FIRST_PAGE_SIZE);
-		final Page<MemberPostDto> posts = memberRepository.findMemberSavedPostDtos(loginMember.getId(), pageable);
+		final Page<MemberPostDto> posts = memberRepository.findMemberSavedPostDtoPage(loginMember.getId(), pageable);
 		final List<MemberPostDto> content = posts.getContent();
 		setMemberPostImageDtos(content);
 		return content;
 	}
 
-	public Page<MemberPostDto> getMemberTaggedPostDtos(String username, int size, int page) {
+	public Page<MemberPostDto> getMemberTaggedPostDtoPage(String username, int size, int page) {
 		final Member loginMember = authUtil.getLoginMember();
 		final Member member = memberRepository.findByUsername(username)
 			.orElseThrow(() -> new EntityNotFoundException(MEMBER_NOT_FOUND));
@@ -106,7 +106,7 @@ public class MemberPostService {
 		}
 
 		final Pageable pageable = PageRequest.of(page + PAGE_OFFSET, size);
-		final Page<MemberPostDto> posts = memberRepository.findMemberTaggedPostDtos(loginMember.getId(), username,
+		final Page<MemberPostDto> posts = memberRepository.findMemberTaggedPostDtoPage(loginMember.getId(), username,
 			pageable);
 		final List<MemberPostDto> content = posts.getContent();
 		setMemberPostImageDtos(content);
@@ -124,7 +124,7 @@ public class MemberPostService {
 		}
 
 		final Pageable pageable = PageRequest.of(0, FIRST_PAGE_SIZE);
-		final Page<MemberPostDto> posts = memberRepository.findMemberTaggedPostDtos(loginMember.getId(), username,
+		final Page<MemberPostDto> posts = memberRepository.findMemberTaggedPostDtoPage(loginMember.getId(), username,
 			pageable);
 		final List<MemberPostDto> content = posts.getContent();
 		setMemberPostImageDtos(content);
@@ -132,7 +132,7 @@ public class MemberPostService {
 		return content;
 	}
 
-	private Page<MemberPostDto> getMemberPostDtos(Long memberId, String username, Pageable pageable) {
+	private Page<MemberPostDto> getMemberPostDtoPage(Long memberId, String username, Pageable pageable) {
 		final Member member = memberRepository.findByUsername(username)
 			.orElseThrow(() -> new EntityNotFoundException(MEMBER_NOT_FOUND));
 

--- a/src/main/java/cloneproject/Instagram/domain/member/service/MemberService.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/service/MemberService.java
@@ -63,7 +63,7 @@ public class MemberService {
 			.build();
 	}
 
-	public UserProfileResponse getUserProfileWithLogin(String username) {
+	public UserProfileResponse getUserProfile(String username) {
 		final Long memberId = authUtil.getLoginMemberId();
 		return getUserProfile(username, memberId);
 	}

--- a/src/main/java/cloneproject/Instagram/global/config/security/WebSecurityConfig.java
+++ b/src/main/java/cloneproject/Instagram/global/config/security/WebSecurityConfig.java
@@ -57,7 +57,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 	private static final String[] AUTH_WHITELIST_SWAGGER = {"/v2/api-docs", "/configuration/ui", "/swagger-resources",
 		"/configuration/security", "/swagger-ui.html", "/webjars/**", "/swagger/**"};
 	private static final String[] AUTH_WHITELIST_STATIC = {"/static/css/**", "/static/js/**", "*.ico"};
-	private static final String[] AUTH_WHITELIST = {"/login", "/login/recovery", "/accounts",
+	private static final String[] AUTH_WHITELIST = {"/login", "/login/recovery", "/accounts", "/**/without",
 		"/accounts/password/email",
 		"/accounts/password/reset", "/reissue", "/swagger-ui.html", "/swagger/**", "/swagger-resources/**",
 		"swagger-ui/**", "/accounts/email", "/accounts/check", "/logout/only/cookie", "/ws-connection/**"};


### PR DESCRIPTION
<!--
✅ Resolve: #이슈번호 형태로 입력해 주세요.
ex) Resolve: #123
-->
## 📌Linked Issues
- #169 

<!--
✅ 변경 사항을 자세히 알려주세요. (why -> what -> how)
-->
## ✏Change Details
### API 추가
- 로그인 없이 멤버 프로필 조회 API 구현
- 로그인 없이 멤버 게시물 조회 API 구현
### 관련된 서비스 로직 일부 수정
- repository 매개변수 일부 수정
  - `member`를 매개변수로 받은 뒤 `member.getId()`, `mebmer.getUsername()`을 통해 쿼리를 실행하는데, id를 사용하도록 통일하고 매개변수로 Long(id)만 받도록 수정
- private 메서드로 추출
- Trasactional(readOnly = true) 적용 및 위치 변경(Service에 붙이도록)
- 해결된 TODO 삭제
- 사용하지 않는 인스턴스 변수 삭제

<!--
✅ 추가로 전달할 내용이 있다면 적어주세요.
-->
## 💬Comment
- `/**/without`을 AUTH_WHITELIST에 추가했습니다. 선필님 API도 로그인 하지 않는 경우 엔드포인트 끝에 `/without`을 추가하도록 통일하면 좋을 것 같습니다 !
- ResultCode는 따로 추가하지 않아도 될 것 같은데, 어떻게 생각하시나요?

<!--
✅ 참고한 사이트가 있다면 공유해주세요.
-->
## 📑References
- 

## ✅Check List
- [x] 추가한 기능에 대한 테스트는 모두 완료하셨나요?
- [x] 코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?
