### PR TITLE
이메일코드서비스 리팩토링 및 테스트 작성

### DIFF
--- a/src/main/java/cloneproject/Instagram/domain/member/service/EmailCodeService.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/service/EmailCodeService.java
@@ -114,11 +114,12 @@ public class EmailCodeService {
 	@PostConstruct
 	private void loadEmailUI() {
 		try {
-			ClassPathResource resource = new ClassPathResource("confirmEmailUI.html");
-			confirmEmailUI = new String(resource.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+			final ClassPathResource confirmEmailUIResource = new ClassPathResource("confirmEmailUI.html");
+			final ClassPathResource resetPasswordEmailUIResource = new ClassPathResource("resetPasswordEmailUI.html");
 
-			resource = new ClassPathResource("resetPasswordEmailUI.html");
-			resetPasswordEmailUI = new String(resource.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+			confirmEmailUI = new String(confirmEmailUIResource.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+			resetPasswordEmailUI = new String(resetPasswordEmailUIResource.getInputStream().readAllBytes(),
+				StandardCharsets.UTF_8);
 		} catch (IOException e) {
 			throw new FileConvertFailException();
 		}

--- a/src/main/java/cloneproject/Instagram/domain/member/service/EmailCodeService.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/service/EmailCodeService.java
@@ -37,7 +37,7 @@ public class EmailCodeService {
 	private static final String RESET_PASSWORD_EMAIL_SUBJECT_POSTFIX = ", recover your account's password.";
 
 	private final MemberRepository memberRepository;
-	private final RegisterCodeRedisRepository emailCodeRedisRepository;
+	private final RegisterCodeRedisRepository registerCodeRedisRepository;
 	private final ResetPasswordCodeRedisRepository resetPasswordCodeRedisRepository;
 	private final EmailService emailService;
 
@@ -54,18 +54,18 @@ public class EmailCodeService {
 			.email(email)
 			.code(code)
 			.build();
-		emailCodeRedisRepository.save(registerCode);
+		registerCodeRedisRepository.save(registerCode);
 	}
 
 	public boolean checkRegisterCode(String username, String email, String code) {
-		final RegisterCode registerCode = emailCodeRedisRepository.findByUsername(username)
+		final RegisterCode registerCode = registerCodeRedisRepository.findByUsername(username)
 			.orElseThrow(EmailNotConfirmedException::new);
 
 		if (!registerCode.getCode().equals(code) || !registerCode.getEmail().equals(email)) {
 			return false;
 		}
 
-		emailCodeRedisRepository.delete(registerCode);
+		registerCodeRedisRepository.delete(registerCode);
 		return true;
 	}
 

--- a/src/test/java/cloneproject/Instagram/domain/member/service/EmailCodeServiceTest.java
+++ b/src/test/java/cloneproject/Instagram/domain/member/service/EmailCodeServiceTest.java
@@ -1,0 +1,229 @@
+package cloneproject.Instagram.domain.member.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.ThrowableAssert.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import cloneproject.Instagram.domain.member.entity.redis.RegisterCode;
+import cloneproject.Instagram.domain.member.entity.redis.ResetPasswordCode;
+import cloneproject.Instagram.domain.member.exception.EmailNotConfirmedException;
+import cloneproject.Instagram.domain.member.exception.PasswordResetFailException;
+import cloneproject.Instagram.domain.member.repository.MemberRepository;
+import cloneproject.Instagram.domain.member.repository.redis.RegisterCodeRedisRepository;
+import cloneproject.Instagram.domain.member.repository.redis.ResetPasswordCodeRedisRepository;
+import cloneproject.Instagram.infra.email.EmailService;
+import cloneproject.Instagram.util.domain.member.MemberUtils;
+
+@ExtendWith(MockitoExtension.class)
+public class EmailCodeServiceTest {
+
+	@InjectMocks
+	private EmailCodeService emailCodeService;
+
+	@Mock
+	private MemberRepository memberRepository;
+
+	@Mock
+	private RegisterCodeRedisRepository emailCodeRedisRepository;
+
+	@Mock
+	private ResetPasswordCodeRedisRepository resetPasswordCodeRedisRepository;
+
+	@Mock
+	private EmailService emailService;
+
+	// TODO 추가 작성
+	// ! static resource 불러오는 방식 해결
+	@Nested
+	class SendRegisterCode {
+
+		@Test
+		void validArguments_SendAndSaveCode() {
+			// given
+			final String username = MemberUtils.getRandomUsername();
+			final String email = RandomStringUtils.random(20, true, true) + "email.com";
+
+			// when
+			emailCodeService.sendRegisterCode(username, email);
+
+			// then
+			then(emailCodeRedisRepository).should().save(any());
+		}
+
+	}
+
+	@Nested
+	class CheckRegisterCode {
+
+		@Test
+		void validArguments_DeleteCodeAndReturnTrue() {
+			// given
+			final RegisterCode registerCode = newRegisterCode();
+			given(emailCodeRedisRepository.findByUsername(registerCode.getUsername())).willReturn(
+				Optional.of(registerCode));
+
+			// when
+			final boolean result = emailCodeService.checkRegisterCode(registerCode.getUsername(),
+				registerCode.getEmail(), registerCode.getCode());
+
+			// then
+			assertThat(result).isTrue();
+			then(emailCodeRedisRepository).should().delete(any());
+		}
+
+		@Test
+		void registerCodeNotExist_ThrowException() {
+			// given
+			final RegisterCode registerCode = newRegisterCode();
+
+			// when
+			final ThrowingCallable executable = () -> emailCodeService.checkRegisterCode(registerCode.getUsername(),
+				registerCode.getEmail(), registerCode.getCode());
+
+			// then
+			assertThatThrownBy(executable).isInstanceOf(EmailNotConfirmedException.class);
+		}
+
+		@Test
+		void registerCodeNotMatch_ReturnFalse() {
+			// given
+			final RegisterCode registerCode = newRegisterCode();
+			given(emailCodeRedisRepository.findByUsername(registerCode.getUsername())).willReturn(
+				Optional.of(registerCode));
+			final String anotherCode = RandomStringUtils.random(30, true, true);
+
+			// when
+			final boolean result = emailCodeService.checkRegisterCode(registerCode.getUsername(),
+				registerCode.getEmail(), anotherCode);
+
+			// then
+			assertThat(result).isFalse();
+		}
+
+		@Test
+		void emailNotMatch_ReturnFalse() {
+			// given
+			final RegisterCode registerCode = newRegisterCode();
+			given(emailCodeRedisRepository.findByUsername(registerCode.getUsername())).willReturn(
+				Optional.of(registerCode));
+			final String anotherEmail = RandomStringUtils.random(9, true, true) + "@email.com";
+
+			// when
+			final boolean result = emailCodeService.checkRegisterCode(registerCode.getUsername(),
+				anotherEmail, registerCode.getCode());
+
+			// then
+			assertThat(result).isFalse();
+		}
+
+	}
+
+	// TODO sendResetPasswordCode
+
+	@Nested
+	class CheckResetPasswordCode {
+
+		@Test
+		void validArguments_ReturnTrue() {
+			// given
+			final ResetPasswordCode resetPasswordCode = newResetPasswordCode();
+			given(resetPasswordCodeRedisRepository.findByUsername(resetPasswordCode.getUsername())).willReturn(
+				Optional.of(resetPasswordCode));
+
+			// when
+			final boolean result = emailCodeService.checkResetPasswordCode(resetPasswordCode.getUsername(),
+				resetPasswordCode.getCode());
+
+			// then
+			assertThat(result).isTrue();
+		}
+
+		@Test
+		void resetPasswordCodeNotExist_ThrowException() {
+			// given
+			final ResetPasswordCode resetPasswordCode = newResetPasswordCode();
+
+			// when
+			final ThrowingCallable executable = () -> emailCodeService.checkResetPasswordCode(
+				resetPasswordCode.getUsername(), resetPasswordCode.getCode());
+
+			// then
+			assertThatThrownBy(executable).isInstanceOf(EmailNotConfirmedException.class);
+		}
+
+		@Test
+		void resetPasswordCodeNotMatch_ReturnFalse() {
+			// given
+			final ResetPasswordCode resetPasswordCode = newResetPasswordCode();
+			given(resetPasswordCodeRedisRepository.findByUsername(resetPasswordCode.getUsername())).willReturn(
+				Optional.of(resetPasswordCode));
+			final String anotherCode = RandomStringUtils.random(29, true, true);
+
+			// when
+			final boolean result = emailCodeService.checkResetPasswordCode(resetPasswordCode.getUsername(),
+				anotherCode);
+
+			// then
+			assertThat(result).isFalse();
+		}
+
+	}
+
+	@Nested
+	class DeleteResetPasswordCode {
+
+		@Test
+		void validArguments_DeleteCode() {
+			// given
+			final ResetPasswordCode resetPasswordCode = newResetPasswordCode();
+			given(resetPasswordCodeRedisRepository.findByUsername(resetPasswordCode.getUsername())).willReturn(
+				Optional.of(resetPasswordCode));
+
+			// when
+			emailCodeService.deleteResetPasswordCode(resetPasswordCode.getUsername());
+
+			// then
+			then(resetPasswordCodeRedisRepository).should().delete(any());
+		}
+
+		@Test
+		void resetPasswordCodeNotExist_ThrowException() {
+			// given
+			final ResetPasswordCode resetPasswordCode = newResetPasswordCode();
+
+			// when
+			final ThrowingCallable executable = () -> emailCodeService.deleteResetPasswordCode(
+				resetPasswordCode.getUsername());
+
+			// then
+			assertThatThrownBy(executable).isInstanceOf(PasswordResetFailException.class);
+		}
+
+	}
+
+	private RegisterCode newRegisterCode() {
+		return RegisterCode.builder()
+			.code(RandomStringUtils.random(30, true, true))
+			.email(RandomStringUtils.random(10, true, true) + "@email.com")
+			.username(RandomStringUtils.random(6, true, true))
+			.build();
+	}
+
+	private ResetPasswordCode newResetPasswordCode() {
+		return ResetPasswordCode.builder()
+			.code(RandomStringUtils.random(30, true, true))
+			.username(RandomStringUtils.random(6, true, true))
+			.build();
+	}
+
+}

--- a/src/test/java/cloneproject/Instagram/domain/member/service/EmailCodeServiceTest.java
+++ b/src/test/java/cloneproject/Instagram/domain/member/service/EmailCodeServiceTest.java
@@ -34,7 +34,7 @@ public class EmailCodeServiceTest {
 	private MemberRepository memberRepository;
 
 	@Mock
-	private RegisterCodeRedisRepository emailCodeRedisRepository;
+	private RegisterCodeRedisRepository registerCodeRedisRepository;
 
 	@Mock
 	private ResetPasswordCodeRedisRepository resetPasswordCodeRedisRepository;
@@ -57,7 +57,7 @@ public class EmailCodeServiceTest {
 			emailCodeService.sendRegisterCode(username, email);
 
 			// then
-			then(emailCodeRedisRepository).should().save(any());
+			then(registerCodeRedisRepository).should().save(any());
 		}
 
 	}
@@ -69,7 +69,7 @@ public class EmailCodeServiceTest {
 		void validArguments_DeleteCodeAndReturnTrue() {
 			// given
 			final RegisterCode registerCode = newRegisterCode();
-			given(emailCodeRedisRepository.findByUsername(registerCode.getUsername())).willReturn(
+			given(registerCodeRedisRepository.findByUsername(registerCode.getUsername())).willReturn(
 				Optional.of(registerCode));
 
 			// when
@@ -78,7 +78,7 @@ public class EmailCodeServiceTest {
 
 			// then
 			assertThat(result).isTrue();
-			then(emailCodeRedisRepository).should().delete(any());
+			then(registerCodeRedisRepository).should().delete(any());
 		}
 
 		@Test
@@ -98,7 +98,7 @@ public class EmailCodeServiceTest {
 		void registerCodeNotMatch_ReturnFalse() {
 			// given
 			final RegisterCode registerCode = newRegisterCode();
-			given(emailCodeRedisRepository.findByUsername(registerCode.getUsername())).willReturn(
+			given(registerCodeRedisRepository.findByUsername(registerCode.getUsername())).willReturn(
 				Optional.of(registerCode));
 			final String anotherCode = RandomStringUtils.random(30, true, true);
 
@@ -114,7 +114,7 @@ public class EmailCodeServiceTest {
 		void emailNotMatch_ReturnFalse() {
 			// given
 			final RegisterCode registerCode = newRegisterCode();
-			given(emailCodeRedisRepository.findByUsername(registerCode.getUsername())).willReturn(
+			given(registerCodeRedisRepository.findByUsername(registerCode.getUsername())).willReturn(
 				Optional.of(registerCode));
 			final String anotherEmail = RandomStringUtils.random(9, true, true) + "@email.com";
 


### PR DESCRIPTION
<!--
✅ Resolve: #이슈번호 형태로 입력해 주세요.
ex) Resolve: #123
-->
## 📌Linked Issues
- #233 
- To do : #235 

<!--
✅ 변경 사항을 자세히 알려주세요. (why -> what -> how)
-->
## ✏Change Details
### EmailCodeService 리팩토링
- 매직넘버 상수화
- final 키워드 추가
- Optional 관련 수정
- 복잡한 String format을 메서드로 추출
- 무작위 코드 생성에 RandomStringUtils 적용
- 기존에 `EmailCodeRedisRepository` -> `RegisterCodeRedisRepository`로 변경 이후, 함께 변경되지 않은 지역변수명 수정
### 테스트 작성
- 이메일코드서비스 관련 테스트 작성
- TODO : 정적 리소스와 관련된 메서드 테스트 미작성
  - 기존에 이메일 내용 작성을 위해 resource파일을 로드 후 string에 저장하는 방식을 사용
  - Test시에는 정적 리소스 로드가 정상적으로 로드되지 않음을 확인
  - test/resource에 정적 리소스를 복사해보았음에도 정상적으로 작동하지 않음 - 아마 SpringBoot전체를 로드하는 방식이 아니라 그런것 같음
  - 테스트 외에도 긴 내용을 String에 저장하고 있는 방식이 옳을까? 라는 의문이 들어서 수정하고자 했습니다

<!--
✅ 추가로 전달할 내용이 있다면 적어주세요.
-->
## 💬Comment
- 위에서 언급한 정적 리소스 관련 사항을 아직 해결하지 못하였는데, 혹시 관련해 아는 방법이 있으면 공유 부탁드립니다 ...
- 언급한 문제로 너무 오래 시간을 끄는 것 같아 우선 PR을 올리게 되었습니다. 시간 여유되실 때 확인해주세요.
  - 해당 문제를 조사하며 브랜치를 따로 파서 다른 서비스 테스트 작성을 진행할 예정입니다.

<!--
✅ 참고한 사이트가 있다면 공유해주세요.
-->
## 📑References
- 

## ✅Check List
- [ ] 추가한 기능에 대한 테스트는 모두 완료하셨나요?
- [ ] 코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?
