### PR TITLE
MemberAuthService 테스트 작성 및 리팩토링

### DIFF
--- a/src/main/java/cloneproject/Instagram/domain/member/controller/MemberAuthController.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/controller/MemberAuthController.java
@@ -33,7 +33,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import cloneproject.Instagram.domain.member.dto.JwtDto;
 import cloneproject.Instagram.domain.member.dto.JwtResponse;
-import cloneproject.Instagram.domain.member.dto.LoginDevicesDto;
+import cloneproject.Instagram.domain.member.dto.LoginDeviceDto;
 import cloneproject.Instagram.domain.member.dto.LoginRequest;
 import cloneproject.Instagram.domain.member.dto.LoginWithCodeRequest;
 import cloneproject.Instagram.domain.member.dto.RegisterRequest;
@@ -300,7 +300,7 @@ public class MemberAuthController {
 	@GetMapping(value = "/accounts/login/device")
 	public ResponseEntity<ResultResponse> getLoginDevices(
 		@CookieValue(value = "refreshToken", required = true) Cookie refreshCookie) {
-		final List<LoginDevicesDto> loginDevicesDtos = memberAuthService.getLoginDevices(refreshCookie.getValue());
+		final List<LoginDeviceDto> loginDevicesDtos = memberAuthService.getLoginDevices(refreshCookie.getValue());
 
 		return ResponseEntity.ok(ResultResponse.of(GET_LOGIN_DEVICES_SUCCESS, loginDevicesDtos));
 	}

--- a/src/main/java/cloneproject/Instagram/domain/member/dto/LoginDeviceDto.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/dto/LoginDeviceDto.java
@@ -11,7 +11,7 @@ import cloneproject.Instagram.infra.location.dto.Location;
 @Getter
 @Builder
 @AllArgsConstructor
-public class LoginDevicesDto {
+public class LoginDeviceDto {
 
 	private String tokenId;
 	private Location location;

--- a/src/main/java/cloneproject/Instagram/domain/member/dto/RegisterRequest.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/dto/RegisterRequest.java
@@ -48,13 +48,4 @@ public class RegisterRequest {
 	@Length(max = 6, min = 6, message = "인증코드는 6자리 입니다.")
 	private String code;
 
-	public Member convert() {
-		return Member.builder()
-			.username(getUsername())
-			.name(getName())
-			.password(getPassword())
-			.email(getEmail())
-			.build();
-	}
-
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/exception/PasswordEqualWithOldException.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/exception/PasswordEqualWithOldException.java
@@ -1,0 +1,12 @@
+package cloneproject.Instagram.domain.member.exception;
+
+import cloneproject.Instagram.global.error.ErrorCode;
+import cloneproject.Instagram.global.error.exception.BusinessException;
+
+public class PasswordEqualWithOldException extends BusinessException {
+
+	public PasswordEqualWithOldException() {
+		super(ErrorCode.PASSWORD_EQUAL_WITH_OLD);
+	}
+
+}

--- a/src/main/java/cloneproject/Instagram/domain/member/service/MemberAuthService.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/service/MemberAuthService.java
@@ -107,7 +107,7 @@ public class MemberAuthService {
 			throw new PasswordResetFailException();
 		}
 		if (bCryptPasswordEncoder.matches(resetPasswordRequest.getNewPassword(), member.getPassword())) {
-			throw new EntityAlreadyExistException(PASSWORD_EQUAL_WITH_OLD);
+			throw new PasswordEqualWithOldException();
 		}
 
 		final String encryptedPassword = bCryptPasswordEncoder.encode(resetPasswordRequest.getNewPassword());

--- a/src/main/java/cloneproject/Instagram/domain/member/service/MemberAuthService.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/service/MemberAuthService.java
@@ -4,7 +4,6 @@ import static cloneproject.Instagram.global.error.ErrorCode.*;
 
 import java.util.List;
 
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,7 +12,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import cloneproject.Instagram.domain.member.dto.JwtDto;
-import cloneproject.Instagram.domain.member.dto.LoginDevicesDto;
+import cloneproject.Instagram.domain.member.dto.LoginDeviceDto;
 import cloneproject.Instagram.domain.member.dto.RegisterRequest;
 import cloneproject.Instagram.domain.member.dto.ResetPasswordRequest;
 import cloneproject.Instagram.domain.member.dto.UpdatePasswordRequest;
@@ -36,7 +35,6 @@ import cloneproject.Instagram.infra.location.dto.Location;
 public class MemberAuthService {
 
 	private final AuthUtil authUtil;
-	private final AuthenticationManagerBuilder authenticationManagerBuilder;
 	private final JwtUtil jwtUtil;
 	private final EmailCodeService emailCodeService;
 	private final MemberRepository memberRepository;
@@ -98,7 +96,6 @@ public class MemberAuthService {
 		return emailCodeService.sendResetPasswordCode(username);
 	}
 
-	// TODO 수정
 	@Transactional
 	public JwtDto resetPassword(ResetPasswordRequest resetPasswordRequest, String device, String ip) {
 		final Member member = memberRepository.findByUsername(resetPasswordRequest.getUsername())
@@ -130,19 +127,19 @@ public class MemberAuthService {
 		return emailCodeService.checkResetPasswordCode(username, code);
 	}
 
-	@Transactional
-	public void logout(String refreshToken) {
-		refreshTokenService.deleteRefreshTokenWithValue(authUtil.getLoginMemberId(), refreshToken);
-	}
-
-	public List<LoginDevicesDto> getLoginDevices(String currentToken) {
+	public List<LoginDeviceDto> getLoginDevices(String currentToken) {
 		final Member member = authUtil.getLoginMember();
 		return refreshTokenService.getLoginDevices(member.getId(), currentToken);
 	}
 
 	@Transactional
+	public void logout(String refreshToken) {
+		refreshTokenService.deleteRefreshTokenByValue(authUtil.getLoginMemberId(), refreshToken);
+	}
+
+	@Transactional
 	public void logoutDevice(String tokenId) {
-		refreshTokenService.deleteRefreshTokenWithId(authUtil.getLoginMemberId(), tokenId);
+		refreshTokenService.deleteRefreshTokenByMemberIdAndId(authUtil.getLoginMemberId(), tokenId);
 	}
 
 	private Member convertRegisterRequestToMember(RegisterRequest registerRequest) {

--- a/src/main/java/cloneproject/Instagram/domain/member/service/MemberAuthService.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/service/MemberAuthService.java
@@ -128,8 +128,7 @@ public class MemberAuthService {
 	}
 
 	public List<LoginDeviceDto> getLoginDevices(String currentToken) {
-		final Member member = authUtil.getLoginMember();
-		return refreshTokenService.getLoginDevices(member.getId(), currentToken);
+		return refreshTokenService.getLoginDevices(authUtil.getLoginMemberId(), currentToken);
 	}
 
 	@Transactional

--- a/src/main/java/cloneproject/Instagram/domain/member/service/MemberAuthService.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/service/MemberAuthService.java
@@ -18,6 +18,7 @@ import cloneproject.Instagram.domain.member.dto.ResetPasswordRequest;
 import cloneproject.Instagram.domain.member.dto.UpdatePasswordRequest;
 import cloneproject.Instagram.domain.member.entity.Member;
 import cloneproject.Instagram.domain.member.exception.AccountMismatchException;
+import cloneproject.Instagram.domain.member.exception.PasswordEqualWithOldException;
 import cloneproject.Instagram.domain.member.exception.PasswordResetFailException;
 import cloneproject.Instagram.domain.member.repository.MemberRepository;
 import cloneproject.Instagram.domain.search.entity.SearchMember;
@@ -84,7 +85,7 @@ public class MemberAuthService {
 			throw new AccountMismatchException();
 		}
 		if (updatePasswordRequest.getOldPassword().equals(updatePasswordRequest.getNewPassword())) {
-			throw new EntityAlreadyExistException(PASSWORD_ALREADY_EXIST);
+			throw new PasswordEqualWithOldException();
 		}
 		final String encryptedPassword = bCryptPasswordEncoder.encode(updatePasswordRequest.getNewPassword());
 		member.setEncryptedPassword(encryptedPassword);
@@ -106,7 +107,7 @@ public class MemberAuthService {
 			throw new PasswordResetFailException();
 		}
 		if (bCryptPasswordEncoder.matches(resetPasswordRequest.getNewPassword(), member.getPassword())) {
-			throw new EntityAlreadyExistException(PASSWORD_ALREADY_EXIST);
+			throw new EntityAlreadyExistException(PASSWORD_EQUAL_WITH_OLD);
 		}
 
 		final String encryptedPassword = bCryptPasswordEncoder.encode(resetPasswordRequest.getNewPassword());

--- a/src/main/java/cloneproject/Instagram/domain/member/service/MemberAuthService.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/service/MemberAuthService.java
@@ -128,6 +128,7 @@ public class MemberAuthService {
 		return emailCodeService.checkResetPasswordCode(username, code);
 	}
 
+	@Transactional(readOnly = true)
 	public List<LoginDeviceDto> getLoginDevices(String currentToken) {
 		return refreshTokenService.getLoginDevices(authUtil.getLoginMemberId(), currentToken);
 	}

--- a/src/main/java/cloneproject/Instagram/domain/member/service/MemberAuthService.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/service/MemberAuthService.java
@@ -61,7 +61,7 @@ public class MemberAuthService {
 			return false;
 		}
 
-		final Member member = registerRequest.convert();
+		final Member member = convertRegisterRequestToMember(registerRequest);
 		final String encryptedPassword = bCryptPasswordEncoder.encode(member.getPassword());
 		member.setEncryptedPassword(encryptedPassword);
 		memberRepository.save(member);
@@ -143,6 +143,15 @@ public class MemberAuthService {
 	@Transactional
 	public void logoutDevice(String tokenId) {
 		refreshTokenService.deleteRefreshTokenWithId(authUtil.getLoginMemberId(), tokenId);
+	}
+
+	private Member convertRegisterRequestToMember(RegisterRequest registerRequest) {
+		return Member.builder()
+			.username(registerRequest.getUsername())
+			.name(registerRequest.getName())
+			.password(registerRequest.getPassword())
+			.email(registerRequest.getEmail())
+			.build();
 	}
 
 }

--- a/src/main/java/cloneproject/Instagram/domain/member/service/RefreshTokenService.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/service/RefreshTokenService.java
@@ -12,7 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-import cloneproject.Instagram.domain.member.dto.LoginDevicesDto;
+import cloneproject.Instagram.domain.member.dto.LoginDeviceDto;
 import cloneproject.Instagram.domain.member.entity.redis.RefreshToken;
 import cloneproject.Instagram.domain.member.exception.JwtInvalidException;
 import cloneproject.Instagram.domain.member.repository.redis.RefreshTokenRedisRepository;
@@ -26,11 +26,66 @@ public class RefreshTokenService {
 	private final RefreshTokenRedisRepository refreshTokenRedisRepository;
 	@Value("${max-login-device}")
 	private long MAX_LOGIN_DEVICE;
-	@Value("${refresh-token-expires}")
-	private long REFRESH_TOKEN_EXPIRES;
 
 	@Transactional
 	public void addRefreshToken(Long memberId, String tokenValue, String device, Location location) {
+		deleteExceedRefreshTokens(memberId);
+
+		final RefreshToken refreshToken = RefreshToken.builder()
+			.memberId(memberId)
+			.value(tokenValue)
+			.device(device)
+			.location(location)
+			.build();
+		refreshTokenRedisRepository.save(refreshToken);
+	}
+
+	@Transactional(readOnly = true)
+	public Optional<RefreshToken> findRefreshToken(Long memberId, String value) {
+		return refreshTokenRedisRepository.findByMemberIdAndValue(memberId, value);
+	}
+
+	@Transactional
+	public void deleteRefreshToken(RefreshToken refreshToken) {
+		refreshTokenRedisRepository.delete(refreshToken);
+	}
+
+	@Transactional
+	public void deleteRefreshTokenByValue(Long memberId, String value) {
+		final RefreshToken refreshToken = refreshTokenRedisRepository.findByMemberIdAndValue(memberId, value)
+			.orElseThrow(JwtInvalidException::new);
+		refreshTokenRedisRepository.delete(refreshToken);
+	}
+
+	@Transactional
+	public void deleteRefreshTokenByMemberIdAndId(Long memberId, String id) {
+		final RefreshToken refreshToken = refreshTokenRedisRepository.findByMemberIdAndId(memberId, id)
+			.orElseThrow(JwtInvalidException::new);
+		refreshTokenRedisRepository.delete(refreshToken);
+	}
+
+	@Transactional(readOnly = true)
+	public List<LoginDeviceDto> getLoginDevices(Long memberId, String currentToken) {
+		final List<RefreshToken> refreshTokens = refreshTokenRedisRepository.findAllByMemberId(memberId)
+			.stream()
+			.sorted(Comparator.comparing(RefreshToken::getLastUpdateDate).reversed())
+			.collect(Collectors.toList());
+		return refreshTokens.stream()
+			.map(rt -> convertRefreshTokenToLoginDevicesDto(rt, currentToken))
+			.collect(Collectors.toList());
+	}
+
+	private LoginDeviceDto convertRefreshTokenToLoginDevicesDto(RefreshToken refreshToken, String currentToken) {
+		return LoginDeviceDto.builder()
+			.tokenId(refreshToken.getId())
+			.device(refreshToken.getDevice())
+			.location(refreshToken.getLocation())
+			.lastLoginDate(refreshToken.getLastUpdateDate())
+			.isCurrent(currentToken.equals(refreshToken.getValue()))
+			.build();
+	}
+
+	private void deleteExceedRefreshTokens(Long memberId){
 		final List<RefreshToken> refreshTokens = refreshTokenRedisRepository.findAllByMemberId(memberId)
 			.stream()
 			.sorted(Comparator.comparing(RefreshToken::getLastUpdateDate))
@@ -40,72 +95,6 @@ public class RefreshTokenService {
 			refreshTokenRedisRepository.deleteById(refreshTokens.get(i).getId());
 			refreshTokens.remove(i);
 		}
-
-		final RefreshToken refreshToken = RefreshToken.builder()
-			.memberId(memberId)
-			.value(tokenValue)
-			.device(device)
-			.location(location)
-			.build();
-
-		refreshTokenRedisRepository.save(refreshToken);
-	}
-
-	@Transactional
-	public Optional<RefreshToken> findRefreshToken(Long memberId, String value) {
-		return refreshTokenRedisRepository.findByMemberIdAndValue(memberId, value);
-	}
-
-	@Transactional
-	public void updateRefreshToken(RefreshToken refreshToken, String newToken) {
-		final RefreshToken newRefreshToken = RefreshToken.builder()
-			.memberId(refreshToken.getMemberId())
-			.value(newToken)
-			.device(refreshToken.getDevice())
-			.location(refreshToken.getLocation())
-			.build();
-		refreshTokenRedisRepository.delete(refreshToken);
-		refreshTokenRedisRepository.save(newRefreshToken);
-	}
-
-	@Transactional
-	public void deleteRefreshTokenWithValue(Long memberId, String value) {
-		final RefreshToken refreshToken = refreshTokenRedisRepository.findByMemberIdAndValue(memberId, value)
-			.orElseThrow(JwtInvalidException::new);
-		refreshTokenRedisRepository.delete(refreshToken);
-	}
-
-	@Transactional
-	public void deleteRefreshToken(RefreshToken refreshToken) {
-		refreshTokenRedisRepository.delete(refreshToken);
-	}
-
-	@Transactional
-	public void deleteRefreshTokenWithId(Long memberId, String id) {
-		final RefreshToken refreshToken = refreshTokenRedisRepository.findByMemberIdAndId(memberId, id)
-			.orElseThrow(JwtInvalidException::new);
-		refreshTokenRedisRepository.delete(refreshToken);
-	}
-
-	@Transactional(readOnly = true)
-	public List<LoginDevicesDto> getLoginDevices(Long memberId, String currentToken) {
-		final List<RefreshToken> refreshTokens = refreshTokenRedisRepository.findAllByMemberId(memberId)
-			.stream()
-			.sorted(Comparator.comparing(RefreshToken::getLastUpdateDate).reversed())
-			.collect(Collectors.toList());
-		return refreshTokens.stream()
-			.map(rt -> convertRefreshTokenToLoginedDevicesDTO(rt, currentToken))
-			.collect(Collectors.toList());
-	}
-
-	private LoginDevicesDto convertRefreshTokenToLoginedDevicesDTO(RefreshToken refreshToken, String currentToken) {
-		return LoginDevicesDto.builder()
-			.tokenId(refreshToken.getId())
-			.device(refreshToken.getDevice())
-			.location(refreshToken.getLocation())
-			.lastLoginDate(refreshToken.getLastUpdateDate())
-			.isCurrent(currentToken.equals(refreshToken.getValue()))
-			.build();
 	}
 
 }

--- a/src/main/java/cloneproject/Instagram/global/error/ErrorCode.java
+++ b/src/main/java/cloneproject/Instagram/global/error/ErrorCode.java
@@ -38,7 +38,7 @@ public enum ErrorCode {
 	UNBLOCK_FAIL(400, "M010", "차단하지 않은 유저는 차단해제 할 수 없습니다."),
 	BLOCK_MYSELF_FAIL(400, "M011", "자기 자신을 차단 할 수 없습니다."),
 	UNBLOCK_MYSELF_FAIL(400, "M012", "자기 자신을 차단해제 할 수 없습니다."),
-	PASSWORD_ALREADY_EXIST(400, "M013", "기존 비밀번호와 동일하게 변경할 수 없습니다."),
+	PASSWORD_EQUAL_WITH_OLD(400, "M013", "기존 비밀번호와 동일하게 변경할 수 없습니다."),
 	LOGOUT_BY_ANOTHER(401, "M014", "다른 기기에 의해 로그아웃되었습니다."),
 
 	// Follow

--- a/src/test/java/cloneproject/Instagram/domain/member/service/MemberAuthServiceTest.java
+++ b/src/test/java/cloneproject/Instagram/domain/member/service/MemberAuthServiceTest.java
@@ -1,0 +1,109 @@
+package cloneproject.Instagram.domain.member.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.ThrowableAssert.*;
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import cloneproject.Instagram.domain.member.dto.RegisterRequest;
+import cloneproject.Instagram.domain.member.repository.MemberRepository;
+import cloneproject.Instagram.domain.search.repository.SearchMemberRepository;
+import cloneproject.Instagram.global.util.AuthUtil;
+import cloneproject.Instagram.global.util.JwtUtil;
+import cloneproject.Instagram.infra.location.LocationService;
+import cloneproject.Instagram.util.domain.member.MemberUtils;
+
+@ExtendWith(MockitoExtension.class)
+public class MemberAuthServiceTest {
+
+	@InjectMocks
+	private MemberAuthService memberAuthService;
+
+	@Mock
+	private AuthUtil authUtil;
+
+	@Mock
+	private JwtUtil jwtUtil;
+
+	@Mock
+	private EmailCodeService emailCodeService;
+
+	@Mock
+	private MemberRepository memberRepository;
+
+	@Mock
+	private RefreshTokenService refreshTokenService;
+
+	@Mock
+	private LocationService locationService;
+
+	@Mock
+	private SearchMemberRepository searchMemberRepository;
+
+	@Mock
+	private BCryptPasswordEncoder bCryptPasswordEncoder;
+
+	@Nested
+	class CheckUsername {
+
+		@Test
+		void UsernameExist_ReturnFalse() {
+			// given
+			final String username = MemberUtils.getRandomUsername();
+			given(memberRepository.existsByUsername(username)).willReturn(true);
+
+			// when
+			final boolean canUseUsername = memberAuthService.checkUsername(username);
+
+			// then
+			assertThat(canUseUsername).isFalse();
+		}
+
+		@Test
+		void UsernameNotExist_ReturnTrue() {
+			// given
+			final String username = MemberUtils.getRandomUsername();
+
+			// when
+			final boolean canUseUsername = memberAuthService.checkUsername(username);
+
+			// then
+			assertThat(canUseUsername).isTrue();
+		}
+
+	}
+
+	@Nested
+	class Register {
+
+		@Test
+		void validArguments_MemberRegistered() {
+			// given
+			final String username = MemberUtils.getRandomUsername();
+			given(memberRepository.existsByUsername(username)).willReturn(true);
+
+			// when
+			final boolean canUseUsername = memberAuthService.checkUsername(username);
+
+			// then
+			assertThat(canUseUsername).isFalse();
+		}
+
+
+	}
+
+	private RegisterRequest newInstance() {
+		return new RegisterRequest(
+			MemberUtils.getRandomUsername(),
+
+		);
+	}
+
+}


### PR DESCRIPTION
<!--
✅ Resolve: #이슈번호 형태로 입력해 주세요.
ex) Resolve: #123
-->
## 📌Linked Issues
- Resolve: #221 

<!--
✅ 변경 사항을 자세히 알려주세요. (why -> what -> how)
-->
## ✏Change Details
### MemberAuthService 리팩토링
- 패스워드가 기존과 같은 경우 EntityAlreadyExist가 아닌 다른 예외를 반환하도록 수정
- RegisterRequest를 Member로 변환하는 메서드를 서비스 단으로 수정
### RefreshTokenService 관련 리팩토링
- LoginDevicesDto -> LoginDeviceDto로 수정
- 메서드 추출 및 분리
- 일부 메서드명 수정
### MemberAuthService 테스트 작성 
> 아래와 같은 코드는 테스트를 어떻게 작성하는게 좋을까요?

```
	@Transactional
	public boolean checkResetPasswordCode(String username, String code) { // true, false 두개의 상황을 테스트?
		return emailCodeService.checkResetPasswordCode(username, code);
	}

	@Transactional(readOnly = true)
	public List<LoginDeviceDto> getLoginDevices(String currentToken) { // List내 원소의 개수 테스트 ?
		return refreshTokenService.getLoginDevices(authUtil.getLoginMemberId(), currentToken);
	}

	@Transactional
	public void logout(String refreshToken) { // then-should를 통해 테스트 ?
		refreshTokenService.deleteRefreshTokenByValue(authUtil.getLoginMemberId(), refreshToken);
	}
```
- 추가로 위 코드에서 getLoginDevices와 refreshTokenService.getLoginDevices 두개의 메서드 각각 @Transactional(readOnly = true) 어노테이션이 붙어있습니다. 두 메서드에 각각 붙여주는게 옳을까요? 아니면 직접적인 repository 접근은 refreshTokenService내에서 일어나니 memberAuthService에서의 getLoginDevices는 어노테이션을 없애도 될까요?
<!--
✅ 추가로 전달할 내용이 있다면 적어주세요.
-->
## 💬Comment
- 해당 PR 머지후에는 이메일 서비스 쪽을 리팩토링할 계획입니다. (시험 끝나고..)

<!--
✅ 참고한 사이트가 있다면 공유해주세요.
-->
## 📑References
- 

## ✅Check List
- [x] 추가한 기능에 대한 테스트는 모두 완료하셨나요?
- [x] 코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?
