### PR TITLE
멤버의 최근 게시물 6개 조회 API 추가, MemberPostService 메서드 리팩토링

### DIFF
--- a/src/main/java/cloneproject/Instagram/domain/member/controller/MemberPostController.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/controller/MemberPostController.java
@@ -59,7 +59,7 @@ public class MemberPostController {
 
 	@ApiOperation(value = "멤버 게시물 6개 조회")
 	@ApiResponses({
-		@ApiResponse(code = 200, message = "MP001 - 회원의 최근 게시물 15개 조회에 성공하였습니다."),
+		@ApiResponse(code = 200, message = "MP007 - 회원의 최근 게시물 6개 조회에 성공하였습니다."),
 		@ApiResponse(code = 400, message = "G003 - 유효하지 않은 입력입니다.\n"
 			+ "G004 - 입력 타입이 유효하지 않습니다.\n"
 			+ "M001 - 존재 하지 않는 유저입니다."),
@@ -71,7 +71,7 @@ public class MemberPostController {
 		final List<MemberPostDto> postList = memberPostService.getMemberPostDtoPage(username, FIRST_PAGE_SIZE_FOR_POST,
 				0).getContent();
 
-		return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_RECENT15_MEMBER_POSTS_SUCCESS, postList));
+		return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_RECENT6_MEMBER_POSTS_SUCCESS, postList));
 	}
 
 	@ApiOperation(value = "멤버 게시물 페이징 조회(무한스크롤)")

--- a/src/main/java/cloneproject/Instagram/domain/member/controller/MemberPostController.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/controller/MemberPostController.java
@@ -33,6 +33,11 @@ import cloneproject.Instagram.global.result.ResultResponse;
 @RequestMapping("/accounts")
 public class MemberPostController {
 
+	private static final int FIRST_PAGE_SIZE_FOR_PROFILE = 15;
+	private static final int FIRST_PAGE_SIZE_FOR_POST = 6;
+	private static final int PAGE_SIZE_FOR_PROFILE = 3;
+	private static final int PAGE_OFFSET_FOR_PROFILE = 4;
+
 	private final MemberPostService memberPostService;
 
 	@ApiOperation(value = "멤버 게시물 15개 조회")
@@ -46,7 +51,25 @@ public class MemberPostController {
 	@ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma")
 	@GetMapping("/{username}/posts/recent")
 	public ResponseEntity<ResultResponse> getRecent15Posts(@PathVariable("username") String username) {
-		final List<MemberPostDto> postList = memberPostService.getRecent15PostDtos(username);
+		final List<MemberPostDto> postList = memberPostService.getMemberPostDtoPage(username,
+				FIRST_PAGE_SIZE_FOR_PROFILE, 0).getContent();
+
+		return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_RECENT15_MEMBER_POSTS_SUCCESS, postList));
+	}
+
+	@ApiOperation(value = "멤버 게시물 6개 조회")
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "MP001 - 회원의 최근 게시물 15개 조회에 성공하였습니다."),
+		@ApiResponse(code = 400, message = "G003 - 유효하지 않은 입력입니다.\n"
+			+ "G004 - 입력 타입이 유효하지 않습니다.\n"
+			+ "M001 - 존재 하지 않는 유저입니다."),
+		@ApiResponse(code = 401, message = "M003 - 로그인이 필요한 화면입니다.")
+	})
+	@ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma")
+	@GetMapping("/{username}/posts/recent/post")
+	public ResponseEntity<ResultResponse> getRecent6Posts(@PathVariable("username") String username) {
+		final List<MemberPostDto> postList = memberPostService.getMemberPostDtoPage(username, FIRST_PAGE_SIZE_FOR_POST,
+				0).getContent();
 
 		return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_RECENT15_MEMBER_POSTS_SUCCESS, postList));
 	}
@@ -66,7 +89,8 @@ public class MemberPostController {
 	@GetMapping("/{username}/posts")
 	public ResponseEntity<ResultResponse> getPostPage(@PathVariable("username") String username,
 		@Min(1) @RequestParam int page) {
-		final Page<MemberPostDto> postPage = memberPostService.getMemberPostDtoPage(username, 3, page);
+		final Page<MemberPostDto> postPage = memberPostService.getMemberPostDtoPage(username, PAGE_SIZE_FOR_PROFILE,
+			page + PAGE_OFFSET_FOR_PROFILE);
 
 		return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_MEMBER_POSTS_SUCCESS, postPage));
 	}
@@ -81,7 +105,8 @@ public class MemberPostController {
 	@ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma")
 	@GetMapping("/{username}/posts/recent/without")
 	public ResponseEntity<ResultResponse> getRecent15PostsWithoutLogin(@PathVariable("username") String username) {
-		final List<MemberPostDto> postList = memberPostService.getRecent15PostDtosWithoutLogin(username);
+		final List<MemberPostDto> postList = memberPostService.getMemberPostDtoPageWithoutLogin(username,
+			FIRST_PAGE_SIZE_FOR_PROFILE, 0).getContent();
 
 		return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_RECENT15_MEMBER_POSTS_SUCCESS, postList));
 	}
@@ -100,7 +125,8 @@ public class MemberPostController {
 	@GetMapping("/{username}/posts/without")
 	public ResponseEntity<ResultResponse> getPostPageWithoutLogin(@PathVariable("username") String username,
 		@Min(1) @RequestParam int page) {
-		final Page<MemberPostDto> postPage = memberPostService.getMemberPostDtoPageWithoutLogin(username, 3, page);
+		final Page<MemberPostDto> postPage = memberPostService.getMemberPostDtoPageWithoutLogin(username,
+			PAGE_SIZE_FOR_PROFILE, page + PAGE_OFFSET_FOR_PROFILE);
 
 		return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_MEMBER_POSTS_SUCCESS, postPage));
 	}
@@ -115,7 +141,8 @@ public class MemberPostController {
 	})
 	@GetMapping("/posts/saved/recent")
 	public ResponseEntity<ResultResponse> getRecent15SavedPosts() {
-		final List<MemberPostDto> postList = memberPostService.getRecent15SavedPostDtos();
+		final List<MemberPostDto> postList = memberPostService.getMemberSavedPostPage(FIRST_PAGE_SIZE_FOR_PROFILE, 0)
+			.getContent();
 
 		return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_RECENT15_MEMBER_SAVED_POSTS_SUCCESS, postList));
 	}
@@ -130,7 +157,8 @@ public class MemberPostController {
 	@GetMapping("/posts/saved")
 	@ApiImplicitParam(name = "page", value = "페이지", required = true, example = "1")
 	public ResponseEntity<ResultResponse> getSavedPostPage(@Min(1) @RequestParam int page) {
-		final Page<MemberPostDto> postPage = memberPostService.getMemberSavedPostPage(3, page);
+		final Page<MemberPostDto> postPage = memberPostService.getMemberSavedPostPage(PAGE_SIZE_FOR_PROFILE,
+			page + PAGE_OFFSET_FOR_PROFILE);
 
 		return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_MEMBER_SAVED_POSTS_SUCCESS, postPage));
 	}
@@ -147,7 +175,8 @@ public class MemberPostController {
 	@ApiImplicitParam(name = "username", value = "유저네임", required = true, example = "dlwlrma")
 	@GetMapping("/{username}/posts/tagged/recent")
 	public ResponseEntity<ResultResponse> getRecent10TaggedPosts(@PathVariable("username") String username) {
-		final List<MemberPostDto> postList = memberPostService.getRecent15TaggedPostDtos(username);
+		final List<MemberPostDto> postList = memberPostService.getMemberTaggedPostDtoPage(username,
+			FIRST_PAGE_SIZE_FOR_PROFILE, 0).getContent();
 
 		return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_RECENT15_MEMBER_TAGGED_POSTS_SUCCESS, postList));
 	}
@@ -167,7 +196,8 @@ public class MemberPostController {
 	@GetMapping("/{username}/posts/tagged")
 	public ResponseEntity<ResultResponse> getTaggedPostPage(@PathVariable("username") String username,
 		@Min(1) @RequestParam int page) {
-		final Page<MemberPostDto> postPage = memberPostService.getMemberTaggedPostDtoPage(username, 3, page);
+		final Page<MemberPostDto> postPage = memberPostService.getMemberTaggedPostDtoPage(username,
+			PAGE_SIZE_FOR_PROFILE, page + PAGE_OFFSET_FOR_PROFILE);
 
 		return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_MEMBER_TAGGED_POSTS_SUCCESS, postPage));
 	}

--- a/src/main/java/cloneproject/Instagram/domain/member/service/MemberPostService.java
+++ b/src/main/java/cloneproject/Instagram/domain/member/service/MemberPostService.java
@@ -2,7 +2,6 @@ package cloneproject.Instagram.domain.member.service;
 
 import static cloneproject.Instagram.global.error.ErrorCode.*;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -30,9 +29,6 @@ import cloneproject.Instagram.global.util.AuthUtil;
 @Transactional(readOnly = true)
 public class MemberPostService {
 
-	private static final int FIRST_PAGE_SIZE = 15;
-	private static final int PAGE_OFFSET = 4;
-
 	private final AuthUtil authUtil;
 	private final MemberRepository memberRepository;
 	private final BlockRepository blockRepository;
@@ -40,60 +36,33 @@ public class MemberPostService {
 	private final PostService postService;
 
 	public Page<MemberPostDto> getMemberPostDtoPageWithoutLogin(String username, int size, int page) {
-		final Pageable pageable = PageRequest.of(page + PAGE_OFFSET, size);
+		final Pageable pageable = PageRequest.of(page, size);
 		final Page<MemberPostDto> posts = getMemberPostDtoPage(-1L, username, pageable);
 		final List<MemberPostDto> content = posts.getContent();
 		setMemberPostImageDtos(content);
 		setPostLikesCount(null, content);
 		return posts;
-	}
-
-	public List<MemberPostDto> getRecent15PostDtosWithoutLogin(String username) {
-		final Pageable pageable = PageRequest.of(0, FIRST_PAGE_SIZE);
-		final Page<MemberPostDto> posts = getMemberPostDtoPage(-1L, username, pageable);
-		final List<MemberPostDto> content = posts.getContent();
-		setMemberPostImageDtos(content);
-		setPostLikesCount(null, content);
-		return content;
 	}
 
 	public Page<MemberPostDto> getMemberPostDtoPage(String username, int size, int page) {
 		final Member loginMember = authUtil.getLoginMember();
-		final Pageable pageable = PageRequest.of(page + PAGE_OFFSET, size);
+		final Pageable pageable = PageRequest.of(page, size);
 		final Page<MemberPostDto> posts = getMemberPostDtoPage(loginMember.getId(), username, pageable);
 		final List<MemberPostDto> content = posts.getContent();
 		setMemberPostImageDtos(content);
 		setPostLikesCount(loginMember, content);
 		return posts;
-	}
-
-	public List<MemberPostDto> getRecent15PostDtos(String username) {
-		final Member loginMember = authUtil.getLoginMember();
-		final Pageable pageable = PageRequest.of(0, FIRST_PAGE_SIZE);
-		final Page<MemberPostDto> posts = getMemberPostDtoPage(loginMember.getId(), username, pageable);
-		final List<MemberPostDto> content = posts.getContent();
-		setMemberPostImageDtos(content);
-		setPostLikesCount(loginMember, content);
-		return content;
 	}
 
 	public Page<MemberPostDto> getMemberSavedPostPage(int size, int page) {
 		final Member loginMember = authUtil.getLoginMember();
-		final Pageable pageable = PageRequest.of(page + PAGE_OFFSET, size);
-		final Page<MemberPostDto> posts = memberRepository.findMemberSavedPostDtoPageByLoginMemberId(loginMember.getId(), pageable);
+		final Pageable pageable = PageRequest.of(page, size);
+		final Page<MemberPostDto> posts = memberRepository.findMemberSavedPostDtoPageByLoginMemberId(
+			loginMember.getId(), pageable);
 		final List<MemberPostDto> content = posts.getContent();
 		setMemberPostImageDtos(content);
 		setPostLikesCount(loginMember, content);
 		return posts;
-	}
-
-	public List<MemberPostDto> getRecent15SavedPostDtos() {
-		final Member loginMember = authUtil.getLoginMember();
-		final Pageable pageable = PageRequest.of(0, FIRST_PAGE_SIZE);
-		final Page<MemberPostDto> posts = memberRepository.findMemberSavedPostDtoPageByLoginMemberId(loginMember.getId(), pageable);
-		final List<MemberPostDto> content = posts.getContent();
-		setMemberPostImageDtos(content);
-		return content;
 	}
 
 	public Page<MemberPostDto> getMemberTaggedPostDtoPage(String username, int size, int page) {
@@ -105,31 +74,14 @@ public class MemberPostService {
 			return Page.empty();
 		}
 
-		final Pageable pageable = PageRequest.of(page + PAGE_OFFSET, size);
-		final Page<MemberPostDto> posts = memberRepository.findMemberTaggedPostDtoPageByLoginMemberIdAndTargetUsername(loginMember.getId(), username,
+		final Pageable pageable = PageRequest.of(page, size);
+		final Page<MemberPostDto> posts = memberRepository.findMemberTaggedPostDtoPageByLoginMemberIdAndTargetUsername(
+			loginMember.getId(), username,
 			pageable);
 		final List<MemberPostDto> content = posts.getContent();
 		setMemberPostImageDtos(content);
 		setPostLikesCount(loginMember, content);
 		return posts;
-	}
-
-	public List<MemberPostDto> getRecent15TaggedPostDtos(String username) {
-		final Member loginMember = authUtil.getLoginMember();
-		final Member member = memberRepository.findByUsername(username)
-			.orElseThrow(() -> new EntityNotFoundException(MEMBER_NOT_FOUND));
-
-		if (blockRepository.isBlockingOrIsBlocked(loginMember.getId(), member.getId())) {
-			return Collections.emptyList();
-		}
-
-		final Pageable pageable = PageRequest.of(0, FIRST_PAGE_SIZE);
-		final Page<MemberPostDto> posts = memberRepository.findMemberTaggedPostDtoPageByLoginMemberIdAndTargetUsername(loginMember.getId(), username,
-			pageable);
-		final List<MemberPostDto> content = posts.getContent();
-		setMemberPostImageDtos(content);
-		setPostLikesCount(loginMember, content);
-		return content;
 	}
 
 	private Page<MemberPostDto> getMemberPostDtoPage(Long memberId, String username, Pageable pageable) {

--- a/src/main/java/cloneproject/Instagram/global/result/ResultCode.java
+++ b/src/main/java/cloneproject/Instagram/global/result/ResultCode.java
@@ -62,6 +62,7 @@ public enum ResultCode {
 	GET_MEMBER_SAVED_POSTS_SUCCESS(200, "MP004", "회원의 저장한 게시물 조회에 성공하였습니다."),
 	GET_RECENT15_MEMBER_TAGGED_POSTS_SUCCESS(200, "MP005", "회원의 최근 태그된 게시물 15개 조회에 성공하였습니다."),
 	GET_MEMBER_TAGGED_POSTS_SUCCESS(200, "MP006", "회원의 태그된 게시물 조회에 성공하였습니다."),
+	GET_RECENT6_MEMBER_POSTS_SUCCESS(200, "MP007", "회원의 최근 게시물 6개 조회에 성공하였습니다."),
 
 	// Feed
 	CREATE_POST_SUCCESS(200, "F001", "게시물 업로드에 성공하였습니다."),


### PR DESCRIPTION
- 추가로 기존에 최신15개 조회, 페이지 조회로 분리되어있던 MemberPostService의 메서드를 하나의 메서드로 통합
  - 이제 Controller단에서 매개변수를 통해 각각의 메서드 호출

<!--
✅ Resolve: #이슈번호 형태로 입력해 주세요.
ex) Resolve: #123
-->
## 📌Linked Issues
- Resolve: #241 

<!--
✅ 변경 사항을 자세히 알려주세요. (why -> what -> how)
-->
## ✏Change Details
### MemberPostService 리팩토링
  - 기존에는 두개의 메서드로 분리되어 있음 ( 최신 15개 포스트를 조회, 페이징 조회 )
  - 코드 상의 중복이 많기 때문에 `최신 15개 포스트 조회`메서드를 삭제후 `페이징 조회`를 위한 메서드만 남겨둠
  - 이후 최신 15개 포스트 조회는 **컨트롤러**에서 서비스의 페이징 조회 메서드의 매개변수를 조절하여 호출함(FIRST_PAGE_SIZE와 PAGE_OFFSET 등 상수를 이용) -> 외부 API 상에선 바뀐점이 없으나 내부 로직만 수정된 것
### 멤버의 최근 게시물 6개 조회 API 추가
- 게시물 단건 조회에 사용할 API 추가
<!--
✅ 추가로 전달할 내용이 있다면 적어주세요.
-->
## 💬Comment
- @seonpilKim 요즘 뒤늦게 기록을 작성하기 시작했는데, 선필님은 프로젝트 진행하면서 어떤 점이 가장 어려우셨나요..? 저는 프론트와 처음 API 연결할 때랑(특히 쿠키 도메인 관련) 로그인 인증을 위해 시큐리티 필터 인터페이스 뜯어보고 구현한거 밖에 떠오르질 않네요
  - 사실 원래 공부하면서 기록을 잘안하는 스타일이었는데 진작에 시작할걸 그랬네요 😥 계속 하다보면 옛날에 공부한게 가물가물 해지네요..
<!--
✅ 참고한 사이트가 있다면 공유해주세요.
-->
## 📑References
- 

## ✅Check List
- [x] 추가한 기능에 대한 테스트는 모두 완료하셨나요?
- [x] 코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?
