### PR TITLE
HibernateDialect 관련 버그 수정

### DIFF
--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -14,7 +14,6 @@ spring:
       hibernate:
         format_sql: true
         default_batch_fetch_size: 1000
-        dialect: org.hibernate.dialect.MySQL55Dialect
     open-in-view: false
 
   redis:


### PR DESCRIPTION
<!--
✅ Resolve: #이슈번호 형태로 입력해 주세요.
ex) Resolve: #123
-->
## 📌Linked Issues
- 

<!--
✅ 변경 사항을 자세히 알려주세요. (why -> what -> how)
-->
## ✏Change Details
### HibernateDialect 관련 버그
### `dialect: org.hibernate.dialect.MySQL55Dialect`가 포함된 상태로 테스트를 실행한 경우(예외의 일부만 적었습니다)
```
2022-08-14 20:54:49.223 ERROR 1840 --- [           main] o.h.engine.jdbc.spi.SqlExceptionHelper   : Table "MEMBERS" not found; SQL statement:
select member0_.member_id as member_i1_13_, member0_.member_email as member_e2_13_, member0_.member_gender as member_g3_13_, member0_.member_image_name as member_i4_13_, member0_.member_image_type as member_i5_13_, member0_.member_image_uuid as member_i6_13_, member0_.member_image_url as member_i7_13_, member0_.member_introduce as member_i8_13_, member0_.member_name as member_n9_13_, member0_.member_password as member_10_13_, member0_.member_phone as member_11_13_, member0_.member_role as member_12_13_, member0_.member_username as member_13_13_, member0_.member_website as member_14_13_ from members member0_ where member0_.member_username=? [42102-200]
2022-08-14 20:54:49.232  INFO 1840 --- [           main] o.s.t.c.transaction.TransactionContext   : Rolled back transaction for test: [DefaultTestContext@5a9d6f02 testClass = MemberRepositoryTest, testInstance = cloneproject.Instagram.domain.member.repository.MemberRepositoryTest@44cab872, testMethod = findByUsername_MemberDoesNotExist_FindMember@MemberRepositoryTest, testException = org.springframework.dao.InvalidDataAccessResourceUsageException: could not prepare statement; SQL [select member0_.member_id as member_i1_13_, member0_.member_email as member_e2_13_, member0_.member_gender as member_g3_13_, member0_.member_image_name as member_i4_13_, member0_.member_image_type as member_i5_13_, member0_.member_image_uuid as member_i6_13_, member0_.member_image_url as member_i7_13_, member0_.member_introduce as member_i8_13_, member0_.member_name as member_n9_13_, member0_.member_password as member_10_13_, member0_.member_phone as member_11_13_, member0_.member_role as member_12_13_, member0_.member_username as member_13_13_, member0_.member_website as member_14_13_ from members member0_ where member0_.member_username=?]; nested exception is org.hibernate.exception.SQLGrammarException: could not prepare statement, mergedContextConfiguration = [MergedContextConfiguration@362045c0 testClass = MemberRepositoryTest, locations = '{}', classes = '{class cloneproject.Instagram.InstagramApplication}', contextInitializerClasses = '[]', activeProfiles = '{}', propertySourceLocations = '{}', propertySourceProperties = '{org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTestContextBootstrapper=true}', contextCustomizers = set[org.springframework.boot.test.autoconfigure.OverrideAutoConfigurationContextCustomizerFactory$DisableAutoConfigurationContextCustomizer@2ce6c6ec, org.springframework.boot.test.autoconfigure.actuate.metrics.MetricsExportContextCustomizerFactory$DisableMetricExportContextCustomizer@1672fe87, org.springframework.boot.test.autoconfigure.filter.TypeExcludeFiltersContextCustomizer@351584c0, org.springframework.boot.test.autoconfigure.properties.PropertyMappingContextCustomizer@e7131088, org.springframework.boot.test.autoconfigure.web.servlet.WebDriverContextCustomizerFactory$Customizer@6e005dc9, [ImportsContextCustomizer@112f364d key = [org.springframework.boot.autoconfigure.cache.CacheAutoConfiguration, org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration, org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration, org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration, org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration, org.springframework.boot.autoconfigure.jdbc.JdbcTemplateAutoConfiguration, org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration, org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration, org.springframework.boot.autoconfigure.sql.init.SqlInitializationAutoConfiguration, org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration, org.springframework.boot.test.autoconfigure.jdbc.TestDatabaseAutoConfiguration, org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManagerAutoConfiguration, cloneproject.Instagram.global.config.QuerydslConfig]], org.springframework.boot.test.context.filter.ExcludeFilterContextCustomizer@6f44a157, org.springframework.boot.test.json.DuplicateJsonObjectContextCustomizerFactory$DuplicateJsonObjectContextCustomizer@17d88132, org.springframework.boot.test.mock.mockito.MockitoContextCustomizer@d03c02b0, org.springframework.boot.test.context.SpringBootTestArgs@1, org.springframework.boot.test.context.SpringBootTestWebEnvironment@0], contextLoader = 'org.springframework.boot.test.context.SpringBootContextLoader', parent = [null]], attributes = map['org.springframework.test.context.event.ApplicationEventsTestExecutionListener.recordApplicationEvents' -> false]]

org.springframework.dao.InvalidDataAccessResourceUsageException: could not prepare statement; SQL [select member0_.member_id as member_i1_13_, member0_.member_email as member_e2_13_, member0_.member_gender as member_g3_13_, member0_.member_image_name as member_i4_13_, member0_.member_image_type as member_i5_13_, member0_.member_image_uuid as member_i6_13_, member0_.member_image_url as member_i7_13_, member0_.member_introduce as member_i8_13_, member0_.member_name as member_n9_13_, member0_.member_password as member_10_13_, member0_.member_phone as member_11_13_, member0_.member_role as member_12_13_, member0_.member_username as member_13_13_, member0_.member_website as member_14_13_ from members member0_ where member0_.member_username=?]; nested exception is org.hibernate.exception.SQLGrammarException: could not prepare statement

	at org.springframework.orm.jpa.vendor.HibernateJpaDialect.convertHibernateAccessException(HibernateJpaDialect.java:259)
	at org.springframework.orm.jpa.vendor.HibernateJpaDialect.translateExceptionIfPossible(HibernateJpaDialect.java:233)
	at org.springframework.orm.jpa.AbstractEntityManagerFactoryBean.translateExceptionIfPossible(AbstractEntityManagerFactoryBean.java:551)
	at org.springframework.dao.support.ChainedPersistenceExceptionTranslator.translateExceptionIfPossible(ChainedPersistenceExceptionTranslator.java:61)
	at org.springframework.dao.support.DataAccessUtils.translateIfNecessary(DataAccessUtils.java:242)
	at org.springframework.dao.support.PersistenceExceptionTranslationInterceptor.invoke(PersistenceExceptionTranslationInterceptor.java:152)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
	at 
.
.
.
.
org.hibernate.query.criteria.internal.compile.CriteriaQueryTypeQueryAdapter.getSingleResult(CriteriaQueryTypeQueryAdapter.java:111)
	at org.springframework.data.jpa.repository.query.JpaQueryExecution$SingleEntityExecution.doExecute(JpaQueryExecution.java:196)
	at org.springframework.data.jpa.repository.query.JpaQueryExecution.execute(JpaQueryExecution.java:88)
	at org.springframework.data.jpa.repository.query.AbstractJpaQuery.doExecute(AbstractJpaQuery.java:155)
	at org.springframework.data.jpa.repository.query.AbstractJpaQuery.execute(AbstractJpaQuery.java:143)
	at org.springframework.data.repository.core.support.RepositoryMethodInvoker.doInvoke(RepositoryMethodInvoker.java:137)
	at org.springframework.data.repository.core.support.RepositoryMethodInvoker.invoke(RepositoryMethodInvoker.java:121)
	at org.springframework.data.repository.core.support.QueryExecutorMethodInterceptor.doInvoke(QueryExecutorMethodInterceptor.java:159)
	at org.springframework.data.repository.core.support.QueryExecutorMethodInterceptor.invoke(QueryExecutorMethodInterceptor.java:138)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
	at org.springframework.data.projection.DefaultMethodInvokingMethodInterceptor.invoke(DefaultMethodInvokingMethodInterceptor.java:80)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
	at org.springframework.transaction.interceptor.TransactionInterceptor$1.proceedWithInvocation(TransactionInterceptor.java:123)
	at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:388)
	at org.springframework.transaction.interceptor.TransactionInterceptor.invoke(TransactionInterceptor.java:119)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
	at org.springframework.dao.support.PersistenceExceptionTranslationInterceptor.invoke(PersistenceExceptionTranslationInterceptor.java:137)
	... 75 more
```
- Stack trace가 너무 길어서 임의로 중략했습니다.
- `Entity` 어노테이션에 의해 table이 자동적으로 생성됐음에도 불구하고 table not found 에러가 발생하는 모습입니다.
### `dialect: org.hibernate.dialect.MySQL55Dialect`를 제거한 경우
![image](https://user-images.githubusercontent.com/58378676/184535390-0cbdbc13-2a9b-434d-ba3e-72f9e3b29fd5.png)
- 위와 같이 정상적으로 테스트 실행 됩니다.
<!--
✅ 추가로 전달할 내용이 있다면 적어주세요.
-->
## 💬Comment
- 버그가 계속 발생해서 하루종일 찾았네요... 검색해봐도 dialect관련된 문제라는 글은 안나와서 다른 부분이 문제라 생각했습니다. 그래서 더 오래걸렸네요
- 한 라인씩 주석 처리, 수정해보며 실행하다가 dialect 부분에 문제가 있는걸 발견했습니다.
- 관련해서 글을 찾아봤는데, dialect는 SpringBoot가 실행되는 과정에서 현재 연결된 데이터베이스에 맞게 자동으로 설정된다고 합니다. 따라서, 직접 설정해줄 필요가 없습니다.
- 직접 설정해준 경우 위와 같이 버전 충돌로 인한 알 수 없는 버그가 발생할 수도 있다고 합니다. ( 아마 위의 문제는 table 명의 대소문자 구분 때문에 발생한 것 같습니다. )
- 한 줄짜리 수정사항이지만 꽤 중요한 사항이라 생각해 PR로 남깁니다 !
<!--
✅ 참고한 사이트가 있다면 공유해주세요.
-->
## 📑References
- https://velog.io/@lehdqlsl/Spring-boot-JPA-Dialect%EB%B0%A9%EC%96%B8-%EC%84%A4%EC%A0%95%EC%97%90-%EA%B4%80%ED%95%98%EC%97%AC
## ✅Check List
- [x] 추가한 기능에 대한 테스트는 모두 완료하셨나요?
- [x] 코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?
