### PR TITLE
게시물 조회 관련 에러 해결

### DIFF
--- a/src/main/java/cloneproject/Instagram/domain/feed/dto/PostDto.java
+++ b/src/main/java/cloneproject/Instagram/domain/feed/dto/PostDto.java
@@ -39,23 +39,6 @@ public class PostDto {
 	@QueryProjection
 	public PostDto(Long postId, String postContent, LocalDateTime postUploadDate, Member member, int postCommentsCount,
 		int postLikesCount, boolean postBookmarkFlag, boolean postLikeFlag, boolean commentOptionFlag,
-		boolean likeOptionFlag) {
-		this.postId = postId;
-		this.postContent = postContent;
-		this.postUploadDate = postUploadDate;
-		this.member = new MemberDto(member);
-		this.postCommentsCount = postCommentsCount;
-		this.postLikesCount = postLikesCount;
-		this.postBookmarkFlag = postBookmarkFlag;
-		this.postLikeFlag = postLikeFlag;
-		this.commentOptionFlag = commentOptionFlag;
-		this.likeOptionFlag = likeOptionFlag;
-		this.isFollowing = true;
-	}
-
-	@QueryProjection
-	public PostDto(Long postId, String postContent, LocalDateTime postUploadDate, Member member, int postCommentsCount,
-		int postLikesCount, boolean postBookmarkFlag, boolean postLikeFlag, boolean commentOptionFlag,
 		boolean likeOptionFlag, boolean isFollowing) {
 		this.postId = postId;
 		this.postContent = postContent;

--- a/src/main/java/cloneproject/Instagram/domain/feed/repository/querydsl/PostRepositoryQuerydslImpl.java
+++ b/src/main/java/cloneproject/Instagram/domain/feed/repository/querydsl/PostRepositoryQuerydslImpl.java
@@ -43,7 +43,8 @@ public class PostRepositoryQuerydslImpl implements PostRepositoryQuerydsl {
 				isExistBookmarkWherePostEqMemberIdEq(memberId),
 				isExistPostLikeWherePostEqAndMemberIdEq(memberId),
 				post.commentFlag,
-				post.likeFlag
+				post.likeFlag,
+				isFollowing(memberId)
 			))
 			.from(post)
 			.innerJoin(post.member, member)

--- a/src/main/java/cloneproject/Instagram/domain/feed/service/PostService.java
+++ b/src/main/java/cloneproject/Instagram/domain/feed/service/PostService.java
@@ -251,7 +251,7 @@ public class PostService {
 	}
 
 	public Page<PostDto> getHashTagPosts(int page, int size, String name) {
-		final Pageable pageable = PageRequest.of(page, size, Sort.Direction.DESC, "postId");
+		final Pageable pageable = PageRequest.of(page, size, Sort.Direction.DESC, "id");
 		return hashtagRepository.findByName(name)
 			.map(hashtag -> {
 				final List<Long> postIds = hashtagPostRepository.findAllWithPostByHashtagId(pageable, hashtag.getId())
@@ -264,7 +264,7 @@ public class PostService {
 				setContents(loginMember, postDtoPage.getContent());
 				return postDtoPage;
 			})
-			.orElse(new PageImpl<>(new ArrayList<>(), pageable, NONE));
+			.orElse(new PageImpl<>(new ArrayList<>()));
 	}
 
 	private void setContents(Member loginMember, List<PostDto> postDtos) {


### PR DESCRIPTION
<!--
✅ Resolve: #이슈번호 형태로 입력해 주세요.
ex) Resolve: #123
-->
## 📌Linked Issues
- Resolve: #227 
- Resolve: #228 

<!--
✅ 변경 사항을 자세히 알려주세요. (why -> what -> how)
-->
## ✏Change Details
### 해시태그 게시물 조회 쿼리 오류
- hashtag_posts 테이블에서 post_id 기준으로 order by를 적용해서 오류가 발생하였습니다.
- hashtag_post_id 기준으로 order by를 적용할 수 있도록 수정하였습니다.

### 게시물 페이징 조회 시 팔로우 여부 불일치 문제
- 기존에는 팔로우한 유저의 게시물만 볼 수 있어서 무조건 isFollowing = true를 반환하였습니다.
- 이제는 게시물 페이징 조회 시, 해시태그 팔로우 게시물도 포함되도록 수정되었기 때문에, 서브쿼리를 추가함으로써 팔로우 여부를 정확하게 전달하도록 수정하였습니다.

<!--
✅ 추가로 전달할 내용이 있다면 적어주세요.
-->
## 💬Comment
-

<!--
✅ 참고한 사이트가 있다면 공유해주세요.
-->
## 📑References
- 

## ✅Check List
- [x] 추가한 기능에 대한 테스트는 모두 완료하셨나요?
- [x] 코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?
