### PR TITLE
BlockRepository 테스트 작성

### DIFF
--- a/src/test/java/cloneproject/Instagram/domain/member/repository/BlockRepositoryTest.java
+++ b/src/test/java/cloneproject/Instagram/domain/member/repository/BlockRepositoryTest.java
@@ -1,0 +1,116 @@
+package cloneproject.Instagram.domain.member.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import cloneproject.Instagram.domain.member.entity.Block;
+import cloneproject.Instagram.domain.member.entity.Member;
+import cloneproject.Instagram.global.config.QuerydslConfig;
+import cloneproject.Instagram.util.domain.member.MemberUtils;
+
+@DataJpaTest
+@Import(QuerydslConfig.class)
+public class BlockRepositoryTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private BlockRepository blockRepository;
+
+    @Nested
+    class ExistsByMemberIdAndBlockMemberId {
+
+        @Test
+        void blockingTarget_ReturnTrue() {
+            // given
+            final Member member = MemberUtils.newInstance();
+            memberRepository.save(member);
+
+            final Member target = MemberUtils.newInstance();
+            memberRepository.save(target);
+
+            final Block block = Block.builder()
+                .member(member)
+                .blockMember(target)
+                .build();
+            blockRepository.save(block);
+
+            // when
+            final boolean isPresent = blockRepository.existsByMemberIdAndBlockMemberId(member.getId(), target.getId());
+
+            //then
+            assertThat(isPresent).isTrue();
+        }
+
+        @Test
+        void notBlockingTarget_ReturnFalse() {
+            // given
+            final Member member = MemberUtils.newInstance();
+            memberRepository.save(member);
+
+            final Member target = MemberUtils.newInstance();
+            memberRepository.save(target);
+
+            // when
+            final boolean isPresent = blockRepository.existsByMemberIdAndBlockMemberId(member.getId(), target.getId());
+
+            //then
+            assertThat(isPresent).isFalse();
+        }
+
+    }
+
+    @Nested
+    class FindByMemberIdAndBlockMemberId {
+
+        @Test
+        void blockingTarget_ReturnBlock() {
+            // given
+            final Member member = MemberUtils.newInstance();
+            memberRepository.save(member);
+
+            final Member target = MemberUtils.newInstance();
+            memberRepository.save(target);
+
+            final Block block = Block.builder()
+                .member(member)
+                .blockMember(target)
+                .build();
+            blockRepository.save(block);
+
+            // when
+            final boolean isPresent = blockRepository.findByMemberIdAndBlockMemberId(member.getId(), target.getId())
+                .isPresent();
+
+            //then
+            assertThat(isPresent).isTrue();
+
+        }
+
+        @Test
+        void notBlockingTarget_ReturnEmpty() {
+            // given
+            final Member member = MemberUtils.newInstance();
+            memberRepository.save(member);
+
+            final Member target = MemberUtils.newInstance();
+            memberRepository.save(target);
+
+            // when
+            final boolean isEmpty = blockRepository.findByMemberIdAndBlockMemberId(member.getId(), target.getId())
+                .isEmpty();
+
+            //then
+            assertThat(isEmpty).isTrue();
+
+        }
+
+    }
+
+}

--- a/src/test/java/cloneproject/Instagram/domain/member/repository/querydsl/BlockRepositoryQuerydslTest.java
+++ b/src/test/java/cloneproject/Instagram/domain/member/repository/querydsl/BlockRepositoryQuerydslTest.java
@@ -1,0 +1,93 @@
+package cloneproject.Instagram.domain.member.repository.querydsl;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import cloneproject.Instagram.domain.member.entity.Block;
+import cloneproject.Instagram.domain.member.entity.Member;
+import cloneproject.Instagram.domain.member.repository.BlockRepository;
+import cloneproject.Instagram.domain.member.repository.MemberRepository;
+import cloneproject.Instagram.global.config.QuerydslConfig;
+import cloneproject.Instagram.util.domain.member.MemberUtils;
+
+@DataJpaTest
+@Import(QuerydslConfig.class)
+public class BlockRepositoryQuerydslTest {
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@Autowired
+	private BlockRepository blockRepository;
+
+	@Nested
+	class IsBlockingOrIsBlocked {
+
+		@Test
+		void blockingTarget_ReturnTrue() {
+			// given
+			final Member member = MemberUtils.newInstance();
+			memberRepository.save(member);
+
+			final Member target = MemberUtils.newInstance();
+			memberRepository.save(target);
+
+			final Block block = Block.builder()
+				.member(member)
+				.blockMember(target)
+				.build();
+			blockRepository.save(block);
+
+			// when
+			final boolean isBlockingOrIsBlocked = blockRepository.isBlockingOrIsBlocked(member.getId(), target.getId());
+
+			//then
+			assertThat(isBlockingOrIsBlocked).isTrue();
+		}
+
+		@Test
+		void blockedByTarget_ReturnTrue() {
+			// given
+			final Member member = MemberUtils.newInstance();
+			memberRepository.save(member);
+
+			final Member target = MemberUtils.newInstance();
+			memberRepository.save(target);
+
+			final Block block = Block.builder()
+				.member(target)
+				.blockMember(member)
+				.build();
+			blockRepository.save(block);
+
+			// when
+			final boolean isBlockingOrIsBlocked = blockRepository.isBlockingOrIsBlocked(member.getId(), target.getId());
+
+			//then
+			assertThat(isBlockingOrIsBlocked).isTrue();
+		}
+
+		@Test
+		void notBlockingEachOther_ReturnFalse() {
+			// given
+			final Member member = MemberUtils.newInstance();
+			memberRepository.save(member);
+
+			final Member target = MemberUtils.newInstance();
+			memberRepository.save(target);
+
+			// when
+			final boolean isBlockingOrIsBlocked = blockRepository.isBlockingOrIsBlocked(member.getId(), target.getId());
+
+			//then
+			assertThat(isBlockingOrIsBlocked).isFalse();
+		}
+
+	}
+
+}


### PR DESCRIPTION
<!--
✅ Resolve: #이슈번호 형태로 입력해 주세요.
ex) Resolve: #123
-->
## 📌Linked Issues
- Resolve: #207

<!--
✅ 변경 사항을 자세히 알려주세요. (why -> what -> how)
-->
## ✏Change Details
### BlockRepsotiory 테스트 작성
- 메서드 명에 의한 쿼리, Querydsl에 대한 테스트 작성
### 메서드 파라매터 이름 수정
- `loginUserId` -> `loginMemberId`
  - 다른 메서드와 동일한 이름으로 변경하였습니다. 
  - MemberRepositoryTest의 프로필 조회도 같은 문제가 있었는데, 간단한 수정이라 바로 develop 브랜치에 푸시했습니다.
<!--
✅ 추가로 전달할 내용이 있다면 적어주세요.
-->
## 💬Comment
- 원래 테스트 파일 별로 PR을 올릴려 했는데, block의 경우 테스트할 메서드가 적어서 한번에 올렸습니다.
- Member도메인 내 테스트 할 repository가 이제 **redis** 관련 3개의 repository만 남아있습니다.
  - 이 3개의 repository도 간단한 쿼리만 있어 한번에 작업해 PR을 올릴 계획입니다. (총 6개 쿼리)
- RedisRepository에 대한 테스트 까지 마치면 멤버 도메인 서비스 리팩토링 및 테스트 작성을 진행할 예정입니다.
<!--
✅ 참고한 사이트가 있다면 공유해주세요.
-->
## 📑References
- 

## ✅Check List
- [x] 추가한 기능에 대한 테스트는 모두 완료하셨나요?
- [x] 코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?
